### PR TITLE
fix: Make Position pickleable

### DIFF
--- a/arroyo/types.py
+++ b/arroyo/types.py
@@ -67,11 +67,22 @@ class Message(Generic[TPayload]):
         return Position(self.next_offset, self.timestamp)
 
 
-@dataclass(order=True, unsafe_hash=True)
+@dataclass(frozen=True)
 class Position:
     __slots__ = ["offset", "timestamp"]
     offset: int
     timestamp: datetime
+
+    def __getstate__(self) -> dict[str, int | datetime]:
+        return dict(
+            (slot, getattr(self, slot))
+            for slot in self.__slots__
+            if hasattr(self, slot)
+        )
+
+    def __setstate__(self, state: dict[str, int | datetime]) -> None:
+        for slot, value in state.items():
+            object.__setattr__(self, slot, value)
 
 
 class Commit(Protocol):

--- a/arroyo/types.py
+++ b/arroyo/types.py
@@ -67,7 +67,7 @@ class Message(Generic[TPayload]):
         return Position(self.next_offset, self.timestamp)
 
 
-@dataclass(frozen=True)
+@dataclass(order=True, unsafe_hash=True)
 class Position:
     __slots__ = ["offset", "timestamp"]
     offset: int

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -15,6 +15,12 @@ def test_message_pickling() -> None:
     assert pickle.loads(pickle.dumps(message)) == message
 
 
-def test_position_pickling() -> None:
+def test_position() -> None:
     position = Position(1, datetime.now())
+
+    # Pickleable
     assert pickle.loads(pickle.dumps(position)) == position
+
+    # Hashable
+    test = {}
+    test[position] = 1

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -1,7 +1,7 @@
 import pickle
 from datetime import datetime
 
-from arroyo.types import Message, Partition, Topic
+from arroyo.types import Message, Partition, Position, Topic
 
 
 def test_topic_contains_partition() -> None:
@@ -13,3 +13,8 @@ def test_topic_contains_partition() -> None:
 def test_message_pickling() -> None:
     message = Message(Partition(Topic("topic"), 0), 0, b"", datetime.now())
     assert pickle.loads(pickle.dumps(message)) == message
+
+
+def test_position_pickling() -> None:
+    position = Position(1, datetime.now())
+    assert pickle.loads(pickle.dumps(position)) == position


### PR DESCRIPTION
All of these common types should be pickleable. Since we expect the user might be passing Position around and manually passing it to the commit function, let's make it pickleable.

This is the workaround described in https://github.com/python/cpython/issues/80605