### PR TITLE
Revamped invalid message model

### DIFF
--- a/arroyo/processing/strategies/dead_letter_queue/policies/abstract.py
+++ b/arroyo/processing/strategies/dead_letter_queue/policies/abstract.py
@@ -1,5 +1,78 @@
+import base64
 from abc import ABC, abstractmethod
-from typing import Any, Sequence
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Mapping, Optional, Sequence, Union
+
+SerializedPayload = Union[str, bytes]
+JSONSerializable = Optional[Union[str, int, datetime]]
+
+
+class InvalidMessage(ABC):
+    """
+    A class representing a bad message to be passed to the DLQ.
+
+    An `InvalidMessages` exception should be raised containing
+    one or more `InvalidMessage` objects in order to actually
+    pass data to the DLQ.
+
+    If a produce policy is configured on the relevant DLQ, a
+    message in the form returned by `to_dict()` will be produced
+    via the policy.
+    """
+
+    @abstractmethod
+    def to_dict(self) -> Mapping[str, JSONSerializable]:
+        raise NotImplementedError
+
+    def deserialize_payload(self, payload: SerializedPayload) -> str:
+        if isinstance(payload, bytes):
+            try:
+                decoded = payload.decode("utf-8")
+            except UnicodeDecodeError:
+                decoded = "(base64) " + base64.b64encode(payload).decode("utf-8")
+        else:
+            decoded = payload
+        return decoded
+
+
+@dataclass(frozen=True)
+class InvalidRawMessage(InvalidMessage):
+    """
+    A dataclass to generally represent any kind of bad message.
+    A `reason` can be provided for debugging purposes.
+    """
+
+    payload: SerializedPayload
+    reason: Optional[str] = None
+
+    def to_dict(self) -> Mapping[str, JSONSerializable]:
+        return {"payload": self.deserialize_payload(self.payload)}
+
+
+@dataclass(frozen=True)
+class InvalidKafkaMessage(InvalidMessage):
+    """
+    A dataclass to generally represent a bad Kafka message.
+    A `reason` can be provided for debugging purposes.
+    """
+
+    payload: SerializedPayload
+    timestamp: datetime
+    reason: Optional[str] = None
+    consumer_group: Optional[str] = None
+    partition: Optional[int] = None
+    offset: Optional[int] = None
+
+    def to_dict(self) -> Mapping[str, JSONSerializable]:
+        return {
+            "payload": self.deserialize_payload(self.payload),
+            "timestamp": self.timestamp,
+            "reason": self.reason,
+            "consumer_group": self.consumer_group,
+            "partition": self.partition,
+            "offset": self.offset,
+        }
 
 
 class InvalidMessages(Exception):
@@ -8,11 +81,11 @@ class InvalidMessages(Exception):
     so they are handled correctly.
     """
 
-    def __init__(self, messages: Sequence[Any]):
+    def __init__(
+        self,
+        messages: Sequence[InvalidKafkaMessage],
+    ):
         self.messages = messages
-
-    def __str__(self) -> str:
-        return f"Invalid Message(s): {self.messages}"
 
 
 class DeadLetterQueuePolicy(ABC):


### PR DESCRIPTION
### Overview
- PR #61 and #57 both rely on a common implementation of what an Invalid Message looks like.
- Pulling out that definition to this PR so it can be merged separately and there is no confusion on what it looks like.
- This would be merged into those two PR's before they are merged to main so there are no conflicts.

