### PR TITLE
doc: Remove reference to synchronized consumer in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,4 +8,3 @@ Arroyo provides:
 
 * Consumer and producer interfaces. The primary use case is for working with Apache Kafka streams, however it also supports custom backends and includes local (memory or file based) consumer and producer implementations
 * Consumer strategy interface that helps build the processing strategy for how raw messages that are consumed should be filtered, transformed, batched and flushed as required
-* A synchronized consumer implementation that supports following another consumer by only consuming messages once already consumed and committed by another consumer group


### PR DESCRIPTION
Synchronized consumer no longer exists in Arroyo 1.0.0