### PR TITLE
feat(consumer): Wrap consumer strategy with DLQ if it exists

### DIFF
--- a/arroyo/processing/strategies/streaming/factory.py
+++ b/arroyo/processing/strategies/streaming/factory.py
@@ -3,6 +3,12 @@ from typing import Callable, Mapping, Optional, Protocol, TypeVar
 
 from arroyo.backends.kafka import KafkaPayload
 from arroyo.processing.strategies import ProcessingStrategy, ProcessingStrategyFactory
+from arroyo.processing.strategies.dead_letter_queue.dead_letter_queue import (
+    DeadLetterQueue,
+)
+from arroyo.processing.strategies.dead_letter_queue.policies.abstract import (
+    DeadLetterQueuePolicy,
+)
 from arroyo.processing.strategies.streaming.collect import (
     CollectStep,
     ParallelCollectStep,
@@ -58,9 +64,11 @@ class ConsumerStrategyFactory(ProcessingStrategyFactory[TPayload]):
         input_block_size: Optional[int],
         output_block_size: Optional[int],
         initialize_parallel_transform: Optional[Callable[[], None]] = None,
+        dead_letter_queue_policy: Optional[DeadLetterQueuePolicy] = None,
         parallel_collect: bool = False,
     ) -> None:
         self.__prefilter = prefilter
+        self.__dead_letter_queue_policy = dead_letter_queue_policy
         self.__process_message = process_message
         self.__collector = collector
 
@@ -125,6 +133,9 @@ class ConsumerStrategyFactory(ProcessingStrategyFactory[TPayload]):
 
         if self.__prefilter is not None:
             strategy = FilterStep(self.__should_accept, strategy)
+
+        if self.__dead_letter_queue_policy is not None:
+            strategy = DeadLetterQueue(strategy, self.__dead_letter_queue_policy)
 
         return strategy
 

--- a/arroyo/processing/strategies/streaming/factory.py
+++ b/arroyo/processing/strategies/streaming/factory.py
@@ -37,8 +37,12 @@ class StreamMessageFilter(Protocol[TPayload]):
 
 class ConsumerStrategyFactory(ProcessingStrategyFactory[TPayload]):
     """
-    Builds a three step consumer strategy consisting of filter, transform
-    and collect phases.
+    Builds a four step consumer strategy consisting of dead letter queue,
+    filter, transform, and collect phases.
+
+    The `dead_letter_queue_policy` defines what to do when an bad message
+    is encountered throughout the next processing step(s). A DLQ wraps the
+    entire strategy and handles a specific exception to handle bad messages.
 
     The `prefilter` supports passing a test function to determine whether a
     message should proceed to the next processing steps or be dropped. If no

--- a/arroyo/processing/strategies/streaming/factory.py
+++ b/arroyo/processing/strategies/streaming/factory.py
@@ -42,7 +42,8 @@ class ConsumerStrategyFactory(ProcessingStrategyFactory[TPayload]):
 
     The `dead_letter_queue_policy` defines what to do when an bad message
     is encountered throughout the next processing step(s). A DLQ wraps the
-    entire strategy and handles a specific exception to handle bad messages.
+    entire strategy, catching InvalidMessage exceptions and handling them
+    as the policy dictates.
 
     The `prefilter` supports passing a test function to determine whether a
     message should proceed to the next processing steps or be dropped. If no


### PR DESCRIPTION
- `ConsumerStrategyFactory` builds the main strategy used by all consumers in Snuba
- Optionally pass a DLQ policy to the Consumer Strategy Factory
- This will wrap the strategy with a DLQ with the given policy

Here's an example of how this will be used:
https://github.com/getsentry/snuba/pull/2585