### PR TITLE
build: Run CI on Python 3.10

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ jobs:
     strategy:
       max-parallel: 3
       matrix:
-        python: [3.8, 3.9, 3.10]
+        python: [3.8, 3.9, "3.10"]
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ jobs:
     strategy:
       max-parallel: 3
       matrix:
-        python: [3.8, 3.9]
+        python: [3.8, 3.9, 3.10]
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Python 3.10 should be supported now by confluent-kafka-python