### PR TITLE
feat: Remove deprecated synchronized module

### DIFF
--- a/arroyo/synchronized.py
+++ b/arroyo/synchronized.py
@@ -1,6 +1,0 @@
-# TODO: This module will be deprecated
-from arroyo.commit import Commit, CommitCodec
-
-commit_codec = CommitCodec()
-
-__all__ = ["Commit", "CommitCodec", "commit_codec"]


### PR DESCRIPTION
The commit codec should be imported from arroyo.commit instead.