### PR TITLE
fix: Fix offset committed by collect step

### DIFF
--- a/arroyo/processing/strategies/streaming/collect.py
+++ b/arroyo/processing/strategies/streaming/collect.py
@@ -17,7 +17,7 @@ class OffsetRange:
     __slots__ = ["lo", "hi", "timestamp"]
 
     lo: int  # inclusive
-    hi: int  # exclusive
+    hi: int  # inclusive
     timestamp: datetime
 
 
@@ -54,11 +54,11 @@ class Batch(Generic[TPayload]):
         self.__length += 1
 
         if message.partition in self.__offsets:
-            self.__offsets[message.partition].hi = message.next_offset
+            self.__offsets[message.partition].hi = message.offset
             self.__offsets[message.partition].timestamp = message.timestamp
         else:
             self.__offsets[message.partition] = OffsetRange(
-                message.offset, message.next_offset, message.timestamp
+                message.offset, message.offset, message.timestamp
             )
 
     def close(self) -> None:

--- a/tests/processing/strategies/test_streaming.py
+++ b/tests/processing/strategies/test_streaming.py
@@ -136,7 +136,7 @@ def test_collect(parallel: int) -> None:
         # Give the threadpool some time to do processing
         time.sleep(1) if parallel else None
         assert commit_function.call_args == call(
-            {partition: Position(2, second_message.timestamp)}
+            {partition: Position(1, second_message.timestamp)}
         )
 
     step_factory.return_value = inner_step = Mock()


### PR DESCRIPTION
I'm not really sure why this was written the way it was. It seems
to me that we should not be committing an offset beyond the last
one we have seen for the batch, which is the only thing that
self.__offsets is used for.