### PR TITLE
feat: Bump confluent-kafka-python to 1.7.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-confluent-kafka==1.6.1
+confluent-kafka==1.7.0
 mypy==0.812


### PR DESCRIPTION
librdkafka 1.7.0 includes improvements to the sticky assignor