### PR TITLE
always use create_with_partitions

### DIFF
--- a/arroyo/processing/strategies/batching.py
+++ b/arroyo/processing/strategies/batching.py
@@ -243,8 +243,10 @@ class BatchProcessingStrategyFactory(ProcessingStrategyFactory[TPayload]):
         self.__max_batch_size = max_batch_size
         self.__max_batch_time = max_batch_time
 
-    def create(
-        self, commit: Callable[[Mapping[Partition, Position]], None]
+    def create_with_partitions(
+        self,
+        commit: Callable[[Mapping[Partition, Position]], None],
+        partitions: Mapping[Partition, int],
     ) -> ProcessingStrategy[TPayload]:
         return BatchProcessingStrategy(
             commit,

--- a/arroyo/processing/strategies/streaming/factory.py
+++ b/arroyo/processing/strategies/streaming/factory.py
@@ -103,8 +103,10 @@ class ConsumerStrategyFactory(ProcessingStrategyFactory[TPayload]):
         assert self.__prefilter is not None
         return not self.__prefilter.should_drop(message)
 
-    def create(
-        self, commit: Callable[[Mapping[Partition, Position]], None]
+    def create_with_partitions(
+        self,
+        commit: Callable[[Mapping[Partition, Position]], None],
+        partitions: Mapping[Partition, int],
     ) -> ProcessingStrategy[TPayload]:
         collect = (
             ParallelCollectStep(

--- a/arroyo/utils/profiler.py
+++ b/arroyo/utils/profiler.py
@@ -60,13 +60,15 @@ class ProcessingStrategyProfilerWrapperFactory(ProcessingStrategyFactory[TPayloa
         self.__output_directory = Path(output_directory)
         assert self.__output_directory.exists() and self.__output_directory.is_dir()
 
-    def create(
-        self, commit: Callable[[Mapping[Partition, Position]], None]
+    def create_with_partitions(
+        self,
+        commit: Callable[[Mapping[Partition, Position]], None],
+        partitions: Mapping[Partition, int],
     ) -> ProcessingStrategy[TPayload]:
         profiler = Profile()
         profiler.enable()
         return ProcessingStrategyProfilerWrapper(
-            self.__strategy_factory.create(commit),
+            self.__strategy_factory.create_with_partitions(commit, partitions),
             profiler,
             str(self.__output_directory / f"{int(time.time() * 1000)}.prof"),
         )

--- a/examples/transform_and_produce/factory.py
+++ b/examples/transform_and_produce/factory.py
@@ -30,8 +30,10 @@ class HashPasswordAndProduceStrategyFactory(ProcessingStrategyFactory[KafkaPaylo
         self.__producer = producer
         self.__topic = topic
 
-    def create(
-        self, commit: Callable[[Mapping[Partition, Position]], None]
+    def create_with_partitions(
+        self,
+        commit: Callable[[Mapping[Partition, Position]], None],
+        partitions: Mapping[Partition, int],
     ) -> ProcessingStrategy[KafkaPayload]:
         return HashPasswordStrategy(
             next_step=ProduceStrategy(commit, self.__producer, self.__topic)


### PR DESCRIPTION
We want to make `create_with_partitions` the default and deprecate `create`. In order to do with we need to update the arroyo factories that are used elsewhere.