### PR TITLE
fix(dlq): InvalidMessages Exception __repr__

### DIFF
--- a/arroyo/processing/strategies/dead_letter_queue/policies/abstract.py
+++ b/arroyo/processing/strategies/dead_letter_queue/policies/abstract.py
@@ -3,7 +3,7 @@ import json
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from datetime import datetime
-from typing import Any, Mapping, Optional, Sequence, Union
+from typing import Any, Mapping, Optional, Sequence, Set, Union
 
 from arroyo.backends.kafka.consumer import Headers
 from arroyo.utils.codecs import Encoder
@@ -94,6 +94,24 @@ class InvalidMessages(Exception):
 
     def __init__(self, messages: Sequence[InvalidMessage]):
         self.messages = messages
+        self.num_kafka_messages = 0
+        self.topics: Set[str] = set()
+        self.num_raw_messages = 0
+        self.__generate_stats()
+
+    def __generate_stats(self) -> Any:
+        for message in self.messages:
+            if isinstance(message, InvalidKafkaMessage):
+                self.num_kafka_messages += 1
+                self.topics.add(message.topic)
+            else:
+                self.num_raw_messages += 1
+
+    def __repr__(self) -> str:
+        return (
+            f"InvalidMessages Exception containing: {self.num_kafka_messages} Kafka messages "
+            f"from topic(s): `{'`, `'.join(self.topics)}`. {self.num_raw_messages} Raw messages."
+        )
 
 
 class DeadLetterQueuePolicy(ABC):


### PR DESCRIPTION
### Overview
- `InvalidMessages` exception results in a huge repr when logging
- Eg, truncated error message in Sentry [here](https://sentry.io/organizations/sentry/issues/3385232274/events/eec842fc7d0f4c139872d673e76629d2/)
- All of it shows up in GCP logs but there is unnecessary data being logged (all of the invalid messages)

### Changes
- Added a `__repr__` method to the `InvalidMessages` exception that returns a simpler message

Example repr:

InvalidMessages Exception containing: 23 Kafka messages from topic(s): \`some-topic\`, \`another-topic\`. 0 Raw messages.