### PR TITLE
Revert "feat: Drop events that fail processing (#26)"

### DIFF
--- a/arroyo/processing/processor.py
+++ b/arroyo/processing/processor.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import logging
-import random
 import time
 from typing import Generic, Mapping, Optional, Sequence
 
@@ -37,7 +36,6 @@ class StreamProcessor(Generic[TPayload]):
         consumer: Consumer[TPayload],
         topic: Topic,
         processor_factory: ProcessingStrategyFactory[TPayload],
-        drop_failed_messages: bool = False,
     ) -> None:
         self.__consumer = consumer
         self.__processor_factory = processor_factory
@@ -46,8 +44,6 @@ class StreamProcessor(Generic[TPayload]):
         self.__processing_strategy: Optional[ProcessingStrategy[TPayload]] = None
 
         self.__message: Optional[Message[TPayload]] = None
-
-        self.__drop_failed_messages = drop_failed_messages
 
         # If the consumer is in the paused state, this is when the last call to
         # ``pause`` occurred.
@@ -109,17 +105,7 @@ class StreamProcessor(Generic[TPayload]):
         logger.debug("Starting")
         try:
             while not self.__shutdown_requested:
-                if self.__drop_failed_messages is True:
-                    try:
-                        self._run_once()
-                    except Exception:
-                        # Log 1 in 10 bad events
-                        if random.random() < 0.1:
-                            logger.exception(
-                                "Event could not be processed", exc_info=True
-                            )
-                else:
-                    self._run_once()
+                self._run_once()
 
             self._shutdown()
         except Exception as error:

--- a/tests/backends/mixins.py
+++ b/tests/backends/mixins.py
@@ -195,7 +195,6 @@ class StreamsTestMixin(ABC, Generic[TPayload]):
             with assert_changes(lambda: revocation_callback.called, False, True):
                 consumer.close()
 
-    @pytest.mark.xfail(reason="Skipping all failed messages")
     def test_consumer_offset_out_of_range(self) -> None:
         payloads = self.get_payloads()
 


### PR DESCRIPTION
This reverts commit e5e1746e66ea6c22d513b8880015a3e57177877b.

The commit being reverted was not intended to be permanent; it
was a quick hack to deal with invalid messages that failed processing
by just skipping them alltogether. We never ended up releasing this
code or skipping messages so let's revert.