### PR TITLE
refactor(dlq): Renamed policy "closure" to policy "creator"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog and versioning
 
+## Unreleased
+
+### Breaking changes
+
+- refactor(dlq): Renamed policy "closure" to policy "creator" (#71) by @rahul-kumar-saini
+
 ## 0.0.20
 
 ### Various fixes & improvements


### PR DESCRIPTION
"Closure" isn't a clear enough term for what the function is actually doing, which is creating the policy object.

https://github.com/getsentry/snuba/pull/2717#discussion_r877329486
