### PR TITLE
feat: Keep track of timestamps together with offsets in a batch

### DIFF
--- a/arroyo/backends/abstract.py
+++ b/arroyo/backends/abstract.py
@@ -35,9 +35,9 @@ class Consumer(Generic[TPayload], ABC):
     during the subscription process. To ensure that a consumer roughly "picks
     up where it left off" after restarting, or that another consumer in the
     same group doesn't read messages that have been processed by another
-    consumer within the same group during a rebalance operation, offsets must
-    be regularly committed by calling ``commit_offsets`` after they have been
-    staged with ``stage_offsets``. Offsets are not staged or committed
+    consumer within the same group during a rebalance operation, positions must
+    be regularly committed by calling ``commit_positions`` after they have been
+    staged with ``stage_positions``. Offsets are not staged or committed
     automatically!
 
     During rebalance operations, working offsets are rolled back to the
@@ -139,7 +139,7 @@ class Consumer(Generic[TPayload], ABC):
         raise NotImplementedError
 
     @abstractmethod
-    def stage_offsets(self, offsets: Mapping[Partition, Position]) -> None:
+    def stage_positions(self, positions: Mapping[Partition, Position]) -> None:
         """
         Stage offsets to be committed. If an offset has already been staged
         for a given partition, that offset is overwritten (even if the offset
@@ -148,7 +148,7 @@ class Consumer(Generic[TPayload], ABC):
         raise NotImplementedError
 
     @abstractmethod
-    def commit_offsets(self) -> Mapping[Partition, Position]:
+    def commit_positions(self) -> Mapping[Partition, Position]:
         """
         Commit staged offsets. The return value of this method is a mapping
         of streams with their committed offsets as values.

--- a/arroyo/backends/abstract.py
+++ b/arroyo/backends/abstract.py
@@ -5,7 +5,7 @@ from abc import ABC, abstractmethod, abstractproperty
 from concurrent.futures import Future
 from typing import Callable, Generic, Mapping, Optional, Sequence, Union
 
-from arroyo.types import Message, Offset, Partition, Topic, TPayload
+from arroyo.types import Message, Partition, Position, Topic, TPayload
 
 logger = logging.getLogger(__name__)
 
@@ -139,7 +139,7 @@ class Consumer(Generic[TPayload], ABC):
         raise NotImplementedError
 
     @abstractmethod
-    def stage_offsets(self, offsets: Mapping[Partition, Offset]) -> None:
+    def stage_offsets(self, offsets: Mapping[Partition, Position]) -> None:
         """
         Stage offsets to be committed. If an offset has already been staged
         for a given partition, that offset is overwritten (even if the offset
@@ -148,7 +148,7 @@ class Consumer(Generic[TPayload], ABC):
         raise NotImplementedError
 
     @abstractmethod
-    def commit_offsets(self) -> Mapping[Partition, Offset]:
+    def commit_offsets(self) -> Mapping[Partition, Position]:
         """
         Commit staged offsets. The return value of this method is a mapping
         of streams with their committed offsets as values.

--- a/arroyo/backends/abstract.py
+++ b/arroyo/backends/abstract.py
@@ -5,7 +5,7 @@ from abc import ABC, abstractmethod, abstractproperty
 from concurrent.futures import Future
 from typing import Callable, Generic, Mapping, Optional, Sequence, Union
 
-from arroyo.types import Message, Partition, Topic, TPayload
+from arroyo.types import Message, Offset, Partition, Topic, TPayload
 
 logger = logging.getLogger(__name__)
 
@@ -139,7 +139,7 @@ class Consumer(Generic[TPayload], ABC):
         raise NotImplementedError
 
     @abstractmethod
-    def stage_offsets(self, offsets: Mapping[Partition, int]) -> None:
+    def stage_offsets(self, offsets: Mapping[Partition, Offset]) -> None:
         """
         Stage offsets to be committed. If an offset has already been staged
         for a given partition, that offset is overwritten (even if the offset
@@ -148,7 +148,7 @@ class Consumer(Generic[TPayload], ABC):
         raise NotImplementedError
 
     @abstractmethod
-    def commit_offsets(self) -> Mapping[Partition, int]:
+    def commit_offsets(self) -> Mapping[Partition, Offset]:
         """
         Commit staged offsets. The return value of this method is a mapping
         of streams with their committed offsets as values.

--- a/arroyo/backends/kafka/consumer.py
+++ b/arroyo/backends/kafka/consumer.py
@@ -563,8 +563,6 @@ class KafkaConsumer(Consumer[KafkaPayload]):
 
         assert result is not None  # synchronous commit should return result immediately
 
-        self.__staged_offsets.clear()
-
         offsets: MutableMapping[Partition, Offset] = {}
 
         for value in result:
@@ -582,6 +580,8 @@ class KafkaConsumer(Consumer[KafkaPayload]):
             offsets[partition] = Offset(
                 value.offset, self.__staged_offsets[partition].timestamp
             )
+
+        self.__staged_offsets.clear()
 
         return offsets
 

--- a/arroyo/backends/kafka/consumer.py
+++ b/arroyo/backends/kafka/consumer.py
@@ -526,21 +526,21 @@ class KafkaConsumer(Consumer[KafkaPayload]):
 
         return [*self.__paused]
 
-    def stage_offsets(self, offsets: Mapping[Partition, Position]) -> None:
+    def stage_positions(self, positions: Mapping[Partition, Position]) -> None:
         if self.__state in {KafkaConsumerState.CLOSED, KafkaConsumerState.ERROR}:
             raise InvalidState(self.__state)
 
-        if offsets.keys() - self.__offsets.keys():
+        if positions.keys() - self.__offsets.keys():
             raise ConsumerError("cannot stage offsets for unassigned partitions")
 
         self.__validate_offsets(
-            {partition: position.offset for (partition, position) in offsets.items()}
+            {partition: position.offset for (partition, position) in positions.items()}
         )
 
         # TODO: Maybe log a warning if these offsets exceed the current
         # offsets, since that's probably a side effect of an incorrect usage
         # pattern?
-        self.__staged_offsets.update(offsets)
+        self.__staged_offsets.update(positions)
 
     def __commit(self) -> Mapping[Partition, Position]:
         if self.__state in {KafkaConsumerState.CLOSED, KafkaConsumerState.ERROR}:
@@ -585,7 +585,7 @@ class KafkaConsumer(Consumer[KafkaPayload]):
 
         return offsets
 
-    def commit_offsets(self) -> Mapping[Partition, Position]:
+    def commit_positions(self) -> Mapping[Partition, Position]:
         """
         Commit staged offsets for all partitions that this consumer is
         assigned to. The return value of this method is a mapping of

--- a/arroyo/backends/kafka/consumer.py
+++ b/arroyo/backends/kafka/consumer.py
@@ -534,7 +534,7 @@ class KafkaConsumer(Consumer[KafkaPayload]):
             raise ConsumerError("cannot stage offsets for unassigned partitions")
 
         self.__validate_offsets(
-            {key: offset.offset for (key, offset) in offsets.items()}
+            {partition: offset.kafka_offset for (partition, offset) in offsets.items()}
         )
 
         # TODO: Maybe log a warning if these offsets exceed the current
@@ -552,7 +552,7 @@ class KafkaConsumer(Consumer[KafkaPayload]):
             result = self.__consumer.commit(
                 offsets=[
                     ConfluentTopicPartition(
-                        partition.topic.name, partition.index, offset.offset
+                        partition.topic.name, partition.index, offset.kafka_offset
                     )
                     for partition, offset in self.__staged_offsets.items()
                 ],

--- a/arroyo/backends/kafka/consumer.py
+++ b/arroyo/backends/kafka/consumer.py
@@ -578,7 +578,10 @@ class KafkaConsumer(Consumer[KafkaPayload]):
                 continue
 
             assert value.offset >= 0, "expected non-negative offset"
-            offsets[Partition(Topic(value.topic), value.partition)] = value.offset
+            partition = Partition(Topic(value.topic), value.partition)
+            offsets[partition] = Offset(
+                value.offset, self.__staged_offsets[partition].timestamp
+            )
 
         return offsets
 

--- a/arroyo/backends/local/backend.py
+++ b/arroyo/backends/local/backend.py
@@ -313,7 +313,10 @@ class LocalConsumer(Consumer[TPayload]):
                 raise ConsumerError("cannot stage offsets for unassigned partitions")
 
             self.__validate_offsets(
-                {key: offset.offset for (key, offset) in offsets.items()}
+                {
+                    partition: offset.kafka_offset
+                    for (partition, offset) in offsets.items()
+                }
             )
 
             self.__staged_offsets.update(offsets)
@@ -325,7 +328,11 @@ class LocalConsumer(Consumer[TPayload]):
 
             offsets = {**self.__staged_offsets}
             self.__broker.commit(
-                self, {key: offset.offset for (key, offset) in offsets.items()}
+                self,
+                {
+                    partition: offset.kafka_offset
+                    for (partition, offset) in offsets.items()
+                },
             )
             self.__staged_offsets.clear()
 

--- a/arroyo/processing/processor.py
+++ b/arroyo/processing/processor.py
@@ -89,10 +89,10 @@ class StreamProcessor(Generic[TPayload]):
             [topic], on_assign=on_partitions_assigned, on_revoke=on_partitions_revoked
         )
 
-    def __commit(self, offsets: Mapping[Partition, Position]) -> None:
-        self.__consumer.stage_offsets(offsets)
+    def __commit(self, positions: Mapping[Partition, Position]) -> None:
+        self.__consumer.stage_positions(positions)
         start = time.time()
-        self.__consumer.commit_offsets()
+        self.__consumer.commit_positions()
         logger.debug(
             "Waited %0.4f seconds for offsets to be committed to %r.",
             time.time() - start,

--- a/arroyo/processing/processor.py
+++ b/arroyo/processing/processor.py
@@ -11,7 +11,7 @@ from arroyo.processing.strategies.abstract import (
     ProcessingStrategy,
     ProcessingStrategyFactory,
 )
-from arroyo.types import Message, Partition, Topic, TPayload
+from arroyo.types import Message, Offset, Partition, Topic, TPayload
 from arroyo.utils.metrics import get_metrics
 
 logger = logging.getLogger(__name__)
@@ -89,7 +89,7 @@ class StreamProcessor(Generic[TPayload]):
             [topic], on_assign=on_partitions_assigned, on_revoke=on_partitions_revoked
         )
 
-    def __commit(self, offsets: Mapping[Partition, int]) -> None:
+    def __commit(self, offsets: Mapping[Partition, Offset]) -> None:
         self.__consumer.stage_offsets(offsets)
         start = time.time()
         self.__consumer.commit_offsets()

--- a/arroyo/processing/processor.py
+++ b/arroyo/processing/processor.py
@@ -11,7 +11,7 @@ from arroyo.processing.strategies.abstract import (
     ProcessingStrategy,
     ProcessingStrategyFactory,
 )
-from arroyo.types import Message, Offset, Partition, Topic, TPayload
+from arroyo.types import Message, Partition, Position, Topic, TPayload
 from arroyo.utils.metrics import get_metrics
 
 logger = logging.getLogger(__name__)
@@ -89,7 +89,7 @@ class StreamProcessor(Generic[TPayload]):
             [topic], on_assign=on_partitions_assigned, on_revoke=on_partitions_revoked
         )
 
-    def __commit(self, offsets: Mapping[Partition, Offset]) -> None:
+    def __commit(self, offsets: Mapping[Partition, Position]) -> None:
         self.__consumer.stage_offsets(offsets)
         start = time.time()
         self.__consumer.commit_offsets()

--- a/arroyo/processing/strategies/abstract.py
+++ b/arroyo/processing/strategies/abstract.py
@@ -1,7 +1,7 @@
 from abc import ABC, abstractmethod
 from typing import Callable, Generic, Mapping, Optional
 
-from arroyo.types import Message, Partition, TPayload
+from arroyo.types import Message, Offset, Partition, TPayload
 
 
 class MessageRejected(Exception):
@@ -93,7 +93,7 @@ class ProcessingStrategy(ABC, Generic[TPayload]):
 class ProcessingStrategyFactory(ABC, Generic[TPayload]):
     @abstractmethod
     def create(
-        self, commit: Callable[[Mapping[Partition, int]], None]
+        self, commit: Callable[[Mapping[Partition, Offset]], None]
     ) -> ProcessingStrategy[TPayload]:
         """
         Instantiate and return a ``ProcessingStrategy`` instance.

--- a/arroyo/processing/strategies/abstract.py
+++ b/arroyo/processing/strategies/abstract.py
@@ -1,7 +1,7 @@
 from abc import ABC, abstractmethod
 from typing import Callable, Generic, Mapping, Optional
 
-from arroyo.types import Message, Offset, Partition, TPayload
+from arroyo.types import Message, Partition, Position, TPayload
 
 
 class MessageRejected(Exception):
@@ -93,7 +93,7 @@ class ProcessingStrategy(ABC, Generic[TPayload]):
 class ProcessingStrategyFactory(ABC, Generic[TPayload]):
     @abstractmethod
     def create(
-        self, commit: Callable[[Mapping[Partition, Offset]], None]
+        self, commit: Callable[[Mapping[Partition, Position]], None]
     ) -> ProcessingStrategy[TPayload]:
         """
         Instantiate and return a ``ProcessingStrategy`` instance.

--- a/arroyo/processing/strategies/batching.py
+++ b/arroyo/processing/strategies/batching.py
@@ -20,7 +20,7 @@ from arroyo.processing.strategies.abstract import (
     ProcessingStrategy,
     ProcessingStrategyFactory,
 )
-from arroyo.types import Message, Offset, Partition, TPayload
+from arroyo.types import Message, Partition, Position, TPayload
 from arroyo.utils.metrics import get_metrics
 
 logger = logging.getLogger(__name__)
@@ -102,7 +102,7 @@ class BatchProcessingStrategy(ProcessingStrategy[TPayload]):
 
     def __init__(
         self,
-        commit: Callable[[Mapping[Partition, Offset]], None],
+        commit: Callable[[Mapping[Partition, Position]], None],
         worker: AbstractBatchWorker[TPayload, TResult],
         max_batch_size: int,
         max_batch_time: int,
@@ -216,7 +216,7 @@ class BatchProcessingStrategy(ProcessingStrategy[TPayload]):
         logger.debug("Committing offsets for batch")
         commit_start = time.time()
         offsets = {
-            partition: Offset(offsets.hi, offsets.timestamp)
+            partition: Position(offsets.hi, offsets.timestamp)
             for partition, offsets in self.__batch.offsets.items()
         }
         self.__commit(offsets)
@@ -239,7 +239,7 @@ class BatchProcessingStrategyFactory(ProcessingStrategyFactory[TPayload]):
         self.__max_batch_time = max_batch_time
 
     def create(
-        self, commit: Callable[[Mapping[Partition, Offset]], None]
+        self, commit: Callable[[Mapping[Partition, Position]], None]
     ) -> ProcessingStrategy[TPayload]:
         return BatchProcessingStrategy(
             commit,

--- a/arroyo/processing/strategies/streaming/factory.py
+++ b/arroyo/processing/strategies/streaming/factory.py
@@ -9,7 +9,7 @@ from arroyo.processing.strategies.streaming.transform import (
     ParallelTransformStep,
     TransformStep,
 )
-from arroyo.types import Message, Offset, Partition
+from arroyo.types import Message, Partition, Position
 
 TPayload = TypeVar("TPayload")
 TProcessed = TypeVar("TProcessed")
@@ -84,7 +84,7 @@ class ConsumerStrategyFactory(ProcessingStrategyFactory[TPayload]):
         return not self.__prefilter.should_drop(message)
 
     def create(
-        self, commit: Callable[[Mapping[Partition, Offset]], None]
+        self, commit: Callable[[Mapping[Partition, Position]], None]
     ) -> ProcessingStrategy[TPayload]:
         collect = CollectStep(
             self.__collector,

--- a/arroyo/processing/strategies/streaming/factory.py
+++ b/arroyo/processing/strategies/streaming/factory.py
@@ -9,7 +9,7 @@ from arroyo.processing.strategies.streaming.transform import (
     ParallelTransformStep,
     TransformStep,
 )
-from arroyo.types import Message, Partition
+from arroyo.types import Message, Offset, Partition
 
 TPayload = TypeVar("TPayload")
 TProcessed = TypeVar("TProcessed")
@@ -84,7 +84,7 @@ class ConsumerStrategyFactory(ProcessingStrategyFactory[TPayload]):
         return not self.__prefilter.should_drop(message)
 
     def create(
-        self, commit: Callable[[Mapping[Partition, int]], None]
+        self, commit: Callable[[Mapping[Partition, Offset]], None]
     ) -> ProcessingStrategy[TPayload]:
         collect = CollectStep(
             self.__collector,

--- a/arroyo/synchronized.py
+++ b/arroyo/synchronized.py
@@ -266,11 +266,11 @@ class SynchronizedConsumer(Consumer[TPayload]):
     def seek(self, offsets: Mapping[Partition, int]) -> None:
         return self.__consumer.seek(offsets)
 
-    def stage_offsets(self, offsets: Mapping[Partition, Position]) -> None:
-        return self.__consumer.stage_offsets(offsets)
+    def stage_positions(self, positions: Mapping[Partition, Position]) -> None:
+        return self.__consumer.stage_positions(positions)
 
-    def commit_offsets(self) -> Mapping[Partition, Position]:
-        return self.__consumer.commit_offsets()
+    def commit_positions(self) -> Mapping[Partition, Position]:
+        return self.__consumer.commit_positions()
 
     def close(self, timeout: Optional[float] = None) -> None:
         # TODO: Be careful to ensure there are not any deadlock conditions

--- a/arroyo/synchronized.py
+++ b/arroyo/synchronized.py
@@ -6,7 +6,7 @@ from typing import Callable, Mapping, MutableMapping, Optional, Sequence, Set
 from arroyo.backends.abstract import Consumer
 from arroyo.backends.kafka import KafkaPayload
 from arroyo.errors import ConsumerError, EndOfPartition
-from arroyo.types import Message, Partition, Topic, TPayload
+from arroyo.types import Message, Offset, Partition, Topic, TPayload
 from arroyo.utils.codecs import Codec
 from arroyo.utils.concurrent import Synchronized, execute
 
@@ -266,10 +266,10 @@ class SynchronizedConsumer(Consumer[TPayload]):
     def seek(self, offsets: Mapping[Partition, int]) -> None:
         return self.__consumer.seek(offsets)
 
-    def stage_offsets(self, offsets: Mapping[Partition, int]) -> None:
+    def stage_offsets(self, offsets: Mapping[Partition, Offset]) -> None:
         return self.__consumer.stage_offsets(offsets)
 
-    def commit_offsets(self) -> Mapping[Partition, int]:
+    def commit_offsets(self) -> Mapping[Partition, Offset]:
         return self.__consumer.commit_offsets()
 
     def close(self, timeout: Optional[float] = None) -> None:

--- a/arroyo/synchronized.py
+++ b/arroyo/synchronized.py
@@ -6,7 +6,7 @@ from typing import Callable, Mapping, MutableMapping, Optional, Sequence, Set
 from arroyo.backends.abstract import Consumer
 from arroyo.backends.kafka import KafkaPayload
 from arroyo.errors import ConsumerError, EndOfPartition
-from arroyo.types import Message, Offset, Partition, Topic, TPayload
+from arroyo.types import Message, Partition, Position, Topic, TPayload
 from arroyo.utils.codecs import Codec
 from arroyo.utils.concurrent import Synchronized, execute
 
@@ -266,10 +266,10 @@ class SynchronizedConsumer(Consumer[TPayload]):
     def seek(self, offsets: Mapping[Partition, int]) -> None:
         return self.__consumer.seek(offsets)
 
-    def stage_offsets(self, offsets: Mapping[Partition, Offset]) -> None:
+    def stage_offsets(self, offsets: Mapping[Partition, Position]) -> None:
         return self.__consumer.stage_offsets(offsets)
 
-    def commit_offsets(self) -> Mapping[Partition, Offset]:
+    def commit_offsets(self) -> Mapping[Partition, Position]:
         return self.__consumer.commit_offsets()
 
     def close(self, timeout: Optional[float] = None) -> None:

--- a/arroyo/types.py
+++ b/arroyo/types.py
@@ -65,7 +65,8 @@ class Message(Generic[TPayload]):
         return f"{type(self).__name__}(partition={self.partition!r}, offset={self.offset!r})"
 
 
-@dataclass
-class Offset:
-    kafka_offset: int
+@dataclass(frozen=True)
+class Position:
+    __slots__ = ["offset", "timestamp"]
+    offset: int
     timestamp: datetime

--- a/arroyo/types.py
+++ b/arroyo/types.py
@@ -67,5 +67,5 @@ class Message(Generic[TPayload]):
 
 @dataclass
 class Offset:
-    offset: int
+    kafka_offset: int
     timestamp: datetime

--- a/arroyo/types.py
+++ b/arroyo/types.py
@@ -63,3 +63,9 @@ class Message(Generic[TPayload]):
         # ``__slots__`` for performance reasons. The class variable names
         # would conflict with the instance slot names, causing an error.
         return f"{type(self).__name__}(partition={self.partition!r}, offset={self.offset!r})"
+
+
+@dataclass
+class Offset:
+    offset: int
+    timestamp: datetime

--- a/arroyo/utils/profiler.py
+++ b/arroyo/utils/profiler.py
@@ -8,7 +8,7 @@ from arroyo.processing.strategies.abstract import (
     ProcessingStrategy,
     ProcessingStrategyFactory,
 )
-from arroyo.types import Message, Partition, TPayload
+from arroyo.types import Message, Offset, Partition, TPayload
 
 logger = logging.getLogger(__name__)
 
@@ -61,7 +61,7 @@ class ProcessingStrategyProfilerWrapperFactory(ProcessingStrategyFactory[TPayloa
         assert self.__output_directory.exists() and self.__output_directory.is_dir()
 
     def create(
-        self, commit: Callable[[Mapping[Partition, int]], None]
+        self, commit: Callable[[Mapping[Partition, Offset]], None]
     ) -> ProcessingStrategy[TPayload]:
         profiler = Profile()
         profiler.enable()

--- a/arroyo/utils/profiler.py
+++ b/arroyo/utils/profiler.py
@@ -8,7 +8,7 @@ from arroyo.processing.strategies.abstract import (
     ProcessingStrategy,
     ProcessingStrategyFactory,
 )
-from arroyo.types import Message, Offset, Partition, TPayload
+from arroyo.types import Message, Partition, Position, TPayload
 
 logger = logging.getLogger(__name__)
 
@@ -61,7 +61,7 @@ class ProcessingStrategyProfilerWrapperFactory(ProcessingStrategyFactory[TPayloa
         assert self.__output_directory.exists() and self.__output_directory.is_dir()
 
     def create(
-        self, commit: Callable[[Mapping[Partition, Offset]], None]
+        self, commit: Callable[[Mapping[Partition, Position]], None]
     ) -> ProcessingStrategy[TPayload]:
         profiler = Profile()
         profiler.enable()

--- a/tests/backends/mixins.py
+++ b/tests/backends/mixins.py
@@ -111,7 +111,7 @@ class StreamsTestMixin(ABC, Generic[TPayload]):
             assert consumer.commit_offsets() == {}
 
             consumer.stage_offsets(
-                {message.partition: Offset(message.next_offset, message.timestamp)}
+                {message.partition: Offset(message.next_offset, messages[1].timestamp)}
             )
 
             with pytest.raises(ConsumerError):

--- a/tests/backends/mixins.py
+++ b/tests/backends/mixins.py
@@ -108,9 +108,9 @@ class StreamsTestMixin(ABC, Generic[TPayload]):
             assert message.offset == messages[0].offset
             assert message.payload == messages[0].payload
 
-            assert consumer.commit_offsets() == {}
+            assert consumer.commit_positions() == {}
 
-            consumer.stage_offsets(
+            consumer.stage_positions(
                 {
                     message.partition: Position(
                         message.next_offset, messages[1].timestamp
@@ -119,7 +119,7 @@ class StreamsTestMixin(ABC, Generic[TPayload]):
             )
 
             with pytest.raises(ConsumerError):
-                consumer.stage_offsets(
+                consumer.stage_positions(
                     {
                         Partition(Topic("invalid"), 0): Position(
                             0, datetime.now() - timedelta(minutes=1)
@@ -127,7 +127,7 @@ class StreamsTestMixin(ABC, Generic[TPayload]):
                     }
                 )
 
-            assert consumer.commit_offsets() == {
+            assert consumer.commit_positions() == {
                 Partition(topic, 0): Position(message.next_offset, message.timestamp)
             }
 
@@ -178,10 +178,10 @@ class StreamsTestMixin(ABC, Generic[TPayload]):
                 consumer.paused()
 
             with pytest.raises(RuntimeError):
-                consumer.stage_offsets({})
+                consumer.stage_positions({})
 
             with pytest.raises(RuntimeError):
-                consumer.commit_offsets()
+                consumer.commit_positions()
 
             consumer.close()  # should be safe, even if the consumer is already closed
 

--- a/tests/processing/strategies/test_streaming.py
+++ b/tests/processing/strategies/test_streaming.py
@@ -17,7 +17,7 @@ from arroyo.processing.strategies.streaming.transform import (
     ValueTooLarge,
     parallel_transform_worker_apply,
 )
-from arroyo.types import Message, Partition, Topic
+from arroyo.types import Message, Offset, Partition, Topic
 from tests.assertions import assert_changes, assert_does_not_change
 from tests.metrics import Gauge as GaugeCall
 from tests.metrics import TestingMetricsBackend
@@ -108,15 +108,18 @@ def test_collect() -> None:
 
     # Subsequent messages should reuse the existing batch, ...
     with assert_does_not_change(lambda: step_factory.call_count, 1):
+        second_message = next(messages)
         collect_step.poll()
-        collect_step.submit(next(messages))  # offset 1
+        collect_step.submit(second_message)  # offset 1
 
     # ...until we hit the batch size limit.
     with assert_changes(lambda: int(inner_step.close.call_count), 0, 1), assert_changes(
         lambda: int(inner_step.join.call_count), 0, 1
     ), assert_changes(lambda: commit_function.call_count, 0, 1):
         collect_step.poll()
-        assert commit_function.call_args == call({partition: 2})
+        assert commit_function.call_args == call(
+            {partition: Offset(2, second_message.timestamp)}
+        )
 
     step_factory.return_value = inner_step = Mock()
 

--- a/tests/processing/strategies/test_streaming.py
+++ b/tests/processing/strategies/test_streaming.py
@@ -17,7 +17,7 @@ from arroyo.processing.strategies.streaming.transform import (
     ValueTooLarge,
     parallel_transform_worker_apply,
 )
-from arroyo.types import Message, Offset, Partition, Topic
+from arroyo.types import Message, Partition, Position, Topic
 from tests.assertions import assert_changes, assert_does_not_change
 from tests.metrics import Gauge as GaugeCall
 from tests.metrics import TestingMetricsBackend
@@ -118,7 +118,7 @@ def test_collect() -> None:
     ), assert_changes(lambda: commit_function.call_count, 0, 1):
         collect_step.poll()
         assert commit_function.call_args == call(
-            {partition: Offset(2, second_message.timestamp)}
+            {partition: Position(2, second_message.timestamp)}
         )
 
     step_factory.return_value = inner_step = Mock()


### PR DESCRIPTION
This is one of the least invasive ways I've found so far to make the
timestamp associated with an offset availble to the collector processing step.
The end goal of this is to allow Snuba to produce that timestamp to the commit log
during the commit offsets phase, so that it can later be used for subscription scheduling.

We already keep track of the hi and lo offset for each batch and use that to commit offsets.
With this change we will also keep track of the associated timestamp together with it's
corresponding offset number.