### PR TITLE
test: Fix flaky test

### DIFF
--- a/tests/backends/mixins.py
+++ b/tests/backends/mixins.py
@@ -102,7 +102,7 @@ class StreamsTestMixin(ABC, Generic[TPayload]):
             with assert_changes(consumer.paused, [Partition(topic, 0)], []):
                 consumer.resume([Partition(topic, 0)])
 
-            message = consumer.poll(1.0)
+            message = consumer.poll(5.0)
             assert isinstance(message, Message)
             assert message.partition == Partition(topic, 0)
             assert message.offset == messages[0].offset


### PR DESCRIPTION
This test frequently fails since it often takes longer than 1 second for
the consumer to poll for the message in CI. Increase the time that
poll() will wait for a message.