### PR TITLE
adjust confluent-kafka version to >=

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-confluent-kafka==1.9.0
+confluent-kafka>=1.9.0


### PR DESCRIPTION
this doesn't change what actual version gets installed -- but allows downstreams to change the version without having to go through the release pipeline here