### PR TITLE
feat: Add docker-compose orchestrated example script

### DIFF
--- a/examples/transform_and_produce/Dockerfile
+++ b/examples/transform_and_produce/Dockerfile
@@ -1,0 +1,8 @@
+FROM python:3.8.13
+
+RUN apt-get update
+RUN apt-get install -y librdkafka-dev
+
+RUN pip install sentry-arroyo
+
+COPY . /app

--- a/examples/transform_and_produce/README.md
+++ b/examples/transform_and_produce/README.md
@@ -18,44 +18,42 @@ The process is fairly simple:
 
 ---
 
-<strong>To begin, start the following commands in different shells:</strong>
+To run this example ensure each of your shells are inside the examples/transfrom_and_produce directory.  To begin, build the session by running `docker-compose up`.  Once Kafka has entered a running state you may continue onto the next section.
 
-_Monitor messages produced to `raw-topic`:_
+Note you will see `transform_and_produce-arroyo-1 exited with code 0`.  You can safely ignore it.  This is expected behavior.
 
-```shell
-$ docker exec -it sentry_kafka kafka-console-consumer \
-                                --bootstrap-server localhost:9092 \
-                                --topic raw-topic
-```
+**Monitoring your raw-topic consumer.**
 
-_Monitor messages produced to `hashed-topic`:_
+This will echo every message produced to the `raw-topic` topic.
 
 ```shell
-$ docker exec -it sentry_kafka kafka-console-consumer \
-                                --bootstrap-server localhost:9092 \
-                                --topic hashed-topic
+docker-compose exec kafka kafka-console-consumer --bootstrap-server kafka:9095 --topic raw-topic
 ```
 
-_Start the script itself:_
+**Running your raw-topic producer.**
+
+This process produces the messages that will flow through the system.  We will need to return to this shell to enter commands once we've finished setup.
 
 ```shell
-$ python3 arroyo/examples/transform_and_produce/script.py
+docker-compose exec kafka kafka-console-producer --bootstrap-server kafka:9095 --topic raw-topic
 ```
 
----
+**Monitoring your hashed-topic consumer.**
 
-<strong>At this point we have all the pieces in place and can start manually producing messages to `raw-topic`:</strong>
+This will echo every message produced to the `hashed-topic` topic.  This is your post-transformation output consumer.  You should see the transformations performed by Arroyo here.
 
 ```shell
-$ docker exec -it sentry_kafka kafka-console-producer \
-                                --bootstrap-server localhost:9092 \
-                                --topic raw-topic
+docker-compose exec kafka kafka-console-consumer --bootstrap-server kafka:9095 --topic hashed-topic
 ```
 
-Produce a message to the topic by typing in a message in the expected format and hitting enter.
+**Running your arroyo middleware.**
 
 ```shell
-{"username": "user1", "password": "Password1!"}
+docker-compose run arroyo python /app/script.py
 ```
+
+**Seeing it all come together.**
+
+Produce a message by returning to our producer shell.  Provide the producer a message formatted similarly to this one: `{"username": "user1", "password": "Password1!"}`.
 
 Now the message should appear in the `raw-topic` shell, followed by another message in the `hashed-topic` shell. The password field of the message in `hashed-topic` should be the SHA256 hash of the password field of the message we manually produced to `raw-topic`.

--- a/examples/transform_and_produce/docker-compose.yml
+++ b/examples/transform_and_produce/docker-compose.yml
@@ -30,13 +30,6 @@ services:
       KAFKA_INTER_BROKER_LISTENER_NAME: LISTENER_DOCKER_INTERNAL
       KAFKA_ZOOKEEPER_CONNECT: "zookeeper:2181"
       KAFKA_BROKER_ID: 1
-      KAFKA_LOG4J_LOGGERS: "kafka.controller=INFO,kafka.producer.async.DefaultEventHandler=INFO,state.change.logger=INFO"
       KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
-      KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: 1
-      KAFKA_TRANSACTION_STATE_LOG_MIN_ISR: 1
-      KAFKA_JMX_PORT: 9999
-      KAFKA_JMX_HOSTNAME: ${DOCKER_HOST_IP:-127.0.0.1}
-      KAFKA_AUTHORIZER_CLASS_NAME: kafka.security.authorizer.AclAuthorizer
-      KAFKA_ALLOW_EVERYONE_IF_NO_ACL_FOUND: "true"
     depends_on:
       - zookeeper

--- a/examples/transform_and_produce/docker-compose.yml
+++ b/examples/transform_and_produce/docker-compose.yml
@@ -1,0 +1,42 @@
+version: '3'
+services:
+  arroyo:
+    build: .
+    environment:
+      - BOOTSTRAP_SERVERS=kafka:9095
+
+  zookeeper:
+    image: confluentinc/cp-zookeeper:6.2.0
+    hostname: zookeeper
+    container_name: zookeeper
+    ports:
+      - "2181:2181"
+    environment:
+      ZOOKEEPER_CLIENT_PORT: 2181
+      ZOOKEEPER_SERVER_ID: 1
+      ZOOKEEPER_SERVERS: zookeeper:2888:3888
+
+  kafka:
+    image: confluentinc/cp-kafka:6.2.0
+    hostname: kafka
+    container_name: kafka
+    ports:
+      - "9094:9094"
+      - "9095:9095"
+    environment:
+      KAFKA_ADVERTISED_LISTENERS: LISTENER_DOCKER_INTERNAL://kafka:9095,LISTENER_DOCKER_EXTERNAL://${DOCKER_HOST_IP:-127.0.0.1}:9094
+      KAFKA_LISTENERS: LISTENER_DOCKER_INTERNAL://kafka:9095,LISTENER_DOCKER_EXTERNAL://${DOCKER_HOST_IP:-127.0.0.1}:9094
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: LISTENER_DOCKER_INTERNAL:PLAINTEXT,LISTENER_DOCKER_EXTERNAL:PLAINTEXT
+      KAFKA_INTER_BROKER_LISTENER_NAME: LISTENER_DOCKER_INTERNAL
+      KAFKA_ZOOKEEPER_CONNECT: "zookeeper:2181"
+      KAFKA_BROKER_ID: 1
+      KAFKA_LOG4J_LOGGERS: "kafka.controller=INFO,kafka.producer.async.DefaultEventHandler=INFO,state.change.logger=INFO"
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
+      KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: 1
+      KAFKA_TRANSACTION_STATE_LOG_MIN_ISR: 1
+      KAFKA_JMX_PORT: 9999
+      KAFKA_JMX_HOSTNAME: ${DOCKER_HOST_IP:-127.0.0.1}
+      KAFKA_AUTHORIZER_CLASS_NAME: kafka.security.authorizer.AclAuthorizer
+      KAFKA_ALLOW_EVERYONE_IF_NO_ACL_FOUND: "true"
+    depends_on:
+      - zookeeper


### PR DESCRIPTION
This pull adds a docker-compose convenience script for testing the Arroyo project.  It is decoupled from Sentry and contains documentation for running the example.

Notes:

* I wanted to simplify the process further by running the Arroyo script within the docker-compose.yml file.  However, it seems the Arroyo example causes Kafka to crash if it's not ready to receive connections.
* The script doesn't perfectly mirror our CI.  The ports are different and LISTENERs have been tweaked but it is mostly similar and broadly applies.