### PR TITLE
build: Rename package to sentry-arroyo

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ def get_requirements() -> Sequence[str]:
 
 
 setup(
-    name="arroyo",
+    name="sentry-arroyo",
     version="0.0.1",
     author="Sentry",
     author_email="oss@sentry.io",


### PR DESCRIPTION
`arroyo` seems to be unavailable on PyPI. Let's try renaming to
`sentry-arroyo`.