### PR TITLE
feat(dlq): Added produce policy

### DIFF
--- a/arroyo/backends/local/backend.py
+++ b/arroyo/backends/local/backend.py
@@ -53,6 +53,9 @@ class LocalBroker(Generic[TPayload]):
             self, group, enable_end_of_partition=enable_end_of_partition
         )
 
+    def get_message_storage(self) -> MessageStorage[TPayload]:
+        return self.__message_storage
+
     def get_producer(self) -> Producer[TPayload]:
         return LocalProducer(self)
 

--- a/arroyo/backends/local/backend.py
+++ b/arroyo/backends/local/backend.py
@@ -53,9 +53,6 @@ class LocalBroker(Generic[TPayload]):
             self, group, enable_end_of_partition=enable_end_of_partition
         )
 
-    def get_message_storage(self) -> MessageStorage[TPayload]:
-        return self.__message_storage
-
     def get_producer(self) -> Producer[TPayload]:
         return LocalProducer(self)
 

--- a/arroyo/processing/strategies/dead_letter_queue/__init__.py
+++ b/arroyo/processing/strategies/dead_letter_queue/__init__.py
@@ -2,6 +2,7 @@ from .dead_letter_queue import DeadLetterQueue
 from .policies.abstract import DeadLetterQueuePolicy, InvalidMessages
 from .policies.count import CountInvalidMessagePolicy
 from .policies.ignore import IgnoreInvalidMessagePolicy
+from .policies.produce import ProduceInvalidMessagePolicy
 from .policies.raise_e import RaiseInvalidMessagePolicy
 
 __all__ = [
@@ -11,4 +12,5 @@ __all__ = [
     "CountInvalidMessagePolicy",
     "IgnoreInvalidMessagePolicy",
     "RaiseInvalidMessagePolicy",
+    "ProduceInvalidMessagePolicy",
 ]

--- a/arroyo/processing/strategies/dead_letter_queue/__init__.py
+++ b/arroyo/processing/strategies/dead_letter_queue/__init__.py
@@ -1,5 +1,11 @@
 from .dead_letter_queue import DeadLetterQueue
-from .policies.abstract import DeadLetterQueuePolicy, InvalidMessages
+from .policies.abstract import (
+    DeadLetterQueuePolicy,
+    InvalidKafkaMessage,
+    InvalidMessage,
+    InvalidMessages,
+    InvalidRawMessage,
+)
 from .policies.count import CountInvalidMessagePolicy
 from .policies.ignore import IgnoreInvalidMessagePolicy
 from .policies.produce import ProduceInvalidMessagePolicy
@@ -7,8 +13,11 @@ from .policies.raise_e import RaiseInvalidMessagePolicy
 
 __all__ = [
     "DeadLetterQueue",
-    "InvalidMessages",
     "DeadLetterQueuePolicy",
+    "InvalidKafkaMessage",
+    "InvalidMessage",
+    "InvalidMessages",
+    "InvalidRawMessage",
     "CountInvalidMessagePolicy",
     "IgnoreInvalidMessagePolicy",
     "RaiseInvalidMessagePolicy",

--- a/arroyo/processing/strategies/dead_letter_queue/dead_letter_queue.py
+++ b/arroyo/processing/strategies/dead_letter_queue/dead_letter_queue.py
@@ -54,5 +54,6 @@ class DeadLetterQueue(ProcessingStep[TPayload]):
         self.__next_step.terminate()
 
     def join(self, timeout: Optional[float] = None) -> None:
+        self.__policy.join(timeout)
         self.__next_step.close()
         self.__next_step.join(timeout)

--- a/arroyo/processing/strategies/dead_letter_queue/policies/abstract.py
+++ b/arroyo/processing/strategies/dead_letter_queue/policies/abstract.py
@@ -23,8 +23,6 @@ class JSONMessageEncoder(Encoder[bytes, Mapping[str, Any]]):
             return value.strftime(DATE_TIME_FORMAT)
         elif isinstance(value, bytes):
             return self.__deserialize_bytes(value)
-        else:
-            raise TypeError
 
     def __deserialize_bytes(self, value: bytes) -> str:
         try:

--- a/arroyo/processing/strategies/dead_letter_queue/policies/abstract.py
+++ b/arroyo/processing/strategies/dead_letter_queue/policies/abstract.py
@@ -1,13 +1,15 @@
 from abc import ABC, abstractmethod
+from datetime import datetime
+from typing import Optional
 
 from arroyo.types import Message, TPayload
 
 
 class InvalidMessage(Exception):
-    def __init__(self, message: Message[TPayload], topic: str, timestamp: str):
+    def __init__(self, message: Message[TPayload], topic: Optional[str] = None):
         self.message = message
-        self.topic = topic
-        self.timestamp = timestamp
+        self.topic = topic or "unknown"
+        self.timestamp = str(datetime.now())
 
     def __str__(self) -> str:
         return (

--- a/arroyo/processing/strategies/dead_letter_queue/policies/abstract.py
+++ b/arroyo/processing/strategies/dead_letter_queue/policies/abstract.py
@@ -7,11 +7,14 @@ class InvalidMessages(Exception):
     """
     An exception to be thrown to pass bad messages to the DLQ
     so they are handled correctly.
+
+    If the original topic the message(s) were produced to is known,
+    that should be passed along via this exception.
     """
 
-    def __init__(self, messages: Sequence[Any], topic: Optional[str] = None):
+    def __init__(self, messages: Sequence[Any], original_topic: Optional[str] = None):
         self.messages = messages
-        self.topic = topic or "unknown"
+        self.topic = original_topic or "unknown"
         self.timestamp = str(datetime.now())
 
     def __str__(self) -> str:

--- a/arroyo/processing/strategies/dead_letter_queue/policies/abstract.py
+++ b/arroyo/processing/strategies/dead_letter_queue/policies/abstract.py
@@ -9,10 +9,26 @@ Serializable = Union[str, bytes]
 
 @dataclass(frozen=True)
 class InvalidMessage:
+    """
+    A dataclass to generally represent a bad Kafka message.
+    The Kafka specific fields (offset etc) are all optional
+    since this can be used to pass almost anything to the
+    DLQ.
+
+    A `reason` can be provided for debugging purposes. If a
+    produce policy is configured on the relevant DLQ, a message
+    in the form returned by `to_dict()` will be produced via
+    the policy.
+
+    An `InvalidMessages` exception should be raised containing
+    one or more objects of this class in order to actually
+    pass data to the DLQ.
+    """
+
     payload: Serializable
     timestamp: datetime
     reason: Optional[str] = None
-    original_topic: Optional[str] = None
+    consumer_group: Optional[str] = None
     partition: Optional[int] = None
     offset: Optional[int] = None
 
@@ -28,7 +44,7 @@ class InvalidMessage:
             "payload": decoded,
             "timestamp": str(self.timestamp),
             "reason": str(self.reason),
-            "original_topic": str(self.original_topic),
+            "consumer_group": str(self.consumer_group),
             "partition": str(self.partition),
             "offset": str(self.offset),
         }

--- a/arroyo/processing/strategies/dead_letter_queue/policies/abstract.py
+++ b/arroyo/processing/strategies/dead_letter_queue/policies/abstract.py
@@ -1,6 +1,8 @@
 from abc import ABC, abstractmethod
 from datetime import datetime
-from typing import Any, Optional, Sequence
+from typing import Optional, Sequence, Union
+
+Serializable = Union[str, bytes]
 
 
 class InvalidMessages(Exception):
@@ -14,7 +16,7 @@ class InvalidMessages(Exception):
 
     def __init__(
         self,
-        messages: Sequence[Any],
+        messages: Sequence[Serializable],
         reason: Optional[str] = None,
         original_topic: Optional[str] = None,
     ):

--- a/arroyo/processing/strategies/dead_letter_queue/policies/abstract.py
+++ b/arroyo/processing/strategies/dead_letter_queue/policies/abstract.py
@@ -12,14 +12,21 @@ class InvalidMessages(Exception):
     that should be passed along via this exception.
     """
 
-    def __init__(self, messages: Sequence[Any], original_topic: Optional[str] = None):
+    def __init__(
+        self,
+        messages: Sequence[Any],
+        reason: Optional[str] = None,
+        original_topic: Optional[str] = None,
+    ):
         self.messages = messages
+        self.reason = reason or "unknown"
         self.topic = original_topic or "unknown"
         self.timestamp = str(datetime.now())
 
     def __str__(self) -> str:
         return (
             f"Invalid Message originally produced to: {self.topic}\n"
+            f"Reason: {self.reason}\n"
             f"Exception thrown at: {self.timestamp}\n"
             f"Message(s): {self.messages}"
         )

--- a/arroyo/processing/strategies/dead_letter_queue/policies/abstract.py
+++ b/arroyo/processing/strategies/dead_letter_queue/policies/abstract.py
@@ -1,14 +1,40 @@
 import base64
+import json
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from datetime import datetime
-from typing import Mapping, Optional, Sequence, Tuple, Union
+from typing import Any, Mapping, Optional, Sequence, Union
 
 from arroyo.backends.kafka.consumer import Headers
+from arroyo.utils.codecs import Encoder
 
 SerializedPayload = Union[str, bytes]
-DeserializedHeaders = Sequence[Tuple[str, str]]
-JSONSerializable = Optional[Union[str, int, datetime, DeserializedHeaders]]
+
+DATE_TIME_FORMAT = "%Y-%m-%d %H:%M:%S"
+
+
+class JSONMessageEncoder(Encoder[bytes, Mapping[str, Any]]):
+    """
+    JSON message encoder to support `bytes` and `datetime` objects.
+    """
+
+    def __default(self, value: Any) -> str:
+        if isinstance(value, datetime):
+            return value.strftime(DATE_TIME_FORMAT)
+        elif isinstance(value, bytes):
+            return self.__deserialize_bytes(value)
+        else:
+            raise TypeError
+
+    def __deserialize_bytes(self, value: bytes) -> str:
+        try:
+            decoded = value.decode("utf-8")
+        except UnicodeDecodeError:
+            decoded = "(base64) " + base64.b64encode(value).decode("utf-8")
+        return decoded
+
+    def encode(self, value: Mapping[str, Any]) -> bytes:
+        return json.dumps(value, default=self.__default).encode("utf-8")
 
 
 class InvalidMessage(ABC):
@@ -24,21 +50,11 @@ class InvalidMessage(ABC):
     via the policy.
     """
 
-    @abstractmethod
-    def to_dict(self) -> Mapping[str, JSONSerializable]:
-        raise NotImplementedError
-
-    def _deserialize_payload(self, payload: SerializedPayload) -> str:
-        if isinstance(payload, bytes):
-            return self._deserialize_bytes(payload)
-        return payload
-
-    def _deserialize_bytes(self, value: bytes) -> str:
-        try:
-            decoded = value.decode("utf-8")
-        except UnicodeDecodeError:
-            decoded = "(base64) " + base64.b64encode(value).decode("utf-8")
-        return decoded
+    def to_bytes(self) -> bytes:
+        """
+        JSON encoded representation of this Invalid Message.
+        """
+        return JSONMessageEncoder().encode(self.__dict__)
 
 
 @dataclass(frozen=True)
@@ -50,9 +66,6 @@ class InvalidRawMessage(InvalidMessage):
 
     payload: SerializedPayload
     reason: Optional[str] = None
-
-    def to_dict(self) -> Mapping[str, JSONSerializable]:
-        return {"payload": super()._deserialize_payload(self.payload)}
 
 
 @dataclass(frozen=True)
@@ -71,25 +84,6 @@ class InvalidKafkaMessage(InvalidMessage):
     headers: Headers
     key: Optional[bytes] = None
     reason: Optional[str] = None
-
-    def to_dict(self) -> Mapping[str, JSONSerializable]:
-        decoded_key: Optional[str] = None
-        if self.key is not None:
-            decoded_key = super()._deserialize_bytes(self.key)
-        return {
-            "payload": super()._deserialize_payload(self.payload),
-            "timestamp": self.timestamp,
-            "topic": self.topic,
-            "consumer_group": self.consumer_group,
-            "partition": self.partition,
-            "offset": self.offset,
-            "headers": self.__deserialize_headers(),
-            "key": decoded_key,
-            "reason": self.reason,
-        }
-
-    def __deserialize_headers(self) -> DeserializedHeaders:
-        return [(key, self._deserialize_bytes(value)) for (key, value) in self.headers]
 
 
 class InvalidMessages(Exception):

--- a/arroyo/processing/strategies/dead_letter_queue/policies/abstract.py
+++ b/arroyo/processing/strategies/dead_letter_queue/policies/abstract.py
@@ -11,10 +11,10 @@ Serializable = Union[str, bytes]
 class InvalidMessage:
     payload: Serializable
     timestamp: datetime
-    reason: str = "unknown"
-    original_topic: str = "unknown"
-    partition: int = -1
-    offset: int = -1
+    reason: Optional[str] = None
+    original_topic: Optional[str] = None
+    partition: Optional[int] = None
+    offset: Optional[int] = None
 
     def to_dict(self) -> Mapping[str, str]:
         if isinstance(self.payload, bytes):
@@ -27,8 +27,8 @@ class InvalidMessage:
         return {
             "payload": decoded,
             "timestamp": str(self.timestamp),
-            "reason": self.reason,
-            "original_topic": self.original_topic,
+            "reason": str(self.reason),
+            "original_topic": str(self.original_topic),
             "partition": str(self.partition),
             "offset": str(self.offset),
         }

--- a/arroyo/processing/strategies/dead_letter_queue/policies/abstract.py
+++ b/arroyo/processing/strategies/dead_letter_queue/policies/abstract.py
@@ -4,11 +4,17 @@ from arroyo.types import Message, TPayload
 
 
 class InvalidMessage(Exception):
-    def __init__(self, message: Message[TPayload]):
+    def __init__(self, message: Message[TPayload], topic: str, timestamp: str):
         self.message = message
+        self.topic = topic
+        self.timestamp = timestamp
 
     def __str__(self) -> str:
-        return f"Invalid Message: {self.message}"
+        return (
+            f"Invalid Message originally produced to: {self.topic}\n"
+            f"Exception thrown at: {self.timestamp}\n"
+            f"Message: {self.message}"
+        )
 
 
 class DeadLetterQueuePolicy(ABC):

--- a/arroyo/processing/strategies/dead_letter_queue/policies/abstract.py
+++ b/arroyo/processing/strategies/dead_letter_queue/policies/abstract.py
@@ -37,7 +37,7 @@ class InvalidMessage:
             try:
                 decoded = self.payload.decode("utf-8")
             except UnicodeDecodeError:
-                decoded = base64.b64encode(self.payload).decode("utf-8")
+                decoded = "(base64) " + base64.b64encode(self.payload).decode("utf-8")
         else:
             decoded = self.payload
         return {

--- a/arroyo/processing/strategies/dead_letter_queue/policies/abstract.py
+++ b/arroyo/processing/strategies/dead_letter_queue/policies/abstract.py
@@ -42,4 +42,11 @@ class DeadLetterQueuePolicy(ABC):
         """
         Decide what to do with invalid messages.
         """
-        pass
+        raise NotImplementedError()
+
+    @abstractmethod
+    def join(self, timeout: Optional[float]) -> None:
+        """
+        Cleanup any asynchronous tasks that may be running.
+        """
+        raise NotImplementedError()

--- a/arroyo/processing/strategies/dead_letter_queue/policies/abstract.py
+++ b/arroyo/processing/strategies/dead_letter_queue/policies/abstract.py
@@ -32,7 +32,7 @@ class InvalidMessage:
     partition: Optional[int] = None
     offset: Optional[int] = None
 
-    def to_dict(self) -> Mapping[str, str]:
+    def to_dict(self) -> Mapping[str, Optional[Union[str, int, datetime]]]:
         if isinstance(self.payload, bytes):
             try:
                 decoded = self.payload.decode("utf-8")
@@ -42,11 +42,11 @@ class InvalidMessage:
             decoded = self.payload
         return {
             "payload": decoded,
-            "timestamp": str(self.timestamp),
-            "reason": str(self.reason),
-            "consumer_group": str(self.consumer_group),
-            "partition": str(self.partition),
-            "offset": str(self.offset),
+            "timestamp": self.timestamp,
+            "reason": self.reason,
+            "consumer_group": self.consumer_group,
+            "partition": self.partition,
+            "offset": self.offset,
         }
 
 

--- a/arroyo/processing/strategies/dead_letter_queue/policies/abstract.py
+++ b/arroyo/processing/strategies/dead_letter_queue/policies/abstract.py
@@ -23,6 +23,8 @@ class JSONMessageEncoder(Encoder[bytes, Mapping[str, Any]]):
             return value.strftime(DATE_TIME_FORMAT)
         elif isinstance(value, bytes):
             return self.__deserialize_bytes(value)
+        else:
+            raise TypeError
 
     def __deserialize_bytes(self, value: bytes) -> str:
         try:

--- a/arroyo/processing/strategies/dead_letter_queue/policies/count.py
+++ b/arroyo/processing/strategies/dead_letter_queue/policies/count.py
@@ -68,3 +68,6 @@ class CountInvalidMessagePolicy(DeadLetterQueuePolicy):
     def _count(self) -> int:
         start = int(time()) - self.__seconds
         return sum(bucket.hits for bucket in self.__hits if bucket.timestamp >= start)
+
+    def join(self, timeout: Optional[float]) -> None:
+        self.__next_policy.join(timeout)

--- a/arroyo/processing/strategies/dead_letter_queue/policies/count.py
+++ b/arroyo/processing/strategies/dead_letter_queue/policies/count.py
@@ -2,15 +2,10 @@ from collections import deque
 from time import time
 from typing import NamedTuple, Optional, Sequence, Tuple
 
-from arroyo.backends.kafka.consumer import KafkaProducer
 from arroyo.processing.strategies.dead_letter_queue.policies.abstract import (
+    DeadLetterQueuePolicy,
     InvalidMessages,
 )
-from arroyo.processing.strategies.dead_letter_queue.policies.produce import (
-    ProduceInvalidMessagePolicy,
-)
-from arroyo.types import Topic
-from arroyo.utils.metrics import get_metrics
 
 
 class _Bucket(NamedTuple):
@@ -22,34 +17,32 @@ class _Bucket(NamedTuple):
     hits: int
 
 
-class CountInvalidMessagePolicy(ProduceInvalidMessagePolicy):
+class CountInvalidMessagePolicy(DeadLetterQueuePolicy):
     """
-    Ignore invalid messages up to a certain limit per time unit window in seconds.
-    This window is 1 minute by default. The exception associated with the invalid
-    messages is raised for all incoming invalid messages which go past this limit.
+    Does not raise invalid messages up to a certain limit per time unit window
+    in seconds. This window is 1 minute by default. The exception associated with
+    the invalid messages is raised for all incoming invalid messages which go past
+    this limit.
+
+    A `next_policy` (a DLQ Policy) must be passed to handle any exception which
+    remains within the per second limit. This gives full control over what happens
+    to exceptions within the limit.
 
     A saved state in the form `[(<timestamp: int>, <hits: int>), ...]` can be passed
     on init to load a previously saved state. This state should be aggregated to
     1 second buckets.
-
-    If a `KafkaProducer` and a `Topic` are passed to this policy, invalid messages
-    will not be ignored but will be produced to the topic using the producer instead.
     """
 
     def __init__(
         self,
+        next_policy: DeadLetterQueuePolicy,
         limit: int,
         seconds: int = 60,
         load_state: Optional[Sequence[Tuple[int, int]]] = None,
-        producer: Optional[KafkaProducer] = None,
-        dead_letter_topic: Optional[Topic] = None,
     ) -> None:
-        self.__produce = producer is not None and dead_letter_topic is not None
-        if producer is not None and dead_letter_topic is not None:
-            super().__init__(producer, dead_letter_topic)
         self.__limit = limit
         self.__seconds = seconds
-        self.__metrics = get_metrics()
+        self.__next_policy = next_policy
         if load_state is None:
             load_state = []
         self.__hits = deque(
@@ -61,13 +54,7 @@ class CountInvalidMessagePolicy(ProduceInvalidMessagePolicy):
         self._add(e)
         if self._count() > self.__limit:
             raise e
-        self._produce_or_ignore(e)
-
-    def _produce_or_ignore(self, e: InvalidMessages) -> None:
-        if self.__produce:
-            super().handle_invalid_messages(e)
-        else:
-            self.__metrics.increment("dlq.dropped_messages", len(e.messages))
+        self.__next_policy.handle_invalid_messages(e)
 
     def _add(self, e: InvalidMessages) -> None:
         now = int(time())

--- a/arroyo/processing/strategies/dead_letter_queue/policies/ignore.py
+++ b/arroyo/processing/strategies/dead_letter_queue/policies/ignore.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 from arroyo.processing.strategies.dead_letter_queue.policies.abstract import (
     DeadLetterQueuePolicy,
     InvalidMessages,
@@ -11,3 +13,6 @@ class IgnoreInvalidMessagePolicy(DeadLetterQueuePolicy):
 
     def handle_invalid_messages(self, e: InvalidMessages) -> None:
         self.__metrics.increment("dlq.dropped_messages", len(e.messages))
+
+    def join(self, timeout: Optional[float]) -> None:
+        return

--- a/arroyo/processing/strategies/dead_letter_queue/policies/produce.py
+++ b/arroyo/processing/strategies/dead_letter_queue/policies/produce.py
@@ -1,0 +1,41 @@
+import json
+
+from arroyo.backends.kafka.consumer import KafkaPayload, KafkaProducer
+from arroyo.processing.strategies.dead_letter_queue.policies.abstract import (
+    DeadLetterQueuePolicy,
+    InvalidMessage,
+)
+from arroyo.types import Topic
+from arroyo.utils.metrics import get_metrics
+
+
+class ProduceInvalidMessagePolicy(DeadLetterQueuePolicy):
+    """
+    Produces given InvalidMessage to a dead letter topic.
+
+    Meant to be used as a baseclass for policies needing to produce
+    invalid messages to a dead letter topic.
+    """
+
+    def __init__(self, producer: KafkaProducer, dead_letter_topic: Topic) -> None:
+        self.__metrics = get_metrics()
+        self.__dead_letter_topic = dead_letter_topic
+        self.__producer = producer
+
+    def handle_invalid_message(self, e: InvalidMessage) -> None:
+        """
+        Produces a message to the given dead letter topic in the form:
+
+        {
+            "topic": <original topic the bad message was produced to>,
+            "timestamp": <time at which exception was thrown>,
+            "message": <original bad KafkaMessage>
+        }
+
+        """
+        data = json.dumps(
+            {"topic": e.topic, "timestamp": e.timestamp, "message": e.message}
+        ).encode("utf-8")
+        payload = KafkaPayload(key=None, value=data, headers=[])
+        self.__producer.produce(destination=self.__dead_letter_topic, payload=payload)
+        self.__metrics.increment("dlq.produced_message")

--- a/arroyo/processing/strategies/dead_letter_queue/policies/produce.py
+++ b/arroyo/processing/strategies/dead_letter_queue/policies/produce.py
@@ -4,7 +4,8 @@ from collections import deque
 from concurrent.futures import Future
 from typing import Deque, Optional
 
-from arroyo.backends.kafka.consumer import KafkaPayload, KafkaProducer
+from arroyo.backends.abstract import Producer
+from arroyo.backends.kafka.consumer import KafkaPayload
 from arroyo.processing.strategies.dead_letter_queue.policies.abstract import (
     DeadLetterQueuePolicy,
     InvalidMessage,
@@ -21,7 +22,9 @@ class ProduceInvalidMessagePolicy(DeadLetterQueuePolicy):
     Produces given InvalidMessages to a dead letter topic.
     """
 
-    def __init__(self, producer: KafkaProducer, dead_letter_topic: Topic) -> None:
+    def __init__(
+        self, producer: Producer[KafkaPayload], dead_letter_topic: Topic
+    ) -> None:
         self.__metrics = get_metrics()
         self.__dead_letter_topic = dead_letter_topic
         self.__producer = producer

--- a/arroyo/processing/strategies/dead_letter_queue/policies/produce.py
+++ b/arroyo/processing/strategies/dead_letter_queue/policies/produce.py
@@ -22,7 +22,7 @@ class ProduceInvalidMessagePolicy(DeadLetterQueuePolicy):
         self.__dead_letter_topic = dead_letter_topic
         self.__producer = producer
 
-    def handle_invalid_message(self, e: InvalidMessages) -> None:
+    def handle_invalid_messages(self, e: InvalidMessages) -> None:
         """
         Produces a message to the given dead letter topic in the form:
 

--- a/arroyo/processing/strategies/dead_letter_queue/policies/produce.py
+++ b/arroyo/processing/strategies/dead_letter_queue/policies/produce.py
@@ -1,4 +1,5 @@
 import json
+from typing import Optional
 
 from arroyo.backends.kafka.consumer import KafkaPayload, KafkaProducer
 from arroyo.processing.strategies.dead_letter_queue.policies.abstract import (
@@ -12,9 +13,6 @@ from arroyo.utils.metrics import get_metrics
 class ProduceInvalidMessagePolicy(DeadLetterQueuePolicy):
     """
     Produces given InvalidMessages to a dead letter topic.
-
-    Meant to be used as a baseclass for policies needing to produce
-    invalid messages to a dead letter topic.
     """
 
     def __init__(self, producer: KafkaProducer, dead_letter_topic: Topic) -> None:
@@ -47,3 +45,6 @@ class ProduceInvalidMessagePolicy(DeadLetterQueuePolicy):
                 destination=self.__dead_letter_topic, payload=payload
             )
             self.__metrics.increment("dlq.produced_messages")
+
+    def join(self, timeout: Optional[float] = None) -> None:
+        pass

--- a/arroyo/processing/strategies/dead_letter_queue/policies/produce.py
+++ b/arroyo/processing/strategies/dead_letter_queue/policies/produce.py
@@ -1,12 +1,15 @@
 import json
-from typing import Optional
+import time
+from collections import deque
+from concurrent.futures import Future
+from typing import Deque, Optional
 
 from arroyo.backends.kafka.consumer import KafkaPayload, KafkaProducer
 from arroyo.processing.strategies.dead_letter_queue.policies.abstract import (
     DeadLetterQueuePolicy,
     InvalidMessages,
 )
-from arroyo.types import Topic
+from arroyo.types import Message, Topic
 from arroyo.utils.metrics import get_metrics
 
 
@@ -19,11 +22,13 @@ class ProduceInvalidMessagePolicy(DeadLetterQueuePolicy):
         self.__metrics = get_metrics()
         self.__dead_letter_topic = dead_letter_topic
         self.__producer = producer
+        self.__futures: Deque[Future[Message[KafkaPayload]]] = deque()
 
     def handle_invalid_messages(self, e: InvalidMessages) -> None:
         """
         Produces a message to the given dead letter topic for each
         invalid message in the form:
+
         {
             "topic": <original topic the bad message was produced to>,
             "reason": <why the message(s) are bad>
@@ -41,10 +46,23 @@ class ProduceInvalidMessagePolicy(DeadLetterQueuePolicy):
                 }
             ).encode("utf-8")
             payload = KafkaPayload(key=None, value=data, headers=[])
+            self._produce(payload)
+
+        self.__metrics.increment("dlq.produced_messages", len(e.messages))
+
+    def _produce(self, payload: KafkaPayload) -> None:
+        if len(self.__futures) >= 10:
+            self.join()
+        self.__futures.append(
             self.__producer.produce(
                 destination=self.__dead_letter_topic, payload=payload
             )
-            self.__metrics.increment("dlq.produced_messages")
+        )
 
     def join(self, timeout: Optional[float] = None) -> None:
-        pass
+        start = time.perf_counter()
+        while self.__futures:
+            if self.__futures[0].done():
+                self.__futures.popleft()
+            if timeout is not None and time.perf_counter() - start > timeout:
+                break

--- a/arroyo/processing/strategies/dead_letter_queue/policies/produce.py
+++ b/arroyo/processing/strategies/dead_letter_queue/policies/produce.py
@@ -3,7 +3,7 @@ import json
 from arroyo.backends.kafka.consumer import KafkaPayload, KafkaProducer
 from arroyo.processing.strategies.dead_letter_queue.policies.abstract import (
     DeadLetterQueuePolicy,
-    InvalidMessage,
+    InvalidMessages,
 )
 from arroyo.types import Topic
 from arroyo.utils.metrics import get_metrics
@@ -11,7 +11,7 @@ from arroyo.utils.metrics import get_metrics
 
 class ProduceInvalidMessagePolicy(DeadLetterQueuePolicy):
     """
-    Produces given InvalidMessage to a dead letter topic.
+    Produces given InvalidMessages to a dead letter topic.
 
     Meant to be used as a baseclass for policies needing to produce
     invalid messages to a dead letter topic.
@@ -22,20 +22,20 @@ class ProduceInvalidMessagePolicy(DeadLetterQueuePolicy):
         self.__dead_letter_topic = dead_letter_topic
         self.__producer = producer
 
-    def handle_invalid_message(self, e: InvalidMessage) -> None:
+    def handle_invalid_message(self, e: InvalidMessages) -> None:
         """
         Produces a message to the given dead letter topic in the form:
 
         {
             "topic": <original topic the bad message was produced to>,
             "timestamp": <time at which exception was thrown>,
-            "message": <original bad KafkaMessage>
+            "messages": <original bad Message(s)>
         }
 
         """
         data = json.dumps(
-            {"topic": e.topic, "timestamp": e.timestamp, "message": e.message}
+            {"topic": e.topic, "timestamp": e.timestamp, "messages": e.messages}
         ).encode("utf-8")
         payload = KafkaPayload(key=None, value=data, headers=[])
         self.__producer.produce(destination=self.__dead_letter_topic, payload=payload)
-        self.__metrics.increment("dlq.produced_message")
+        self.__metrics.increment("dlq.produced_messages")

--- a/arroyo/processing/strategies/dead_letter_queue/policies/produce.py
+++ b/arroyo/processing/strategies/dead_letter_queue/policies/produce.py
@@ -1,9 +1,7 @@
-import json
 import time
 from collections import deque
 from concurrent.futures import Future
-from datetime import datetime
-from typing import Any, Deque, Mapping, Optional
+from typing import Deque, Optional
 
 from arroyo.backends.abstract import Producer
 from arroyo.backends.kafka.consumer import KafkaPayload
@@ -11,25 +9,11 @@ from arroyo.processing.strategies.dead_letter_queue.policies.abstract import (
     DeadLetterQueuePolicy,
     InvalidMessage,
     InvalidMessages,
-    JSONSerializable,
 )
 from arroyo.types import Message, Topic
-from arroyo.utils.codecs import Encoder
 from arroyo.utils.metrics import get_metrics
 
 MAX_QUEUE_SIZE = 5000
-DATE_TIME_FORMAT = "%Y-%m-%d %H:%M:%S"
-
-
-class JSONMessageEncoder(Encoder[bytes, Mapping[str, JSONSerializable]]):
-    def __default(self, value: Any) -> str:
-        if isinstance(value, datetime):
-            return value.strftime(DATE_TIME_FORMAT)
-        else:
-            raise TypeError
-
-    def encode(self, value: Mapping[str, JSONSerializable]) -> bytes:
-        return json.dumps(value, default=self.__default).encode("utf-8")
 
 
 class ProduceInvalidMessagePolicy(DeadLetterQueuePolicy):
@@ -57,7 +41,7 @@ class ProduceInvalidMessagePolicy(DeadLetterQueuePolicy):
         self.__metrics.increment("dlq.produced_messages", len(e.messages))
 
     def _build_payload(self, message: InvalidMessage) -> KafkaPayload:
-        data = JSONMessageEncoder().encode(message.to_dict())
+        data = message.to_bytes()
         return KafkaPayload(key=None, value=data, headers=[])
 
     def _produce(self, payload: KafkaPayload) -> None:

--- a/arroyo/processing/strategies/dead_letter_queue/policies/produce.py
+++ b/arroyo/processing/strategies/dead_letter_queue/policies/produce.py
@@ -3,7 +3,7 @@ import time
 from collections import deque
 from concurrent.futures import Future
 from datetime import datetime
-from typing import Any, Deque, Mapping, Optional, Union
+from typing import Any, Deque, Mapping, Optional
 
 from arroyo.backends.abstract import Producer
 from arroyo.backends.kafka.consumer import KafkaPayload
@@ -11,6 +11,7 @@ from arroyo.processing.strategies.dead_letter_queue.policies.abstract import (
     DeadLetterQueuePolicy,
     InvalidMessage,
     InvalidMessages,
+    JSONSerializable,
 )
 from arroyo.types import Message, Topic
 from arroyo.utils.codecs import Encoder
@@ -20,16 +21,14 @@ MAX_QUEUE_SIZE = 5000
 DATE_TIME_FORMAT = "%Y-%m-%d %H:%M:%S"
 
 
-class JSONMessageEncoder(
-    Encoder[bytes, Mapping[str, Optional[Union[str, int, datetime]]]]
-):
+class JSONMessageEncoder(Encoder[bytes, Mapping[str, JSONSerializable]]):
     def __default(self, value: Any) -> str:
         if isinstance(value, datetime):
             return value.strftime(DATE_TIME_FORMAT)
         else:
             raise TypeError
 
-    def encode(self, value: Mapping[str, Optional[Union[str, int, datetime]]]) -> bytes:
+    def encode(self, value: Mapping[str, JSONSerializable]) -> bytes:
         return json.dumps(value, default=self.__default).encode("utf-8")
 
 

--- a/arroyo/processing/strategies/dead_letter_queue/policies/produce.py
+++ b/arroyo/processing/strategies/dead_letter_queue/policies/produce.py
@@ -28,13 +28,19 @@ class ProduceInvalidMessagePolicy(DeadLetterQueuePolicy):
         invalid message in the form:
         {
             "topic": <original topic the bad message was produced to>,
+            "reason": <why the message(s) are bad>
             "timestamp": <time at which exception was thrown>,
             "message": <original bad message>
         }
         """
         for message in e.messages:
             data = json.dumps(
-                {"topic": e.topic, "timestamp": e.timestamp, "message": message}
+                {
+                    "topic": e.topic,
+                    "reason": e.reason,
+                    "timestamp": e.timestamp,
+                    "message": message,
+                }
             ).encode("utf-8")
             payload = KafkaPayload(key=None, value=data, headers=[])
             self.__producer.produce(

--- a/arroyo/processing/strategies/dead_letter_queue/policies/raise_e.py
+++ b/arroyo/processing/strategies/dead_letter_queue/policies/raise_e.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 from arroyo.processing.strategies.dead_letter_queue.policies.abstract import (
     DeadLetterQueuePolicy,
     InvalidMessages,
@@ -7,3 +9,6 @@ from arroyo.processing.strategies.dead_letter_queue.policies.abstract import (
 class RaiseInvalidMessagePolicy(DeadLetterQueuePolicy):
     def handle_invalid_messages(self, e: InvalidMessages) -> None:
         raise e
+
+    def join(self, timeout: Optional[float]) -> None:
+        return

--- a/tests/processing/strategies/test_dead_letter_queue.py
+++ b/tests/processing/strategies/test_dead_letter_queue.py
@@ -34,9 +34,14 @@ class FakeProcessingStep(ProcessingStrategy[KafkaPayload]):
 
     def poll(self) -> None:
         raise InvalidMessage(
-            Message(
-                Partition(Topic(""), 0), 0, KafkaPayload(None, b"", []), datetime.now()
-            )
+            message=Message(
+                Partition(Topic("topic"), 0),
+                0,
+                KafkaPayload(None, b"", []),
+                datetime.now(),
+            ),
+            topic="topic",
+            timestamp=str(datetime.now()),
         )
 
     def join(self, timeout: Optional[float] = None) -> None:
@@ -53,7 +58,7 @@ class FakeProcessingStep(ProcessingStrategy[KafkaPayload]):
         Valid message is one with a key.
         """
         if message.payload.key is None:
-            raise InvalidMessage(message)
+            raise InvalidMessage(message, "topic", str(datetime.now()))
 
 
 class FakeProcessingStepFactory(ProcessingStrategyFactory[KafkaPayload]):

--- a/tests/processing/strategies/test_dead_letter_queue.py
+++ b/tests/processing/strategies/test_dead_letter_queue.py
@@ -1,3 +1,4 @@
+import json
 import time
 from datetime import datetime
 from typing import MutableSequence, Optional, Tuple
@@ -270,3 +271,8 @@ def test_produce_invalid_messages(
     dlq_produce.submit(invalid_message)
     produced_message = broker.get_message_storage().consume(Partition(topic, 0), 0)
     assert produced_message is not None
+
+    # produced message should have appropriate info
+    dead_letter_payload = produced_message.payload.value
+    dead_letter_dict = json.loads(dead_letter_payload)
+    assert dead_letter_dict["reason"] == NO_KEY

--- a/tests/processing/strategies/test_dead_letter_queue.py
+++ b/tests/processing/strategies/test_dead_letter_queue.py
@@ -251,7 +251,7 @@ def test_produce_invalid_messages(
     valid_message: Message[KafkaPayload],
     invalid_message: Message[KafkaPayload],
     processing_step: FakeProcessingStep,
-    broker: LocalBroker,
+    broker: LocalBroker[KafkaPayload],
 ) -> None:
     producer = broker.get_producer()
     topic = Topic("test-dead-letter-topic")

--- a/tests/processing/strategies/test_dead_letter_queue.py
+++ b/tests/processing/strategies/test_dead_letter_queue.py
@@ -1,7 +1,7 @@
 import json
 import time
 from datetime import datetime
-from typing import MutableSequence, Optional, Tuple
+from typing import Any, Mapping, MutableSequence, Optional, Tuple
 
 import pytest
 
@@ -14,6 +14,7 @@ from arroyo.processing.strategies.dead_letter_queue.dead_letter_queue import (
 from arroyo.processing.strategies.dead_letter_queue.policies.abstract import (
     InvalidMessage,
     InvalidMessages,
+    Serializable,
 )
 from arroyo.processing.strategies.dead_letter_queue.policies.count import (
     CountInvalidMessagePolicy,
@@ -22,6 +23,7 @@ from arroyo.processing.strategies.dead_letter_queue.policies.ignore import (
     IgnoreInvalidMessagePolicy,
 )
 from arroyo.processing.strategies.dead_letter_queue.policies.produce import (
+    DATE_TIME_FORMAT,
     ProduceInvalidMessagePolicy,
 )
 from arroyo.processing.strategies.dead_letter_queue.policies.raise_e import (
@@ -30,6 +32,8 @@ from arroyo.processing.strategies.dead_letter_queue.policies.raise_e import (
 from arroyo.types import Message, Partition, Topic
 
 NO_KEY = "No key"
+BAD_PAYLOAD = "Bad payload"
+NOW = datetime.now()
 
 
 class FakeProcessingStep(ProcessingStrategy[KafkaPayload]):
@@ -38,9 +42,7 @@ class FakeProcessingStep(ProcessingStrategy[KafkaPayload]):
     """
 
     def poll(self) -> None:
-        raise InvalidMessages(
-            [InvalidMessage("a bad message", datetime.now(), reason=NO_KEY)]
-        )
+        raise InvalidMessages([InvalidMessage("a bad message", NOW, reason=NO_KEY)])
 
     def join(self, timeout: Optional[float] = None) -> None:
         pass
@@ -53,17 +55,29 @@ class FakeProcessingStep(ProcessingStrategy[KafkaPayload]):
 
     def submit(self, message: Message[KafkaPayload]) -> None:
         """
-        Valid message is one with a key.
+        Valid message is one with a key and decodable value.
         """
-        if message.payload.key is None:
+        payload: Serializable = ""
+        reason: str = ""
+        try:
+            message.payload.value.decode("utf-8")
+        except UnicodeDecodeError:
+            reason = BAD_PAYLOAD
+            payload = message.payload.value
+        else:
+            if message.payload.key is None:
+                reason = NO_KEY
+                payload = str(message.payload)
+
+        if reason:
             raise InvalidMessages(
                 [
                     InvalidMessage(
-                        payload=str(message.payload),
+                        payload=payload,
                         timestamp=message.timestamp,
                         offset=message.offset,
                         partition=message.partition.index,
-                        reason=NO_KEY,
+                        reason=reason,
                     )
                 ]
             )
@@ -103,19 +117,25 @@ def processing_step() -> ProcessingStrategy[KafkaPayload]:
 
 @pytest.fixture
 def valid_message() -> Message[KafkaPayload]:
-    valid_payload = KafkaPayload(b"", b"", [])
-    return Message(Partition(Topic(""), 0), 0, valid_payload, datetime.now())
+    valid_payload = KafkaPayload(b"Key", b"Value", [])
+    return Message(Partition(Topic(""), 0), 0, valid_payload, NOW)
 
 
 @pytest.fixture
-def invalid_message() -> Message[KafkaPayload]:
-    invalid_payload = KafkaPayload(None, b"", [])
-    return Message(Partition(Topic(""), 0), 0, invalid_payload, datetime.now())
+def invalid_message_no_key() -> Message[KafkaPayload]:
+    invalid_payload = KafkaPayload(None, b"Value", [])
+    return Message(Partition(Topic(""), 0), 0, invalid_payload, NOW)
+
+
+@pytest.fixture
+def invalid_message_bad_value() -> Message[KafkaPayload]:
+    invalid_payload = KafkaPayload(key=b"Key", value=b"\xff", headers=[])
+    return Message(Partition(Topic(""), 0), 0, invalid_payload, NOW)
 
 
 def test_raise(
     valid_message: Message[KafkaPayload],
-    invalid_message: Message[KafkaPayload],
+    invalid_message_no_key: Message[KafkaPayload],
     processing_step: FakeProcessingStep,
 ) -> None:
     dlq_raise: DeadLetterQueue[KafkaPayload] = DeadLetterQueue(
@@ -123,26 +143,26 @@ def test_raise(
     )
     dlq_raise.submit(valid_message)
     with pytest.raises(InvalidMessages):
-        dlq_raise.submit(invalid_message)
+        dlq_raise.submit(invalid_message_no_key)
     with pytest.raises(InvalidMessages):
         dlq_raise.poll()
 
 
 def test_ignore(
     valid_message: Message[KafkaPayload],
-    invalid_message: Message[KafkaPayload],
+    invalid_message_no_key: Message[KafkaPayload],
     processing_step: FakeProcessingStep,
 ) -> None:
     dlq_ignore: DeadLetterQueue[KafkaPayload] = DeadLetterQueue(
         processing_step, IgnoreInvalidMessagePolicy()
     )
     dlq_ignore.submit(valid_message)
-    dlq_ignore.submit(invalid_message)
+    dlq_ignore.submit(invalid_message_no_key)
 
 
 def test_count(
     valid_message: Message[KafkaPayload],
-    invalid_message: Message[KafkaPayload],
+    invalid_message_no_key: Message[KafkaPayload],
     processing_step: FakeProcessingStep,
 ) -> None:
     dlq_count: DeadLetterQueue[KafkaPayload] = DeadLetterQueue(
@@ -151,14 +171,14 @@ def test_count(
     )
     dlq_count.submit(valid_message)
     for _ in range(5):
-        dlq_count.submit(invalid_message)
+        dlq_count.submit(invalid_message_no_key)
     with pytest.raises(InvalidMessages):
-        dlq_count.submit(invalid_message)
+        dlq_count.submit(invalid_message_no_key)
 
 
 def test_count_short(
     valid_message: Message[KafkaPayload],
-    invalid_message: Message[KafkaPayload],
+    invalid_message_no_key: Message[KafkaPayload],
     processing_step: FakeProcessingStep,
 ) -> None:
     dlq_count_short: DeadLetterQueue[KafkaPayload] = DeadLetterQueue(
@@ -169,20 +189,20 @@ def test_count_short(
     )
     dlq_count_short.submit(valid_message)
     for _ in range(5):
-        dlq_count_short.submit(invalid_message)
+        dlq_count_short.submit(invalid_message_no_key)
     with pytest.raises(InvalidMessages):
-        dlq_count_short.submit(invalid_message)
+        dlq_count_short.submit(invalid_message_no_key)
     time.sleep(1)
-    dlq_count_short.submit(invalid_message)
+    dlq_count_short.submit(invalid_message_no_key)
 
 
 def test_stateful_count(
     valid_message: Message[KafkaPayload],
-    invalid_message: Message[KafkaPayload],
+    invalid_message_no_key: Message[KafkaPayload],
     processing_step: FakeProcessingStep,
 ) -> None:
 
-    now = int(datetime.now().timestamp())
+    now = int(NOW.timestamp())
     state: MutableSequence[Tuple[int, int]] = [(now - 1, 2), (now, 2)]
 
     # Stateful count DLQ intialized with 4 hits in the state
@@ -198,16 +218,16 @@ def test_stateful_count(
     dlq_count_load_state.submit(valid_message)
 
     # Limit is 5, 4 hits exist, 1 more should be added without exception raised
-    dlq_count_load_state.submit(invalid_message)
+    dlq_count_load_state.submit(invalid_message_no_key)
 
     # Limit is 5, 5 hits exist, next invalid message should cause exception
     with pytest.raises(InvalidMessages):
-        dlq_count_load_state.submit(invalid_message)
+        dlq_count_load_state.submit(invalid_message_no_key)
 
 
 def test_multiple_invalid_messages(
     valid_message: Message[KafkaPayload],
-    invalid_message: Message[KafkaPayload],
+    invalid_message_no_key: Message[KafkaPayload],
 ) -> None:
     fake_batching_processor = FakeBatchingProcessingStep()
     count_policy = CountInvalidMessagePolicy(
@@ -227,12 +247,12 @@ def test_multiple_invalid_messages(
     - count policy now holds 5 invalid messages
     """
     for _ in range(5):
-        dlq_count.submit(invalid_message)
+        dlq_count.submit(invalid_message_no_key)
         dlq_count.submit(valid_message)
 
     # build the next batch with 4 invalid messages, count policy still only sees 5 invalid messages
     for _ in range(4):
-        dlq_count.submit(invalid_message)
+        dlq_count.submit(invalid_message_no_key)
     assert count_policy._count() == 5
 
     """
@@ -248,7 +268,8 @@ def test_multiple_invalid_messages(
 
 def test_produce_invalid_messages(
     valid_message: Message[KafkaPayload],
-    invalid_message: Message[KafkaPayload],
+    invalid_message_no_key: Message[KafkaPayload],
+    invalid_message_bad_value: Message[KafkaPayload],
     processing_step: FakeProcessingStep,
     broker: LocalBroker[KafkaPayload],
 ) -> None:
@@ -269,13 +290,42 @@ def test_produce_invalid_messages(
     dlq_produce.submit(valid_message)
     assert consumer.poll() is None
 
-    # invalid message should
-    dlq_produce.submit(invalid_message)
+    # invalid messages should
+    dlq_produce.submit(invalid_message_no_key)
+    dlq_produce.submit(invalid_message_bad_value)
 
     produced_message = consumer.poll()
-    assert produced_message is not None
+    assert_produced_message_is_expected(
+        produced_message,
+        {
+            "payload": "KafkaPayload(key=None, value=b'Value', headers=[])",
+            "timestamp": NOW.strftime(DATE_TIME_FORMAT),
+            "reason": NO_KEY,
+            "consumer_group": None,
+            "partition": 0,
+            "offset": 0,
+        },
+    )
 
+    produced_message = consumer.poll()
+    assert_produced_message_is_expected(
+        produced_message,
+        {
+            "payload": "(base64) /w==",
+            "timestamp": NOW.strftime(DATE_TIME_FORMAT),
+            "reason": BAD_PAYLOAD,
+            "consumer_group": None,
+            "partition": 0,
+            "offset": 0,
+        },
+    )
+
+
+def assert_produced_message_is_expected(
+    produced_message: Optional[Message[KafkaPayload]], expected_dict: Mapping[str, Any]
+) -> None:
+    assert produced_message is not None
     # produced message should have appropriate info
     dead_letter_payload = produced_message.payload.value
     dead_letter_dict = json.loads(dead_letter_payload)
-    assert dead_letter_dict["reason"] == NO_KEY
+    assert dead_letter_dict == expected_dict

--- a/tests/processing/strategies/test_dead_letter_queue.py
+++ b/tests/processing/strategies/test_dead_letter_queue.py
@@ -263,13 +263,17 @@ def test_produce_invalid_messages(
         processing_step, produce_policy
     )
 
+    consumer = broker.get_consumer("test-group")
+    consumer.subscribe([topic])
+
     # valid message should not be produced to dead-letter topic
     dlq_produce.submit(valid_message)
-    assert broker.consume(Partition(topic, 0), 0) is None
+    assert consumer.poll() is None
 
     # invalid message should
     dlq_produce.submit(invalid_message)
-    produced_message = broker.consume(Partition(topic, 0), 0)
+
+    produced_message = consumer.poll()
     assert produced_message is not None
 
     # produced message should have appropriate info

--- a/tests/processing/strategies/test_dead_letter_queue.py
+++ b/tests/processing/strategies/test_dead_letter_queue.py
@@ -133,7 +133,8 @@ def test_count(
     processing_step: FakeProcessingStep,
 ) -> None:
     dlq_count: DeadLetterQueue[KafkaPayload] = DeadLetterQueue(
-        processing_step, CountInvalidMessagePolicy(5)
+        processing_step,
+        CountInvalidMessagePolicy(next_policy=IgnoreInvalidMessagePolicy(), limit=5),
     )
     dlq_count.submit(valid_message)
     for _ in range(5):
@@ -148,7 +149,10 @@ def test_count_short(
     processing_step: FakeProcessingStep,
 ) -> None:
     dlq_count_short: DeadLetterQueue[KafkaPayload] = DeadLetterQueue(
-        processing_step, CountInvalidMessagePolicy(5, 1)
+        processing_step,
+        CountInvalidMessagePolicy(
+            next_policy=IgnoreInvalidMessagePolicy(), limit=5, seconds=1
+        ),
     )
     dlq_count_short.submit(valid_message)
     for _ in range(5):
@@ -172,6 +176,7 @@ def test_stateful_count(
     dlq_count_load_state: DeadLetterQueue[KafkaPayload] = DeadLetterQueue(
         processing_step,
         CountInvalidMessagePolicy(
+            next_policy=IgnoreInvalidMessagePolicy(),
             limit=5,
             load_state=state,
         ),
@@ -192,7 +197,9 @@ def test_multiple_invalid_messages(
     invalid_message: Message[KafkaPayload],
 ) -> None:
     fake_batching_processor = FakeBatchingProcessingStep()
-    count_policy = CountInvalidMessagePolicy(5)
+    count_policy = CountInvalidMessagePolicy(
+        next_policy=IgnoreInvalidMessagePolicy(), limit=5
+    )
     dlq_count: DeadLetterQueue[KafkaPayload] = DeadLetterQueue(
         fake_batching_processor, count_policy
     )

--- a/tests/processing/strategies/test_dead_letter_queue.py
+++ b/tests/processing/strategies/test_dead_letter_queue.py
@@ -61,7 +61,6 @@ class FakeProcessingStep(ProcessingStrategy[KafkaPayload]):
                     InvalidMessage(
                         payload=str(message.payload),
                         timestamp=message.timestamp,
-                        original_topic=message.partition.topic.name,
                         offset=message.offset,
                         partition=message.partition.index,
                         reason=NO_KEY,

--- a/tests/processing/strategies/test_dead_letter_queue.py
+++ b/tests/processing/strategies/test_dead_letter_queue.py
@@ -39,9 +39,7 @@ class FakeProcessingStep(ProcessingStrategy[KafkaPayload]):
                 0,
                 KafkaPayload(None, b"", []),
                 datetime.now(),
-            ),
-            topic="topic",
-            timestamp=str(datetime.now()),
+            )
         )
 
     def join(self, timeout: Optional[float] = None) -> None:
@@ -58,7 +56,7 @@ class FakeProcessingStep(ProcessingStrategy[KafkaPayload]):
         Valid message is one with a key.
         """
         if message.payload.key is None:
-            raise InvalidMessage(message, "topic", str(datetime.now()))
+            raise InvalidMessage(message)
 
 
 class FakeProcessingStepFactory(ProcessingStrategyFactory[KafkaPayload]):

--- a/tests/processing/strategies/test_dead_letter_queue.py
+++ b/tests/processing/strategies/test_dead_letter_queue.py
@@ -265,11 +265,11 @@ def test_produce_invalid_messages(
 
     # valid message should not be produced to dead-letter topic
     dlq_produce.submit(valid_message)
-    assert broker.get_message_storage().consume(Partition(topic, 0), 0) is None
+    assert broker.consume(Partition(topic, 0), 0) is None
 
     # invalid message should
     dlq_produce.submit(invalid_message)
-    produced_message = broker.get_message_storage().consume(Partition(topic, 0), 0)
+    produced_message = broker.consume(Partition(topic, 0), 0)
     assert produced_message is not None
 
     # produced message should have appropriate info

--- a/tests/processing/strategies/test_dead_letter_queue.py
+++ b/tests/processing/strategies/test_dead_letter_queue.py
@@ -12,6 +12,7 @@ from arroyo.processing.strategies.dead_letter_queue.dead_letter_queue import (
     DeadLetterQueue,
 )
 from arroyo.processing.strategies.dead_letter_queue.policies.abstract import (
+    DATE_TIME_FORMAT,
     InvalidKafkaMessage,
     InvalidMessages,
 )
@@ -22,7 +23,6 @@ from arroyo.processing.strategies.dead_letter_queue.policies.ignore import (
     IgnoreInvalidMessagePolicy,
 )
 from arroyo.processing.strategies.dead_letter_queue.policies.produce import (
-    DATE_TIME_FORMAT,
     ProduceInvalidMessagePolicy,
 )
 from arroyo.processing.strategies.dead_letter_queue.policies.raise_e import (


### PR DESCRIPTION
I'm not sure if I did this correctly but eventually our DLQ policies need to produce invalid messages to a dead letter topic.

- Introduced a new Policy which has the sole purpose of producing a given message to a dead letter topic
- This could be extended by other policies such as the count policy to start putting the invalid messages into the dead letter topic instead of just ignoring them
- Modified `InvalidMessage` Exception to also hold the original topic the message was produced to along with the timestamp the exception was thrown
