### PR TITLE
perf(metrics) Add some metrics to the batching consumer

### DIFF
--- a/arroyo/processing/strategies/batching.py
+++ b/arroyo/processing/strategies/batching.py
@@ -113,7 +113,7 @@ class BatchProcessingStrategy(ProcessingStrategy[TPayload]):
 
         self.__batch: Optional[Batch[TResult]] = None
         self.__closed = False
-        self.__flush_done: Optional[float] = None
+        self.__flush_done = time.time()
 
     def poll(self) -> None:
         """
@@ -125,10 +125,10 @@ class BatchProcessingStrategy(ProcessingStrategy[TPayload]):
             len(self.__batch.results) >= self.__max_batch_size
             or time.time() > self.__batch.created + self.__max_batch_time / 1000.0
         ):
-            if self.__flush_done is not None:
-                self.__metrics.timing(
-                    "processing_phase", time.time() - self.__flush_done
-                )
+
+            self.__metrics.timing(
+                "processing_phase", time.time() - self.__flush_done
+            )
             self.__flush()
             self.__flush_done = time.time()
 

--- a/arroyo/processing/strategies/batching.py
+++ b/arroyo/processing/strategies/batching.py
@@ -113,6 +113,7 @@ class BatchProcessingStrategy(ProcessingStrategy[TPayload]):
 
         self.__batch: Optional[Batch[TResult]] = None
         self.__closed = False
+        self.__flush_done: Optional[float] = None
 
     def poll(self) -> None:
         """
@@ -124,7 +125,12 @@ class BatchProcessingStrategy(ProcessingStrategy[TPayload]):
             len(self.__batch.results) >= self.__max_batch_size
             or time.time() > self.__batch.created + self.__max_batch_time / 1000.0
         ):
+            if self.__flush_done is not None:
+                self.__metrics.timing(
+                    "processing_phase", time.time() - self.__flush_done
+                )
             self.__flush()
+            self.__flush_done = time.time()
 
     def submit(self, message: Message[TPayload]) -> None:
         """
@@ -203,6 +209,7 @@ class BatchProcessingStrategy(ProcessingStrategy[TPayload]):
             self.__worker.flush_batch(self.__batch.results)
             flush_duration = (time.time() - flush_start) * 1000
             logger.info("Worker flush took %dms", flush_duration)
+            self.__metrics.increment("batch.flush.items", batch_results_length)
             self.__metrics.timing("batch.flush", flush_duration)
             self.__metrics.timing(
                 "batch.flush.normalized", flush_duration / batch_results_length
@@ -236,8 +243,5 @@ class BatchProcessingStrategyFactory(ProcessingStrategyFactory[TPayload]):
         self, commit: Callable[[Mapping[Partition, int]], None]
     ) -> ProcessingStrategy[TPayload]:
         return BatchProcessingStrategy(
-            commit,
-            self.__worker,
-            self.__max_batch_size,
-            self.__max_batch_time,
+            commit, self.__worker, self.__max_batch_size, self.__max_batch_time,
         )


### PR DESCRIPTION
We do not have a metric on the number of items in the batch during flush and on the time between two flushes.