### PR TITLE
meta(gha): Deploy workflow enforce-license-compliance.yml

### DIFF
--- a/.github/workflows/enforce-license-compliance.yml
+++ b/.github/workflows/enforce-license-compliance.yml
@@ -1,0 +1,25 @@
+name: Enforce License Compliance
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+jobs:
+  enforce-license-compliance:
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Checkout Code"
+        uses: actions/checkout@v2
+
+      - name: "Run FOSSA Scan"
+        uses: fossas/fossa-action@v1.1.0
+        with:
+          api-key: ${{secrets.FOSSA_API_KEY}}
+
+      - name: "Run FOSSA Test"
+        uses: fossas/fossa-action@v1.1.0
+        with:
+          api-key: ${{secrets.FOSSA_API_KEY}}
+          run-tests: true

--- a/.github/workflows/enforce-license-compliance.yml
+++ b/.github/workflows/enforce-license-compliance.yml
@@ -2,9 +2,9 @@ name: Enforce License Compliance
 
 on:
   push:
-    branches: [master]
+    branches: [main]
   pull_request:
-    branches: [master]
+    branches: [main]
 
 jobs:
   enforce-license-compliance:


### PR DESCRIPTION
I are a bot, here to deploy [enforce-license-compliance.yml](https://github.com/getsentry/.github/blob/135d4e0f41194b0379a3d2220a9226a7a180dd5d/.github/workflows/enforce-license-compliance.yml). 🤖