### PR TITLE
feat(perf) Add latency metrics to the messages coming from the commit log

### DIFF
--- a/arroyo/synchronized.py
+++ b/arroyo/synchronized.py
@@ -164,6 +164,7 @@ class SynchronizedConsumer(Consumer[TPayload]):
             if commit.group not in self.__commit_log_groups:
                 continue
 
+            now = time()
             with self.__remote_offsets.get() as remote_offsets:
                 # NOTE: This will store data about partitions that are not
                 # actually part of the subscription or assignment. This
@@ -177,18 +178,18 @@ class SynchronizedConsumer(Consumer[TPayload]):
             if commit.orig_message_ts is not None:
                 self.__metrics.timing(
                     "commit_log_msg_latency",
-                    (time() - datetime.timestamp(commit.orig_message_ts)) * 1000,
+                    (now - datetime.timestamp(commit.orig_message_ts)) * 1000,
                     tags={
                         "partition": str(commit.partition.index),
-                        "consumer_group": commit.group,
+                        "group": commit.group,
                     }
                 )
             self.__metrics.timing(
                 "commit_log_latency",
-                (time() - datetime.timestamp(message.timestamp)) * 1000,
+                (now - datetime.timestamp(message.timestamp)) * 1000,
                 tags={
                     "partition": str(commit.partition.index),
-                    "consumer_group": commit.group,
+                    "group": commit.group,
                 }
             )
 


### PR DESCRIPTION
Lately we observed weird temporary increases in subscriptions consumer latency on selected partitions.
It is hard to understand exactly who is causing them. 
One theory is that somehow the commit log messages could be delayed or could be processed too late by the subscriptions consumer. 

Adding latency metrics to the code that consumes the commit log to rule out this hypothesis.
Specifically we record both the difference between the current time and the broker time the commit log message was produced at and the difference between the current time and the broker timestamp of the last message the commit log messages refers to.
The first gives us an indication if the commit log messages are late.
The second gives us an indication if the main consumer is consuming old messages.