### PR TITLE
feat: Parallel transform step accepts optional initializer function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Add optional initializer function to parallel transform step. Supports passing a custom function to be run on multiprocessing pool initialization.
+
 ## 0.0.1
 
 - First release 🎉
-

--- a/arroyo/processing/strategies/streaming/factory.py
+++ b/arroyo/processing/strategies/streaming/factory.py
@@ -54,6 +54,7 @@ class ConsumerStrategyFactory(ProcessingStrategyFactory[TPayload]):
         processes: Optional[int],
         input_block_size: Optional[int],
         output_block_size: Optional[int],
+        initialize_parallel_transform: Optional[Callable[[], None]] = None,
     ) -> None:
         self.__prefilter = prefilter
         self.__process_message = process_message
@@ -76,6 +77,7 @@ class ConsumerStrategyFactory(ProcessingStrategyFactory[TPayload]):
         self.__processes = processes
         self.__input_block_size = input_block_size
         self.__output_block_size = output_block_size
+        self.__initialize_parallel_transform = initialize_parallel_transform
 
     def __should_accept(self, message: Message[TPayload]) -> bool:
         assert self.__prefilter is not None
@@ -107,6 +109,7 @@ class ConsumerStrategyFactory(ProcessingStrategyFactory[TPayload]):
                 max_batch_time=self.__max_batch_time,
                 input_block_size=self.__input_block_size,
                 output_block_size=self.__output_block_size,
+                initializer=self.__initialize_parallel_transform,
             )
 
         if self.__prefilter is not None:


### PR DESCRIPTION
This adds an optional `initializer` argument to the parallel transform step
which allows a custom initialization function to be run when a process is
spawned. The custom initialize function can also be provided via the
ConsumerStrategyFactory.

The primary motivation for this is to allow Snuba to pass a function that
sets up the Sentry SDK immediately when a process is spawned so that
any logs or errors can be reported to Sentry.

This should not be included in the `0.0.1` release