### PR TITLE
fix(dlq): Policy closure added + Producer closed

### DIFF
--- a/arroyo/processing/strategies/dead_letter_queue/dead_letter_queue.py
+++ b/arroyo/processing/strategies/dead_letter_queue/dead_letter_queue.py
@@ -54,6 +54,8 @@ class DeadLetterQueue(ProcessingStep[TPayload]):
 
     def terminate(self) -> None:
         self.close()
+        logger.debug("Terminating %r...", self.__policy)
+        self.__policy.terminate()
         logger.debug("Terminating %r...", self.__next_step)
         self.__next_step.terminate()
 

--- a/arroyo/processing/strategies/dead_letter_queue/policies/abstract.py
+++ b/arroyo/processing/strategies/dead_letter_queue/policies/abstract.py
@@ -114,3 +114,18 @@ class DeadLetterQueuePolicy(ABC):
         Cleanup any asynchronous tasks that may be running.
         """
         raise NotImplementedError()
+
+    @abstractmethod
+    def close(self) -> None:
+        """
+        Close the policy from handling any new messages.
+        """
+        raise NotImplementedError()
+
+    @abstractmethod
+    def terminate(self) -> None:
+        """
+        Immediately close this policy, abandoning any work in
+        progress
+        """
+        raise NotImplementedError()

--- a/arroyo/processing/strategies/dead_letter_queue/policies/count.py
+++ b/arroyo/processing/strategies/dead_letter_queue/policies/count.py
@@ -40,6 +40,7 @@ class CountInvalidMessagePolicy(DeadLetterQueuePolicy):
         seconds: int = 60,
         load_state: Optional[Sequence[Tuple[int, int]]] = None,
     ) -> None:
+        self.__closed = False
         self.__limit = limit
         self.__seconds = seconds
         self.__next_policy = next_policy
@@ -51,6 +52,7 @@ class CountInvalidMessagePolicy(DeadLetterQueuePolicy):
         )
 
     def handle_invalid_messages(self, e: InvalidMessages) -> None:
+        assert not self.__closed
         self._add(e)
         if self._count() > self.__limit:
             raise e
@@ -71,3 +73,9 @@ class CountInvalidMessagePolicy(DeadLetterQueuePolicy):
 
     def join(self, timeout: Optional[float]) -> None:
         self.__next_policy.join(timeout)
+
+    def close(self) -> None:
+        self.__closed = True
+
+    def terminate(self) -> None:
+        self.close()

--- a/arroyo/processing/strategies/dead_letter_queue/policies/ignore.py
+++ b/arroyo/processing/strategies/dead_letter_queue/policies/ignore.py
@@ -9,10 +9,18 @@ from arroyo.utils.metrics import get_metrics
 
 class IgnoreInvalidMessagePolicy(DeadLetterQueuePolicy):
     def __init__(self) -> None:
+        self.__closed = False
         self.__metrics = get_metrics()
 
     def handle_invalid_messages(self, e: InvalidMessages) -> None:
+        assert not self.__closed
         self.__metrics.increment("dlq.dropped_messages", len(e.messages))
 
     def join(self, timeout: Optional[float]) -> None:
         return
+
+    def close(self) -> None:
+        self.__closed = True
+
+    def terminate(self) -> None:
+        self.close()

--- a/arroyo/processing/strategies/dead_letter_queue/policies/produce.py
+++ b/arroyo/processing/strategies/dead_letter_queue/policies/produce.py
@@ -24,6 +24,7 @@ class ProduceInvalidMessagePolicy(DeadLetterQueuePolicy):
     def __init__(
         self, producer: Producer[KafkaPayload], dead_letter_topic: Topic
     ) -> None:
+        self.__closed = False
         self.__metrics = get_metrics()
         self.__dead_letter_topic = dead_letter_topic
         self.__producer = producer
@@ -35,6 +36,8 @@ class ProduceInvalidMessagePolicy(DeadLetterQueuePolicy):
         invalid message. Produced message is in the form provided
         by `InvalidMessage.to_dict()`
         """
+        assert not self.__closed
+
         for message in e.messages:
             payload = self._build_payload(message)
             self._produce(payload)
@@ -68,3 +71,10 @@ class ProduceInvalidMessagePolicy(DeadLetterQueuePolicy):
                 self.__futures.popleft()
             if timeout is not None and time.perf_counter() - start > timeout:
                 break
+
+    def close(self) -> None:
+        self.__closed = True
+
+    def terminate(self) -> None:
+        self.close()
+        self.__producer.close()

--- a/arroyo/processing/strategies/dead_letter_queue/policies/produce.py
+++ b/arroyo/processing/strategies/dead_letter_queue/policies/produce.py
@@ -64,13 +64,13 @@ class ProduceInvalidMessagePolicy(DeadLetterQueuePolicy):
         )
 
     def join(self, timeout: Optional[float] = None) -> None:
-        self.__producer.close()
         start = time.perf_counter()
         while self.__futures:
             if self.__futures[0].done():
                 self.__futures.popleft()
             if timeout is not None and time.perf_counter() - start > timeout:
                 break
+        self.__producer.close()
 
     def close(self) -> None:
         self.__closed = True

--- a/arroyo/processing/strategies/dead_letter_queue/policies/produce.py
+++ b/arroyo/processing/strategies/dead_letter_queue/policies/produce.py
@@ -61,6 +61,7 @@ class ProduceInvalidMessagePolicy(DeadLetterQueuePolicy):
         )
 
     def join(self, timeout: Optional[float] = None) -> None:
+        self.__producer.close()
         start = time.perf_counter()
         while self.__futures:
             if self.__futures[0].done():

--- a/arroyo/processing/strategies/dead_letter_queue/policies/raise_e.py
+++ b/arroyo/processing/strategies/dead_letter_queue/policies/raise_e.py
@@ -7,8 +7,18 @@ from arroyo.processing.strategies.dead_letter_queue.policies.abstract import (
 
 
 class RaiseInvalidMessagePolicy(DeadLetterQueuePolicy):
+    def __init__(self) -> None:
+        self.__closed = False
+
     def handle_invalid_messages(self, e: InvalidMessages) -> None:
+        assert not self.__closed
         raise e
 
     def join(self, timeout: Optional[float]) -> None:
         return
+
+    def close(self) -> None:
+        self.__closed = True
+
+    def terminate(self) -> None:
+        self.close()


### PR DESCRIPTION
### Overview
- The produce policy takes in a producer which is never closed, this leaves the consumer hanging on shutdown
    - Added `self.__producer.close()` to the produce policy join method, this fixes the hanging issue
- The produce policy takes in a producer which is not recreated upon consumer rebalancing
    - Introduced the policy closure to the Consumer Strategy Factory in order to recreate the policy entirely every time the create() method is called (eg when rebalancing)
- Introduced `close()` and `terminate()` methods to Policies to be used when DLQ is closed/terminated