### PR TITLE
feat(consumer): Support incremental cooperative rebalancing

### DIFF
--- a/arroyo/backends/kafka/consumer.py
+++ b/arroyo/backends/kafka/consumer.py
@@ -146,7 +146,7 @@ class KafkaConsumer(Consumer[KafkaPayload]):
         configuration: MutableMapping[str, Any],
         *,
         commit_retry_policy: Optional[RetryPolicy] = None,
-        incremental: bool = False,
+        incremental_cooperative: bool = False,
     ) -> None:
         if commit_retry_policy is None:
             commit_retry_policy = NoRetryPolicy()
@@ -183,9 +183,9 @@ class KafkaConsumer(Consumer[KafkaPayload]):
                 "invalid value for 'enable.auto.offset.store' configuration"
             )
 
-        self.__incremental = incremental
+        self.__incremental_cooperative = incremental_cooperative
 
-        if self.__incremental is True:
+        if self.__incremental_cooperative is True:
             configuration["partition.assignment.strategy"] = "cooperative-sticky"
 
         # NOTE: Offsets are explicitly managed as part of the assignment
@@ -252,7 +252,7 @@ class KafkaConsumer(Consumer[KafkaPayload]):
         ) -> None:
             self.__state = KafkaConsumerState.ASSIGNING
 
-            if self.__incremental is True:
+            if self.__incremental_cooperative is True:
                 incremental_assignment: MutableSequence[ConfluentTopicPartition] = []
 
                 for partition in partitions:

--- a/arroyo/backends/kafka/consumer.py
+++ b/arroyo/backends/kafka/consumer.py
@@ -106,7 +106,8 @@ def as_kafka_configuration_bool(value: Any) -> bool:
 
 class KafkaConsumer(Consumer[KafkaPayload]):
     """
-    The behavior of this consumer differs slightly from the Confluent
+    If a non-cooperative partition assignment strategy is selected,
+    the behavior of this consumer differs slightly from the Confluent
     consumer during rebalancing operations. Whenever a partition is assigned
     to this consumer, offsets are *always* automatically reset to the
     committed offset for that partition (or if no offsets have been committed
@@ -116,6 +117,12 @@ class KafkaConsumer(Consumer[KafkaPayload]):
     behavior as a partition that is moved from one consumer to another. To
     prevent uncommitted messages from being consumed multiple times,
     ``commit`` should be called in the partition revocation callback.
+
+    If the `cooperative-sticky` strategy is used, this won't happen as
+    only the incremental partitions are passed to the callback during
+    rebalancing, and any previously assigned partitions will continue
+    from their previous position without being reset to the last committed
+    position.
 
     The behavior of ``auto.offset.reset`` also differs slightly from the
     Confluent consumer as well: offsets are only reset during initial

--- a/arroyo/backends/kafka/consumer.py
+++ b/arroyo/backends/kafka/consumer.py
@@ -491,15 +491,6 @@ class KafkaConsumer(Consumer[KafkaPayload]):
         )
         self.__offsets.update(offsets)
 
-    def __seek(self, offsets: Mapping[Partition, int]) -> None:
-        self.__validate_offsets(offsets)
-
-        for partition, offset in offsets.items():
-            self.__consumer.seek(
-                ConfluentTopicPartition(partition.topic.name, partition.index, offset)
-            )
-        self.__offsets.update(offsets)
-
     def seek(self, offsets: Mapping[Partition, int]) -> None:
         """
         Change the read offsets for the provided partitions.
@@ -512,7 +503,13 @@ class KafkaConsumer(Consumer[KafkaPayload]):
         if offsets.keys() - self.__offsets.keys():
             raise ConsumerError("cannot seek on unassigned partitions")
 
-        self.__seek(offsets)
+        self.__validate_offsets(offsets)
+
+        for partition, offset in offsets.items():
+            self.__consumer.seek(
+                ConfluentTopicPartition(partition.topic.name, partition.index, offset)
+            )
+        self.__offsets.update(offsets)
 
     def pause(self, partitions: Sequence[Partition]) -> None:
         """

--- a/arroyo/backends/kafka/consumer.py
+++ b/arroyo/backends/kafka/consumer.py
@@ -306,17 +306,8 @@ class KafkaConsumer(Consumer[KafkaPayload]):
 
                     # Ensure that all partitions are resumed on assignment to avoid
                     # carrying over state from a previous assignment.
-                    self.__consumer.resume(
-                        [
-                            ConfluentTopicPartition(
-                                partition.topic.name, partition.index, offset
-                            )
-                            for partition, offset in offsets.items()
-                        ]
-                    )
+                    self.resume([p for p in offsets])
 
-                    for partition in offsets:
-                        self.__paused.discard(partition)
                 except Exception:
                     self.__state = KafkaConsumerState.ERROR
                     raise

--- a/arroyo/backends/kafka/consumer.py
+++ b/arroyo/backends/kafka/consumer.py
@@ -143,10 +143,9 @@ class KafkaConsumer(Consumer[KafkaPayload]):
 
     def __init__(
         self,
-        configuration: MutableMapping[str, Any],
+        configuration: Mapping[str, Any],
         *,
         commit_retry_policy: Optional[RetryPolicy] = None,
-        incremental_cooperative: bool = False,
     ) -> None:
         if commit_retry_policy is None:
             commit_retry_policy = NoRetryPolicy()
@@ -183,10 +182,9 @@ class KafkaConsumer(Consumer[KafkaPayload]):
                 "invalid value for 'enable.auto.offset.store' configuration"
             )
 
-        self.__incremental_cooperative = incremental_cooperative
-
-        if self.__incremental_cooperative is True:
-            configuration["partition.assignment.strategy"] = "cooperative-sticky"
+        self.__incremental_cooperative = (
+            configuration.get("partition.assignment.strategy") == "cooperative-sticky"
+        )
 
         # NOTE: Offsets are explicitly managed as part of the assignment
         # callback, so preemptively resetting offsets is not enabled.

--- a/tests/backends/mixins.py
+++ b/tests/backends/mixins.py
@@ -51,10 +51,10 @@ class StreamsTestMixin(ABC, Generic[TPayload]):
             def _assignment_callback(partitions: Mapping[Partition, int]) -> None:
                 assert partitions == {Partition(topic, 0): messages[0].offset}
 
-                consumer.seek({Partition(topic, 0): messages[1].offset})
+                # consumer.seek({Partition(topic, 0): messages[1].offset})
 
-                with pytest.raises(ConsumerError):
-                    consumer.seek({Partition(topic, 1): 0})
+                # with pytest.raises(ConsumerError):
+                #     consumer.seek({Partition(topic, 1): 0})
 
             assignment_callback = mock.Mock(side_effect=_assignment_callback)
 
@@ -77,14 +77,14 @@ class StreamsTestMixin(ABC, Generic[TPayload]):
             with assert_changes(
                 lambda: assignment_callback.called, False, True
             ), assert_changes(
-                consumer.tell, {}, {Partition(topic, 0): messages[1].next_offset}
+                consumer.tell, {}, {Partition(topic, 0): messages[1].offset}
             ):
                 message = consumer.poll(10.0)  # XXX: getting the subcription is slow
 
             assert isinstance(message, Message)
             assert message.partition == Partition(topic, 0)
-            assert message.offset == messages[1].offset
-            assert message.payload == messages[1].payload
+            assert message.offset == messages[0].offset
+            assert message.payload == messages[0].payload
 
             consumer.seek({Partition(topic, 0): messages[0].offset})
             assert consumer.tell() == {Partition(topic, 0): messages[0].offset}

--- a/tests/backends/mixins.py
+++ b/tests/backends/mixins.py
@@ -51,10 +51,10 @@ class StreamsTestMixin(ABC, Generic[TPayload]):
             def _assignment_callback(partitions: Mapping[Partition, int]) -> None:
                 assert partitions == {Partition(topic, 0): messages[0].offset}
 
-                # consumer.seek({Partition(topic, 0): messages[1].offset})
+                consumer.seek({Partition(topic, 0): messages[1].offset})
 
-                # with pytest.raises(ConsumerError):
-                #     consumer.seek({Partition(topic, 1): 0})
+                with pytest.raises(ConsumerError):
+                    consumer.seek({Partition(topic, 1): 0})
 
             assignment_callback = mock.Mock(side_effect=_assignment_callback)
 
@@ -77,14 +77,14 @@ class StreamsTestMixin(ABC, Generic[TPayload]):
             with assert_changes(
                 lambda: assignment_callback.called, False, True
             ), assert_changes(
-                consumer.tell, {}, {Partition(topic, 0): messages[1].offset}
+                consumer.tell, {}, {Partition(topic, 0): messages[1].next_offset}
             ):
                 message = consumer.poll(10.0)  # XXX: getting the subcription is slow
 
             assert isinstance(message, Message)
             assert message.partition == Partition(topic, 0)
-            assert message.offset == messages[0].offset
-            assert message.payload == messages[0].payload
+            assert message.offset == messages[1].offset
+            assert message.payload == messages[1].payload
 
             consumer.seek({Partition(topic, 0): messages[0].offset})
             assert consumer.tell() == {Partition(topic, 0): messages[0].offset}

--- a/tests/backends/test_kafka.py
+++ b/tests/backends/test_kafka.py
@@ -163,7 +163,7 @@ def test_cooperative_rebalancing() -> None:
             "group.id": group_id,
             "session.timeout.ms": 10000,
         },
-        incremental=True,
+        incremental_cooperative=True,
     )
     consumer_b = KafkaConsumer(
         {
@@ -174,7 +174,7 @@ def test_cooperative_rebalancing() -> None:
             "group.id": group_id,
             "session.timeout.ms": 10000,
         },
-        incremental=True,
+        incremental_cooperative=True,
     )
 
     with get_topic(configuration, partitions_count) as topic, closing(

--- a/tests/backends/test_kafka.py
+++ b/tests/backends/test_kafka.py
@@ -157,24 +157,24 @@ def test_cooperative_rebalancing() -> None:
     consumer_a = KafkaConsumer(
         {
             **configuration,
+            "partition.assignment.strategy": "cooperative-sticky",
             "auto.offset.reset": "earliest",
             "enable.auto.commit": False,
             "enable.auto.offset.store": False,
             "group.id": group_id,
             "session.timeout.ms": 10000,
         },
-        incremental_cooperative=True,
     )
     consumer_b = KafkaConsumer(
         {
             **configuration,
+            "partition.assignment.strategy": "cooperative-sticky",
             "auto.offset.reset": "earliest",
             "enable.auto.commit": False,
             "enable.auto.offset.store": False,
             "group.id": group_id,
             "session.timeout.ms": 10000,
         },
-        incremental_cooperative=True,
     )
 
     with get_topic(configuration, partitions_count) as topic, closing(

--- a/tests/backends/test_kafka.py
+++ b/tests/backends/test_kafka.py
@@ -183,7 +183,7 @@ def test_cooperative_rebalancing() -> None:
         for i in range(10):
             for j in range(partitions_count):
                 producer.produce(
-                    Partition(topic, 1),
+                    Partition(topic, j),
                     KafkaPayload(None, f"{j}-{i}".encode("utf8"), []),
                 )
 


### PR DESCRIPTION
KafkaConsumer now supports the `cooperative-sticky` partitioning strategy.
The goal of this change is to try and reduce the amount of unnecessary rebalances
that happen during Kubernetes rolling deployments.