### PR TITLE
perf: Record time spent by synchronized consumer `poll()` method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog and versioning
 
+
+## Unreleased
+
+- Record a metric with the time spent in the poll method of the synchronized consumer
+
 ## 0.0.4
 
 - Handle missing `orig_message_ts` header. Since all events in the pipeline produced using an older version of arroyo may not have the header yet, temporarily support a None value for `orig_message_ts`.


### PR DESCRIPTION
Recording a metric to help better understand the impact of synchronized consumer
on subscription performance.