### PR TITLE
feat: Add flag to restore confluence kafka auto.offset.reset behavior

### DIFF
--- a/arroyo/backends/abstract.py
+++ b/arroyo/backends/abstract.py
@@ -139,11 +139,19 @@ class Consumer(Generic[TPayload], ABC):
         raise NotImplementedError
 
     @abstractmethod
-    def stage_positions(self, positions: Mapping[Partition, Position]) -> None:
+    def stage_positions(
+        self, positions: Mapping[Partition, Position], force: bool = False
+    ) -> None:
         """
         Stage offsets to be committed. If an offset has already been staged
         for a given partition, that offset is overwritten (even if the offset
         moves in reverse.)
+
+        The force flag overrides the validation of the partitions.  This lets one
+        stage a position to a partition that is not yet assigned to the consumer.
+        This functionality is useful in some corner cases when trying to write tests
+        for instance where specific offsets need to be written without having to wait
+        for an initial poll which can take time.
         """
         raise NotImplementedError
 

--- a/arroyo/backends/kafka/configuration.py
+++ b/arroyo/backends/kafka/configuration.py
@@ -70,6 +70,7 @@ def build_kafka_consumer_configuration(
     default_config: Mapping[str, Any],
     group_id: str,
     auto_offset_reset: Optional[str] = None,
+    force_offset_reset: Optional[str] = None,
     queued_max_messages_kbytes: Optional[int] = None,
     queued_min_messages: Optional[int] = None,
     bootstrap_servers: Optional[Sequence[str]] = None,
@@ -95,6 +96,7 @@ def build_kafka_consumer_configuration(
             "enable.auto.offset.store": False,
             "group.id": group_id,
             "auto.offset.reset": auto_offset_reset,
+            "force.offset.reset": force_offset_reset,
             # overridden to reduce memory usage when there's a large backlog
             "queued.max.messages.kbytes": queued_max_messages_kbytes,
             "queued.min.messages": queued_min_messages,

--- a/arroyo/backends/kafka/configuration.py
+++ b/arroyo/backends/kafka/configuration.py
@@ -70,11 +70,11 @@ def build_kafka_consumer_configuration(
     default_config: Mapping[str, Any],
     group_id: str,
     auto_offset_reset: Optional[str] = None,
-    force_offset_reset: Optional[str] = None,
     queued_max_messages_kbytes: Optional[int] = None,
     queued_min_messages: Optional[int] = None,
     bootstrap_servers: Optional[Sequence[str]] = None,
     override_params: Optional[Mapping[str, Any]] = None,
+    strict_offset_reset: Optional[bool] = None,
 ) -> KafkaBrokerConfig:
 
     if auto_offset_reset is None:
@@ -96,7 +96,8 @@ def build_kafka_consumer_configuration(
             "enable.auto.offset.store": False,
             "group.id": group_id,
             "auto.offset.reset": auto_offset_reset,
-            "force.offset.reset": force_offset_reset,
+            # this is an arroyo specific flag that only affects the consumer.
+            "arroyo.strict.offset.reset": strict_offset_reset,
             # overridden to reduce memory usage when there's a large backlog
             "queued.max.messages.kbytes": queued_max_messages_kbytes,
             "queued.min.messages": queued_min_messages,

--- a/arroyo/backends/kafka/consumer.py
+++ b/arroyo/backends/kafka/consumer.py
@@ -160,7 +160,7 @@ class KafkaConsumer(Consumer[KafkaPayload]):
 
         configuration = dict(configuration)
         auto_offset_reset = configuration.get("auto.offset.reset", "largest")
-        self.__force_offset_reset = configuration.pop("force.offset.reset")
+        self.__force_offset_reset = configuration.pop("force.offset.reset", None)
         if auto_offset_reset in {"smallest", "earliest", "beginning"}:
             self.__resolve_partition_starting_offset = (
                 self.__resolve_partition_offset_earliest

--- a/arroyo/backends/kafka/consumer.py
+++ b/arroyo/backends/kafka/consumer.py
@@ -575,16 +575,22 @@ class KafkaConsumer(Consumer[KafkaPayload]):
 
         return [*self.__paused]
 
-    def stage_positions(self, positions: Mapping[Partition, Position]) -> None:
+    def stage_positions(
+        self, positions: Mapping[Partition, Position], force: bool = False
+    ) -> None:
         if self.__state in {KafkaConsumerState.CLOSED, KafkaConsumerState.ERROR}:
             raise InvalidState(self.__state)
 
-        if positions.keys() - self.__offsets.keys():
-            raise ConsumerError("cannot stage offsets for unassigned partitions")
+        if not force:
+            if positions.keys() - self.__offsets.keys():
+                raise ConsumerError("cannot stage offsets for unassigned partitions")
 
-        self.__validate_offsets(
-            {partition: position.offset for (partition, position) in positions.items()}
-        )
+            self.__validate_offsets(
+                {
+                    partition: position.offset
+                    for (partition, position) in positions.items()
+                }
+            )
 
         # TODO: Maybe log a warning if these offsets exceed the current
         # offsets, since that's probably a side effect of an incorrect usage

--- a/arroyo/backends/kafka/consumer.py
+++ b/arroyo/backends/kafka/consumer.py
@@ -158,6 +158,7 @@ class KafkaConsumer(Consumer[KafkaPayload]):
         if commit_retry_policy is None:
             commit_retry_policy = NoRetryPolicy()
 
+        configuration = dict(configuration)
         auto_offset_reset = configuration.get("auto.offset.reset", "largest")
         self.__force_offset_reset = configuration.pop("force.offset.reset", False)
         if auto_offset_reset in {"smallest", "earliest", "beginning"}:
@@ -431,7 +432,7 @@ class KafkaConsumer(Consumer[KafkaPayload]):
                 KafkaError._AUTO_OFFSET_RESET,
             ):
                 if self.__force_offset_reset:
-                    return
+                    return None
                 raise OffsetOutOfRange(str(error))
             else:
                 raise ConsumerError(str(error))

--- a/arroyo/backends/kafka/consumer.py
+++ b/arroyo/backends/kafka/consumer.py
@@ -160,7 +160,7 @@ class KafkaConsumer(Consumer[KafkaPayload]):
 
         configuration = dict(configuration)
         auto_offset_reset = configuration.get("auto.offset.reset", "largest")
-        self.__force_offset_reset = configuration.pop("force.offset.reset", False)
+        self.__force_offset_reset = configuration.pop("force.offset.reset")
         if auto_offset_reset in {"smallest", "earliest", "beginning"}:
             self.__resolve_partition_starting_offset = (
                 self.__resolve_partition_offset_earliest

--- a/arroyo/backends/kafka/consumer.py
+++ b/arroyo/backends/kafka/consumer.py
@@ -433,10 +433,6 @@ class KafkaConsumer(Consumer[KafkaPayload]):
                 KafkaError.OFFSET_OUT_OF_RANGE,
                 KafkaError._AUTO_OFFSET_RESET,
             ):
-                # In theory this should not happen under auto offset reset.
-                # However just in case it comes around, be explicit about it.
-                if self.__force_offset_reset:
-                    return None
                 raise OffsetOutOfRange(str(error))
             else:
                 raise ConsumerError(str(error))

--- a/arroyo/backends/local/backend.py
+++ b/arroyo/backends/local/backend.py
@@ -304,20 +304,25 @@ class LocalConsumer(Consumer[TPayload]):
 
             self.__offsets.update(offsets)
 
-    def stage_positions(self, positions: Mapping[Partition, Position]) -> None:
+    def stage_positions(
+        self, positions: Mapping[Partition, Position], force: bool = False
+    ) -> None:
         with self.__lock:
             if self.__closed:
                 raise RuntimeError("consumer is closed")
 
-            if positions.keys() - self.__offsets.keys():
-                raise ConsumerError("cannot stage offsets for unassigned partitions")
+            if not force:
+                if positions.keys() - self.__offsets.keys():
+                    raise ConsumerError(
+                        "cannot stage offsets for unassigned partitions"
+                    )
 
-            self.__validate_offsets(
-                {
-                    partition: position.offset
-                    for (partition, position) in positions.items()
-                }
-            )
+                self.__validate_offsets(
+                    {
+                        partition: position.offset
+                        for (partition, position) in positions.items()
+                    }
+                )
 
             self.__staged_positions.update(positions)
 

--- a/arroyo/processing/strategies/batching.py
+++ b/arroyo/processing/strategies/batching.py
@@ -128,9 +128,7 @@ class BatchProcessingStrategy(ProcessingStrategy[TPayload]):
             or time.time() > self.__batch.created + self.__max_batch_time / 1000.0
         ):
 
-            self.__metrics.timing(
-                "processing_phase", time.time() - self.__flush_done
-            )
+            self.__metrics.timing("processing_phase", time.time() - self.__flush_done)
             self.__flush()
             self.__flush_done = time.time()
 
@@ -249,5 +247,8 @@ class BatchProcessingStrategyFactory(ProcessingStrategyFactory[TPayload]):
         self, commit: Callable[[Mapping[Partition, Position]], None]
     ) -> ProcessingStrategy[TPayload]:
         return BatchProcessingStrategy(
-            commit, self.__worker, self.__max_batch_size, self.__max_batch_time,
+            commit,
+            self.__worker,
+            self.__max_batch_size,
+            self.__max_batch_time,
         )

--- a/arroyo/processing/strategies/streaming/transform.py
+++ b/arroyo/processing/strategies/streaming/transform.py
@@ -142,7 +142,7 @@ class MessageBatch(Generic[TPayload]):
         return pickle.loads(
             data,
             buffers=[
-                self.block.buf[offset: offset + length].tobytes()
+                self.block.buf[offset : offset + length].tobytes()
                 for offset, length in buffers
             ],
         )
@@ -179,7 +179,7 @@ class MessageBatch(Generic[TPayload]):
                 raise ValueTooLarge(
                     f"value exceeds available space in block, {length} bytes needed but {self.block.size - offset} bytes free"
                 )
-            self.block.buf[offset: offset + length] = value
+            self.block.buf[offset : offset + length] = value
             self.__offset += length
             buffers.append((offset, length))
 
@@ -384,7 +384,12 @@ class ParallelTransformStep(ProcessingStep[TPayload]):
                 input_batch,
                 self.__pool.apply_async(
                     parallel_transform_worker_apply,
-                    (self.__transform_function, input_batch, output_batch.block, i,),
+                    (
+                        self.__transform_function,
+                        input_batch,
+                        output_batch.block,
+                        i,
+                    ),
                 ),
             )
             return
@@ -429,7 +434,9 @@ class ParallelTransformStep(ProcessingStep[TPayload]):
             raise MessageRejected("no available input blocks") from e
 
         self.__batch_builder = BatchBuilder(
-            MessageBatch(input_block), self.__max_batch_size, self.__max_batch_time,
+            MessageBatch(input_block),
+            self.__max_batch_size,
+            self.__max_batch_time,
         )
 
     def submit(self, message: Message[TPayload]) -> None:

--- a/arroyo/synchronized.py
+++ b/arroyo/synchronized.py
@@ -182,7 +182,7 @@ class SynchronizedConsumer(Consumer[TPayload]):
                     tags={
                         "partition": str(commit.partition.index),
                         "group": commit.group,
-                    }
+                    },
                 )
             self.__metrics.timing(
                 "commit_log_latency",
@@ -190,7 +190,7 @@ class SynchronizedConsumer(Consumer[TPayload]):
                 tags={
                     "partition": str(commit.partition.index),
                     "group": commit.group,
-                }
+                },
             )
 
         self.__commit_log_consumer.close()

--- a/arroyo/synchronized.py
+++ b/arroyo/synchronized.py
@@ -315,8 +315,10 @@ class SynchronizedConsumer(Consumer[TPayload]):
     def seek(self, offsets: Mapping[Partition, int]) -> None:
         return self.__consumer.seek(offsets)
 
-    def stage_positions(self, positions: Mapping[Partition, Position]) -> None:
-        return self.__consumer.stage_positions(positions)
+    def stage_positions(
+        self, positions: Mapping[Partition, Position], force: bool = False
+    ) -> None:
+        return self.__consumer.stage_positions(positions, force=force)
 
     def commit_positions(self) -> Mapping[Partition, Position]:
         return self.__consumer.commit_positions()

--- a/tests/backends/test_kafka.py
+++ b/tests/backends/test_kafka.py
@@ -10,7 +10,6 @@ from typing import Any, Iterator, Mapping, MutableSequence, Optional
 from unittest import TestCase
 
 import pytest
-import confluent_kafka
 from confluent_kafka.admin import AdminClient, NewTopic
 
 from arroyo.backends.kafka import KafkaConsumer, KafkaPayload, KafkaProducer

--- a/tests/backends/test_kafka.py
+++ b/tests/backends/test_kafka.py
@@ -161,6 +161,9 @@ class KafkaStreamsTestCase(StreamsTestMixin[KafkaPayload], TestCase):
                 assert result_message.payload.key == b"a"
                 assert result_message.payload.value == b"0"
 
+                # make sure we reset our offset now
+                consumer.commit_positions()
+
     def test_auto_offset_reset_error(self) -> None:
         with self.get_topic() as topic:
             with closing(self.get_producer()) as producer:

--- a/tests/backends/test_kafka.py
+++ b/tests/backends/test_kafka.py
@@ -141,7 +141,7 @@ class KafkaStreamsTestCase(StreamsTestMixin[KafkaPayload], TestCase):
                 message = producer.produce(topic, payload).result(5.0)
 
             # write a nonsense offset
-            with closing(self.get_consumer(auto_offset_reset="error")) as consumer:
+            with closing(self.get_consumer(auto_offset_reset="latest")) as consumer:
                 consumer.subscribe([topic])
                 consumer.stage_positions(
                     {

--- a/tests/backends/test_kafka.py
+++ b/tests/backends/test_kafka.py
@@ -156,10 +156,10 @@ class KafkaStreamsTestCase(StreamsTestMixin[KafkaPayload], TestCase):
 
             with closing(self.get_consumer(force_offset_reset="latest")) as consumer:
                 consumer.subscribe([topic])
-                message = consumer.poll(10.0)
-                assert message is not None
-                assert message.payload.key == b"a"
-                assert message.payload.value == b"0"
+                result_message = consumer.poll(10.0)
+                assert result_message is not None
+                assert result_message.payload.key == b"a"
+                assert result_message.payload.value == b"0"
 
     def test_auto_offset_reset_error(self) -> None:
         with self.get_topic() as topic:

--- a/tests/backends/test_kafka.py
+++ b/tests/backends/test_kafka.py
@@ -10,6 +10,7 @@ from typing import Any, Iterator, Mapping, MutableSequence, Optional
 from unittest import TestCase
 
 import pytest
+import confluent_kafka
 from confluent_kafka.admin import AdminClient, NewTopic
 
 from arroyo.backends.kafka import KafkaConsumer, KafkaPayload, KafkaProducer
@@ -17,7 +18,7 @@ from arroyo.backends.kafka.configuration import build_kafka_configuration
 from arroyo.backends.kafka.consumer import as_kafka_configuration_bool
 from arroyo.errors import ConsumerError, EndOfPartition
 from arroyo.synchronized import Commit, commit_codec
-from arroyo.types import Message, Partition, Topic
+from arroyo.types import Message, Partition, Topic, Position
 from tests.backends.mixins import StreamsTestMixin
 
 
@@ -84,11 +85,13 @@ class KafkaStreamsTestCase(StreamsTestMixin[KafkaPayload], TestCase):
         group: Optional[str] = None,
         enable_end_of_partition: bool = True,
         auto_offset_reset: str = "earliest",
+        force_offset_reset: Optional[str] = None,
     ) -> KafkaConsumer:
         return KafkaConsumer(
             {
                 **self.configuration,
                 "auto.offset.reset": auto_offset_reset,
+                "force.offset.reset": force_offset_reset,
                 "enable.auto.commit": "false",
                 "enable.auto.offset.store": "false",
                 "enable.partition.eof": enable_end_of_partition,
@@ -131,6 +134,32 @@ class KafkaStreamsTestCase(StreamsTestMixin[KafkaPayload], TestCase):
                     assert error.offset == 1
                 else:
                     raise AssertionError("expected EndOfPartition error")
+
+    def test_force_offset_reset_latest(self) -> None:
+        payload = KafkaPayload(b"a", b"0", [])
+        with self.get_topic() as topic:
+            with closing(self.get_producer()) as producer:
+                message = producer.produce(topic, payload).result(5.0)
+
+            # write a nonsense offset
+            with closing(self.get_consumer(auto_offset_reset="error")) as consumer:
+                consumer.subscribe([topic])
+                consumer.stage_positions(
+                    {
+                        message.partition: Position(
+                            offset=message.offset + 1000, timestamp=message.timestamp
+                        )
+                    },
+                    force=True,
+                )
+                consumer.commit_positions()
+
+            with closing(self.get_consumer(force_offset_reset="latest")) as consumer:
+                consumer.subscribe([topic])
+                message = consumer.poll(10.0)
+                assert message is not None
+                assert message.payload.key == b"a"
+                assert message.payload.value == b"0"
 
     def test_auto_offset_reset_error(self) -> None:
         with self.get_topic() as topic:

--- a/tests/processing/strategies/test_dead_letter_queue.py
+++ b/tests/processing/strategies/test_dead_letter_queue.py
@@ -219,7 +219,7 @@ def test_stateful_count(
     processing_step: FakeProcessingStep,
 ) -> None:
 
-    now = int(NOW.timestamp())
+    now = int(datetime.now().timestamp())
     state: MutableSequence[Tuple[int, int]] = [(now - 1, 2), (now, 2)]
 
     # Stateful count DLQ intialized with 4 hits in the state


### PR DESCRIPTION
Adds a flag to disable the special handling for auto offset resets in arroyo. When the made up `force.offset.reset` flag is set to `True` (defaults to `False`) then the auto offset reset error is not converted into a `OffsetOutOfRange` exception.

Refs https://github.com/getsentry/snuba/pull/2573