### PR TITLE
feat: Introduce commit policies

### DIFF
--- a/arroyo/backends/kafka/commit.py
+++ b/arroyo/backends/kafka/commit.py
@@ -1,0 +1,55 @@
+from datetime import datetime
+from typing import Optional
+
+from arroyo.backends.kafka import KafkaPayload
+from arroyo.commit import Commit
+from arroyo.types import Partition, Topic
+from arroyo.utils.codecs import Codec
+
+DATETIME_FORMAT = "%Y-%m-%dT%H:%M:%S.%fZ"
+
+
+class CommitCodec(Codec[KafkaPayload, Commit]):
+    def encode(self, value: Commit) -> KafkaPayload:
+        assert value.orig_message_ts is not None
+
+        return KafkaPayload(
+            f"{value.partition.topic.name}:{value.partition.index}:{value.group}".encode(
+                "utf-8"
+            ),
+            f"{value.offset}".encode("utf-8"),
+            [
+                (
+                    "orig_message_ts",
+                    datetime.strftime(value.orig_message_ts, DATETIME_FORMAT).encode(
+                        "utf-8"
+                    ),
+                )
+            ],
+        )
+
+    def decode(self, value: KafkaPayload) -> Commit:
+        key = value.key
+        if not isinstance(key, bytes):
+            raise TypeError("payload key must be a bytes object")
+
+        val = value.value
+        if not isinstance(val, bytes):
+            raise TypeError("payload value must be a bytes object")
+
+        headers = {k: v for (k, v) in value.headers}
+        try:
+            orig_message_ts: Optional[datetime] = datetime.strptime(
+                headers["orig_message_ts"].decode("utf-8"), DATETIME_FORMAT
+            )
+        except KeyError:
+            orig_message_ts = None
+
+        topic_name, partition_index, group = key.decode("utf-8").split(":", 3)
+        offset = int(val.decode("utf-8"))
+        return Commit(
+            group,
+            Partition(Topic(topic_name), int(partition_index)),
+            offset,
+            orig_message_ts,
+        )

--- a/arroyo/processing/strategies/abstract.py
+++ b/arroyo/processing/strategies/abstract.py
@@ -1,7 +1,7 @@
 from abc import ABC, abstractmethod
-from typing import Callable, Generic, Mapping, Optional
+from typing import Generic, Mapping, Optional
 
-from arroyo.types import Message, Partition, Position, TPayload
+from arroyo.types import Commit, Message, Partition, TPayload
 
 
 class MessageRejected(Exception):
@@ -101,7 +101,7 @@ class ProcessingStrategyFactory(ABC, Generic[TPayload]):
     @abstractmethod
     def create_with_partitions(
         self,
-        commit: Callable[[Mapping[Partition, Position]], None],
+        commit: Commit,
         partitions: Mapping[Partition, int],
     ) -> ProcessingStrategy[TPayload]:
         """

--- a/arroyo/synchronized.py
+++ b/arroyo/synchronized.py
@@ -1,6 +1,0 @@
-# TODO: This module will be deprecated
-from arroyo.commit import Commit, CommitCodec
-
-commit_codec = CommitCodec()
-
-__all__ = ["Commit", "CommitCodec", "commit_codec"]

--- a/arroyo/types.py
+++ b/arroyo/types.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from datetime import datetime
-from typing import Generic, TypeVar
+from typing import Generic, Mapping, Protocol, TypeVar
 
 
 @dataclass(order=True, unsafe_hash=True)
@@ -68,3 +68,10 @@ class Position:
     __slots__ = ["offset", "timestamp"]
     offset: int
     timestamp: datetime
+
+
+class Commit(Protocol):
+    def __call__(
+        self, positions: Mapping[Partition, Position], force: bool = False
+    ) -> None:
+        pass

--- a/arroyo/utils/profiler.py
+++ b/arroyo/utils/profiler.py
@@ -2,13 +2,13 @@ import logging
 import time
 from cProfile import Profile
 from pathlib import Path
-from typing import Callable, Mapping, Optional
+from typing import Mapping, Optional
 
 from arroyo.processing.strategies.abstract import (
     ProcessingStrategy,
     ProcessingStrategyFactory,
 )
-from arroyo.types import Message, Partition, Position, TPayload
+from arroyo.types import Commit, Message, Partition, TPayload
 
 logger = logging.getLogger(__name__)
 
@@ -62,7 +62,7 @@ class ProcessingStrategyProfilerWrapperFactory(ProcessingStrategyFactory[TPayloa
 
     def create_with_partitions(
         self,
-        commit: Callable[[Mapping[Partition, Position]], None],
+        commit: Commit,
         partitions: Mapping[Partition, int],
     ) -> ProcessingStrategy[TPayload]:
         profiler = Profile()

--- a/docs/source/getstarted.rst
+++ b/docs/source/getstarted.rst
@@ -266,6 +266,25 @@ do it in the poll on the completed callback. When the consumer is stopped, or th
 revoked, we wait for all the missing callbacks to complete in the `join` method.
 
 
+Committing offsets
+==================
+Arroyo does not auto commit offsets. It is up to you to manually commit offsets when processing for that
+message is completed.
+
+The commit callback will be passed to processing strategy via `ProcessingStrategyFactory.create_with_partitions`.
+You should pass this to the strategy and have you strategy call this commit function once the rest of the message
+processing has been done.
+
+The offset to be committed in Kafka is always the next offset to be consumed from, i.e. message's offset + 1.
+In Arroyo, this means you should commit `Message.next_offset` and never `Message.offset` when done processing
+that message.
+
+It is not safe to commit every offset in a high throughput consumer as this will add a lot of load to the system.
+Commits should generally be throttled. In order to make this easier, Arroyo supports passing an optional `CommitPolicy`
+to the stream processor, which allows specifying a minimum commit frequency (or messages between commits). Commit
+throttling can be skipped when needed (i.e. during consumer shutdown) by passing `force=True` to the commit callback.
+
+
 Further examples
 ================
 

--- a/tests/backends/test_commit.py
+++ b/tests/backends/test_commit.py
@@ -1,0 +1,31 @@
+from datetime import datetime
+
+from arroyo.backends.kafka import KafkaPayload
+from arroyo.backends.kafka.commit import CommitCodec
+from arroyo.backends.local.backend import LocalBroker as Broker
+from arroyo.commit import Commit
+from arroyo.types import Partition, Topic
+
+
+def test_encode_decode(broker: Broker[KafkaPayload]) -> None:
+    topic = Topic("topic")
+    broker.create_topic(topic, partitions=1)
+
+    producer = broker.get_producer()
+
+    message = producer.produce(
+        topic, KafkaPayload(None, "hello".encode("utf8"), [])
+    ).result(1.0)
+
+    commit_codec = CommitCodec()
+
+    commit = Commit(
+        "leader-a",
+        Partition(topic, 0),
+        message.next_offset,
+        datetime.now(),
+    )
+
+    encoded = commit_codec.encode(commit)
+
+    assert commit_codec.decode(encoded) == commit

--- a/tests/backends/test_kafka.py
+++ b/tests/backends/test_kafka.py
@@ -13,12 +13,15 @@ import pytest
 from confluent_kafka.admin import AdminClient, NewTopic
 
 from arroyo.backends.kafka import KafkaConsumer, KafkaPayload, KafkaProducer
+from arroyo.backends.kafka.commit import CommitCodec
 from arroyo.backends.kafka.configuration import build_kafka_configuration
 from arroyo.backends.kafka.consumer import as_kafka_configuration_bool
+from arroyo.commit import Commit
 from arroyo.errors import ConsumerError, EndOfPartition
-from arroyo.synchronized import Commit, commit_codec
 from arroyo.types import Message, Partition, Position, Topic
 from tests.backends.mixins import StreamsTestMixin
+
+commit_codec = CommitCodec()
 
 
 def test_payload_equality() -> None:


### PR DESCRIPTION
This is an attempt to simplify throttling commits in consumers. Generally speaking it is not safe for high throughput consumers to commit every offset. Today in order to achieve this with Arroyo, every consumer needs to manually implement throttling by themselves (unless batching is being used). This is verbose and easy to get wrong. This change aims to make it easier to do the right thing.

With this change, the stream processor takes an optional commit policy argument. The commit policy specifies the minimum time or minimum messages between commits.

In order to avoid throttling during shutdown, the commit function also now supports a force flag to override the commit policy / throttling behavior. This should be passed during consumer shutdown sequence as we no longer want to throttle in that scenario and just want to commit the latest offsets.

This change is designed to be backward compatible. The default behavior if no commit policy is passed remains the same as it was previously (no throttling, every offset committed).