### PR TITLE
test: Simplify the commit codec test

### DIFF
--- a/tests/backends/test_commit.py
+++ b/tests/backends/test_commit.py
@@ -1,28 +1,20 @@
 from datetime import datetime
 
-from arroyo.backends.kafka import KafkaPayload
 from arroyo.backends.kafka.commit import CommitCodec
-from arroyo.backends.local.backend import LocalBroker as Broker
 from arroyo.commit import Commit
 from arroyo.types import Partition, Topic
 
 
-def test_encode_decode(broker: Broker[KafkaPayload]) -> None:
+def test_encode_decode() -> None:
     topic = Topic("topic")
-    broker.create_topic(topic, partitions=1)
-
-    producer = broker.get_producer()
-
-    message = producer.produce(
-        topic, KafkaPayload(None, "hello".encode("utf8"), [])
-    ).result(1.0)
-
     commit_codec = CommitCodec()
+
+    offset_to_commit = 5
 
     commit = Commit(
         "leader-a",
         Partition(topic, 0),
-        message.next_offset,
+        offset_to_commit,
         datetime.now(),
     )
 


### PR DESCRIPTION
This test was unnecessarily complex. There is no reason to involve a fake broker and producer when all we are doing is testing that encoding and decoding a message works correctly and we get the same value back after it is decoded.