### PR TITLE
fix(dlq): Join method did not handle InvalidMessages

### DIFF
--- a/arroyo/processing/strategies/dead_letter_queue/dead_letter_queue.py
+++ b/arroyo/processing/strategies/dead_letter_queue/dead_letter_queue.py
@@ -60,6 +60,10 @@ class DeadLetterQueue(ProcessingStep[TPayload]):
         self.__next_step.terminate()
 
     def join(self, timeout: Optional[float] = None) -> None:
-        self.__policy.join(timeout)
         self.__next_step.close()
-        self.__next_step.join(timeout)
+        try:
+            self.__next_step.join(timeout)
+        except InvalidMessages as e:
+            self._handle_invalid_messages(e)
+        self.__policy.close()
+        self.__policy.join(timeout)

--- a/tests/processing/strategies/test_dead_letter_queue.py
+++ b/tests/processing/strategies/test_dead_letter_queue.py
@@ -2,6 +2,7 @@ import json
 import time
 from datetime import datetime
 from typing import Any, Mapping, MutableSequence, Optional, Tuple
+from unittest.mock import patch
 
 import pytest
 
@@ -56,7 +57,7 @@ class FakeProcessingStep(ProcessingStrategy[KafkaPayload]):
     Raises InvalidMessages if a submitted message has no key in payload.
     """
 
-    def poll(self) -> None:
+    def __raise(self) -> None:
         raise InvalidMessages(
             [
                 InvalidKafkaMessage(
@@ -72,8 +73,11 @@ class FakeProcessingStep(ProcessingStrategy[KafkaPayload]):
             ]
         )
 
+    def poll(self) -> None:
+        self.__raise()
+
     def join(self, timeout: Optional[float] = None) -> None:
-        pass
+        self.__raise()
 
     def terminate(self) -> None:
         pass
@@ -188,6 +192,16 @@ def test_ignore(
     )
     dlq_ignore.submit(valid_message)
     dlq_ignore.submit(invalid_message_no_key)
+
+
+def test_dlq_join(processing_step: FakeProcessingStep) -> None:
+    # processing step should raise, dlq should handle within join
+    dlq_ignore: DeadLetterQueue[KafkaPayload] = DeadLetterQueue(
+        processing_step, IgnoreInvalidMessagePolicy()
+    )
+    with patch.object(dlq_ignore, "_handle_invalid_messages") as mock:
+        dlq_ignore.join()
+    mock.assert_called_once()
 
 
 def test_count(

--- a/tests/processing/strategies/test_dead_letter_queue.py
+++ b/tests/processing/strategies/test_dead_letter_queue.py
@@ -196,10 +196,9 @@ def test_ignore(
 
 def test_dlq_join(processing_step: FakeProcessingStep) -> None:
     # processing step should raise, dlq should handle within join
-    dlq_ignore: DeadLetterQueue[KafkaPayload] = DeadLetterQueue(
-        processing_step, IgnoreInvalidMessagePolicy()
-    )
-    with patch.object(dlq_ignore, "_handle_invalid_messages") as mock:
+    policy = IgnoreInvalidMessagePolicy()
+    dlq_ignore: DeadLetterQueue[KafkaPayload] = DeadLetterQueue(processing_step, policy)
+    with patch.object(policy, "handle_invalid_messages") as mock:
         dlq_ignore.join()
     mock.assert_called_once()
 


### PR DESCRIPTION
### Overview
- A processing strategy's `join()` method may raise `InvalidMessages`
- DLQ currently doesn't catch that, it happened here: https://sentry.io/organizations/sentry/issues/3385232274/
- Updated DLQ to catch and handle it