### PR TITLE
fix(docs) Fix branch name on GHA

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -3,7 +3,7 @@ name: Arroyo Docs
 on:
   push:
     branches:
-      - master
+      - main
 
 jobs:
   docs:


### PR DESCRIPTION
We need to run the docs when we push on `main` not `master`. 
I had copied it from Snuba.