### PR TITLE
fix: Use correct log level for fatal crashes [sns-1622]

### DIFF
--- a/arroyo/processing/processor.py
+++ b/arroyo/processing/processor.py
@@ -132,7 +132,7 @@ class StreamProcessor(Generic[TPayload]):
 
             self._shutdown()
         except Exception as error:
-            logger.info("Caught %r, shutting down...", error)
+            logger.exception("Caught exception, shutting down...")
 
             if self.__processing_strategy is not None:
                 logger.debug("Terminating %r...", self.__processing_strategy)


### PR DESCRIPTION
This will cause the sentry SDK, if initialized, to pick up the crash and
send it to sentry.

signals/KeyboardInterrupt shouldn't be caught by `except Exception:`
