### PR TITLE
feat: Split the Message interface to better support batching steps

### DIFF
--- a/arroyo/backends/abstract.py
+++ b/arroyo/backends/abstract.py
@@ -5,7 +5,7 @@ from abc import ABC, abstractmethod, abstractproperty
 from concurrent.futures import Future
 from typing import Callable, Generic, Mapping, Optional, Sequence, Union
 
-from arroyo.types import BrokerPayload, Partition, Position, Topic, TPayload
+from arroyo.types import BrokerValue, Partition, Position, Topic, TPayload
 
 logger = logging.getLogger(__name__)
 
@@ -62,9 +62,7 @@ class Consumer(Generic[TPayload], ABC):
         raise NotImplementedError
 
     @abstractmethod
-    def poll(
-        self, timeout: Optional[float] = None
-    ) -> Optional[BrokerPayload[TPayload]]:
+    def poll(self, timeout: Optional[float] = None) -> Optional[BrokerValue[TPayload]]:
         """
         Fetch a message from the consumer. If no message is available before
         the timeout, ``None`` is returned.
@@ -170,7 +168,7 @@ class Producer(Generic[TPayload], ABC):
     @abstractmethod
     def produce(
         self, destination: Union[Topic, Partition], payload: TPayload
-    ) -> Future[BrokerPayload[TPayload]]:
+    ) -> Future[BrokerValue[TPayload]]:
         """
         Produce to a topic or partition.
         """

--- a/arroyo/backends/abstract.py
+++ b/arroyo/backends/abstract.py
@@ -62,9 +62,7 @@ class Consumer(Generic[TPayload], ABC):
         raise NotImplementedError
 
     @abstractmethod
-    def poll(
-        self, timeout: Optional[float] = None
-    ) -> Optional[Message[BrokerPayload[TPayload]]]:
+    def poll(self, timeout: Optional[float] = None) -> Optional[Message[TPayload]]:
         """
         Fetch a message from the consumer. If no message is available before
         the timeout, ``None`` is returned.

--- a/arroyo/backends/abstract.py
+++ b/arroyo/backends/abstract.py
@@ -5,7 +5,7 @@ from abc import ABC, abstractmethod, abstractproperty
 from concurrent.futures import Future
 from typing import Callable, Generic, Mapping, Optional, Sequence, Union
 
-from arroyo.types import BrokerPayload, Message, Partition, Position, Topic, TPayload
+from arroyo.types import BrokerPayload, Partition, Position, Topic, TPayload
 
 logger = logging.getLogger(__name__)
 
@@ -62,7 +62,9 @@ class Consumer(Generic[TPayload], ABC):
         raise NotImplementedError
 
     @abstractmethod
-    def poll(self, timeout: Optional[float] = None) -> Optional[Message[TPayload]]:
+    def poll(
+        self, timeout: Optional[float] = None
+    ) -> Optional[BrokerPayload[TPayload]]:
         """
         Fetch a message from the consumer. If no message is available before
         the timeout, ``None`` is returned.

--- a/arroyo/backends/abstract.py
+++ b/arroyo/backends/abstract.py
@@ -5,7 +5,7 @@ from abc import ABC, abstractmethod, abstractproperty
 from concurrent.futures import Future
 from typing import Callable, Generic, Mapping, Optional, Sequence, Union
 
-from arroyo.types import Message, Partition, Position, Topic, TPayload
+from arroyo.types import BrokerPayload, Message, Partition, Position, Topic, TPayload
 
 logger = logging.getLogger(__name__)
 
@@ -62,7 +62,9 @@ class Consumer(Generic[TPayload], ABC):
         raise NotImplementedError
 
     @abstractmethod
-    def poll(self, timeout: Optional[float] = None) -> Optional[Message[TPayload]]:
+    def poll(
+        self, timeout: Optional[float] = None
+    ) -> Optional[Message[BrokerPayload[TPayload]]]:
         """
         Fetch a message from the consumer. If no message is available before
         the timeout, ``None`` is returned.
@@ -168,7 +170,7 @@ class Producer(Generic[TPayload], ABC):
     @abstractmethod
     def produce(
         self, destination: Union[Topic, Partition], payload: TPayload
-    ) -> Future[Message[TPayload]]:
+    ) -> Future[BrokerPayload[TPayload]]:
         """
         Produce to a topic or partition.
         """

--- a/arroyo/backends/kafka/consumer.py
+++ b/arroyo/backends/kafka/consumer.py
@@ -43,7 +43,7 @@ from arroyo.errors import (
     OffsetOutOfRange,
     TransportError,
 )
-from arroyo.types import BrokerPayload, Partition, Position, Topic
+from arroyo.types import BrokerValue, Partition, Position, Topic
 from arroyo.utils.concurrent import execute
 from arroyo.utils.retries import NoRetryPolicy, RetryPolicy
 
@@ -396,7 +396,7 @@ class KafkaConsumer(Consumer[KafkaPayload]):
 
     def poll(
         self, timeout: Optional[float] = None
-    ) -> Optional[BrokerPayload[KafkaPayload]]:
+    ) -> Optional[BrokerValue[KafkaPayload]]:
         """
         Return the next message available to be consumed, if one is
         available. If no message is available, this method will block up to
@@ -452,7 +452,7 @@ class KafkaConsumer(Consumer[KafkaPayload]):
                 raise ConsumerError(str(error))
 
         headers: Optional[Headers] = message.headers()
-        consumer_payload = BrokerPayload(
+        consumer_payload = BrokerValue(
             KafkaPayload(
                 message.key(),
                 message.value(),
@@ -700,7 +700,7 @@ class KafkaProducer(Producer[KafkaPayload]):
 
     def __delivery_callback(
         self,
-        future: Future[BrokerPayload[KafkaPayload]],
+        future: Future[BrokerValue[KafkaPayload]],
         payload: KafkaPayload,
         error: KafkaError,
         message: ConfluentMessage,
@@ -714,7 +714,7 @@ class KafkaProducer(Producer[KafkaPayload]):
                     raise ValueError("timestamp not available")
 
                 future.set_result(
-                    BrokerPayload(
+                    BrokerValue(
                         payload,
                         Partition(Topic(message.topic()), message.partition()),
                         message.offset(),
@@ -728,7 +728,7 @@ class KafkaProducer(Producer[KafkaPayload]):
         self,
         destination: Union[Topic, Partition],
         payload: KafkaPayload,
-    ) -> Future[BrokerPayload[KafkaPayload]]:
+    ) -> Future[BrokerValue[KafkaPayload]]:
         if self.__shutdown_requested.is_set():
             raise RuntimeError("producer has been closed")
 
@@ -743,7 +743,7 @@ class KafkaProducer(Producer[KafkaPayload]):
         else:
             raise TypeError("invalid destination type")
 
-        future: Future[BrokerPayload[KafkaPayload]] = Future()
+        future: Future[BrokerValue[KafkaPayload]] = Future()
         future.set_running_or_notify_cancel()
         produce(
             value=payload.value,

--- a/arroyo/backends/kafka/consumer.py
+++ b/arroyo/backends/kafka/consumer.py
@@ -452,7 +452,7 @@ class KafkaConsumer(Consumer[KafkaPayload]):
                 raise ConsumerError(str(error))
 
         headers: Optional[Headers] = message.headers()
-        consumer_payload = BrokerValue(
+        broker_value = BrokerValue(
             KafkaPayload(
                 message.key(),
                 message.value(),
@@ -462,9 +462,9 @@ class KafkaConsumer(Consumer[KafkaPayload]):
             message.offset(),
             datetime.utcfromtimestamp(message.timestamp()[1] / 1000.0),
         )
-        self.__offsets[consumer_payload.partition] = consumer_payload.next_offset
+        self.__offsets[broker_value.partition] = broker_value.next_offset
 
-        return consumer_payload
+        return broker_value
 
     def tell(self) -> Mapping[Partition, int]:
         """

--- a/arroyo/backends/kafka/consumer.py
+++ b/arroyo/backends/kafka/consumer.py
@@ -43,7 +43,7 @@ from arroyo.errors import (
     OffsetOutOfRange,
     TransportError,
 )
-from arroyo.types import BrokerPayload, Message, Partition, Position, Topic
+from arroyo.types import BrokerPayload, Partition, Position, Topic
 from arroyo.utils.concurrent import execute
 from arroyo.utils.retries import NoRetryPolicy, RetryPolicy
 
@@ -394,7 +394,9 @@ class KafkaConsumer(Consumer[KafkaPayload]):
 
         self.__consumer.unsubscribe()
 
-    def poll(self, timeout: Optional[float] = None) -> Optional[Message[KafkaPayload]]:
+    def poll(
+        self, timeout: Optional[float] = None
+    ) -> Optional[BrokerPayload[KafkaPayload]]:
         """
         Return the next message available to be consumed, if one is
         available. If no message is available, this method will block up to
@@ -460,11 +462,9 @@ class KafkaConsumer(Consumer[KafkaPayload]):
             message.offset(),
             datetime.utcfromtimestamp(message.timestamp()[1] / 1000.0),
         )
-        result = Message(consumer_payload)
-
         self.__offsets[consumer_payload.partition] = consumer_payload.next_offset
 
-        return result
+        return consumer_payload
 
     def tell(self) -> Mapping[Partition, int]:
         """

--- a/arroyo/backends/local/storages/abstract.py
+++ b/arroyo/backends/local/storages/abstract.py
@@ -2,7 +2,7 @@ from abc import ABC, abstractmethod
 from datetime import datetime
 from typing import Generic, Iterator, Optional
 
-from arroyo.types import BrokerPayload, Partition, Topic, TPayload
+from arroyo.types import BrokerValue, Partition, Topic, TPayload
 
 
 class TopicExists(Exception):
@@ -61,7 +61,7 @@ class MessageStorage(ABC, Generic[TPayload]):
     @abstractmethod
     def consume(
         self, partition: Partition, offset: int
-    ) -> Optional[BrokerPayload[TPayload]]:
+    ) -> Optional[BrokerValue[TPayload]]:
         """
         Consume a message from the provided partition, reading from the given
         offset. If no message exists at the given offset when reading from
@@ -80,7 +80,7 @@ class MessageStorage(ABC, Generic[TPayload]):
     @abstractmethod
     def produce(
         self, partition: Partition, payload: TPayload, timestamp: datetime
-    ) -> BrokerPayload[TPayload]:
+    ) -> BrokerValue[TPayload]:
         """
         Produce a single message to the provided partition.
 

--- a/arroyo/backends/local/storages/abstract.py
+++ b/arroyo/backends/local/storages/abstract.py
@@ -2,7 +2,7 @@ from abc import ABC, abstractmethod
 from datetime import datetime
 from typing import Generic, Iterator, Optional
 
-from arroyo.types import BrokerPayload, Message, Partition, Topic, TPayload
+from arroyo.types import BrokerPayload, Partition, Topic, TPayload
 
 
 class TopicExists(Exception):
@@ -59,7 +59,9 @@ class MessageStorage(ABC, Generic[TPayload]):
         raise NotImplementedError
 
     @abstractmethod
-    def consume(self, partition: Partition, offset: int) -> Optional[Message[TPayload]]:
+    def consume(
+        self, partition: Partition, offset: int
+    ) -> Optional[BrokerPayload[TPayload]]:
         """
         Consume a message from the provided partition, reading from the given
         offset. If no message exists at the given offset when reading from

--- a/arroyo/backends/local/storages/abstract.py
+++ b/arroyo/backends/local/storages/abstract.py
@@ -2,7 +2,7 @@ from abc import ABC, abstractmethod
 from datetime import datetime
 from typing import Generic, Iterator, Optional
 
-from arroyo.types import Message, Partition, Topic, TPayload
+from arroyo.types import BrokerPayload, Message, Partition, Topic, TPayload
 
 
 class TopicExists(Exception):
@@ -59,7 +59,9 @@ class MessageStorage(ABC, Generic[TPayload]):
         raise NotImplementedError
 
     @abstractmethod
-    def consume(self, partition: Partition, offset: int) -> Optional[Message[TPayload]]:
+    def consume(
+        self, partition: Partition, offset: int
+    ) -> Optional[Message[BrokerPayload[TPayload]]]:
         """
         Consume a message from the provided partition, reading from the given
         offset. If no message exists at the given offset when reading from
@@ -78,7 +80,7 @@ class MessageStorage(ABC, Generic[TPayload]):
     @abstractmethod
     def produce(
         self, partition: Partition, payload: TPayload, timestamp: datetime
-    ) -> Message[TPayload]:
+    ) -> BrokerPayload[TPayload]:
         """
         Produce a single message to the provided partition.
 

--- a/arroyo/backends/local/storages/abstract.py
+++ b/arroyo/backends/local/storages/abstract.py
@@ -59,9 +59,7 @@ class MessageStorage(ABC, Generic[TPayload]):
         raise NotImplementedError
 
     @abstractmethod
-    def consume(
-        self, partition: Partition, offset: int
-    ) -> Optional[Message[BrokerPayload[TPayload]]]:
+    def consume(self, partition: Partition, offset: int) -> Optional[Message[TPayload]]:
         """
         Consume a message from the provided partition, reading from the given
         offset. If no message exists at the given offset when reading from

--- a/arroyo/backends/local/storages/file.py
+++ b/arroyo/backends/local/storages/file.py
@@ -25,7 +25,7 @@ from arroyo.backends.local.storages.abstract import (
     TopicExists,
 )
 from arroyo.errors import OffsetOutOfRange
-from arroyo.types import BrokerPayload, Message, Partition, Position, Topic, TPayload
+from arroyo.types import BrokerPayload, Partition, Position, Topic, TPayload
 from arroyo.utils.codecs import Codec
 
 
@@ -171,7 +171,9 @@ class FileMessageStorage(MessageStorage[TPayload]):
 
         return FilePayload(payload, partition, offset, timestamp, file.tell())
 
-    def consume(self, partition: Partition, offset: int) -> Optional[Message[TPayload]]:
+    def consume(
+        self, partition: Partition, offset: int
+    ) -> Optional[BrokerPayload[TPayload]]:
         file_partition = self.__get_file_partition(partition)
         file = file_partition.reader
 
@@ -194,6 +196,4 @@ class FileMessageStorage(MessageStorage[TPayload]):
             )
         payload, timestamp = self.__codec.decode(encoded)
 
-        return Message(
-            FilePayload(payload, partition, offset, timestamp, file.tell()),
-        )
+        return FilePayload(payload, partition, offset, timestamp, file.tell())

--- a/arroyo/backends/local/storages/file.py
+++ b/arroyo/backends/local/storages/file.py
@@ -10,7 +10,6 @@ from typing import (
     Any,
     BinaryIO,
     Iterator,
-    Mapping,
     MutableMapping,
     MutableSequence,
     Optional,
@@ -25,7 +24,7 @@ from arroyo.backends.local.storages.abstract import (
     TopicExists,
 )
 from arroyo.errors import OffsetOutOfRange
-from arroyo.types import BrokerPayload, Partition, Position, Topic, TPayload
+from arroyo.types import BrokerPayload, Partition, Topic, TPayload
 from arroyo.utils.codecs import Codec
 
 
@@ -45,8 +44,8 @@ class FilePayload(BrokerPayload[TPayload]):
         self._next_offset = next_offset
 
     @property
-    def committable(self) -> Mapping[Partition, Position]:
-        return {self.partition: Position(self._next_offset, self.timestamp)}
+    def next_offset(self) -> int:
+        return self._next_offset
 
 
 class PickleCodec(Codec[bytes, Tuple[TPayload, datetime]]):

--- a/arroyo/backends/local/storages/file.py
+++ b/arroyo/backends/local/storages/file.py
@@ -24,12 +24,12 @@ from arroyo.backends.local.storages.abstract import (
     TopicExists,
 )
 from arroyo.errors import OffsetOutOfRange
-from arroyo.types import BrokerPayload, Partition, Topic, TPayload
+from arroyo.types import BrokerValue, Partition, Topic, TPayload
 from arroyo.utils.codecs import Codec
 
 
 @dataclass(unsafe_hash=True)
-class FilePayload(BrokerPayload[TPayload]):
+class FileValue(BrokerValue[TPayload]):
     _next_offset: int
 
     def __init__(
@@ -160,7 +160,7 @@ class FileMessageStorage(MessageStorage[TPayload]):
 
     def produce(
         self, partition: Partition, payload: TPayload, timestamp: datetime
-    ) -> BrokerPayload[TPayload]:
+    ) -> BrokerValue[TPayload]:
         encoded = self.__codec.encode((payload, timestamp))
         file = self.__get_file_partition(partition).writer
         offset = file.tell()
@@ -168,11 +168,11 @@ class FileMessageStorage(MessageStorage[TPayload]):
         file.write(encoded)
         file.flush()
 
-        return FilePayload(payload, partition, offset, timestamp, file.tell())
+        return FileValue(payload, partition, offset, timestamp, file.tell())
 
     def consume(
         self, partition: Partition, offset: int
-    ) -> Optional[BrokerPayload[TPayload]]:
+    ) -> Optional[BrokerValue[TPayload]]:
         file_partition = self.__get_file_partition(partition)
         file = file_partition.reader
 
@@ -195,4 +195,4 @@ class FileMessageStorage(MessageStorage[TPayload]):
             )
         payload, timestamp = self.__codec.decode(encoded)
 
-        return FilePayload(payload, partition, offset, timestamp, file.tell())
+        return FileValue(payload, partition, offset, timestamp, file.tell())

--- a/arroyo/backends/local/storages/memory.py
+++ b/arroyo/backends/local/storages/memory.py
@@ -8,7 +8,7 @@ from arroyo.backends.local.storages.abstract import (
     TopicExists,
 )
 from arroyo.errors import OffsetOutOfRange
-from arroyo.types import Message, Partition, Topic, TPayload
+from arroyo.types import BrokerPayload, Message, Partition, Position, Topic, TPayload
 
 
 class MemoryMessageStorage(MessageStorage[TPayload]):
@@ -52,7 +52,9 @@ class MemoryMessageStorage(MessageStorage[TPayload]):
         except IndexError as e:
             raise PartitionDoesNotExist(partition) from e
 
-    def consume(self, partition: Partition, offset: int) -> Optional[Message[TPayload]]:
+    def consume(
+        self, partition: Partition, offset: int
+    ) -> Optional[Message[BrokerPayload[TPayload]]]:
         messages = self.__get_messages(partition)
 
         try:
@@ -63,13 +65,17 @@ class MemoryMessageStorage(MessageStorage[TPayload]):
             else:
                 raise OffsetOutOfRange()
 
-        return Message(partition, offset, payload, timestamp)
+        return Message(
+            BrokerPayload(partition, offset, timestamp, payload),
+            {partition: Position(offset, timestamp)},
+        )
 
     def produce(
         self, partition: Partition, payload: TPayload, timestamp: datetime
-    ) -> Message[TPayload]:
+    ) -> BrokerPayload[TPayload]:
         messages = self.__get_messages(partition)
 
         offset = len(messages)
         messages.append((payload, timestamp))
-        return Message(partition, offset, payload, timestamp)
+
+        return BrokerPayload(partition, offset, timestamp, payload)

--- a/arroyo/backends/local/storages/memory.py
+++ b/arroyo/backends/local/storages/memory.py
@@ -8,7 +8,7 @@ from arroyo.backends.local.storages.abstract import (
     TopicExists,
 )
 from arroyo.errors import OffsetOutOfRange
-from arroyo.types import BrokerPayload, Message, Partition, Topic, TPayload
+from arroyo.types import BrokerPayload, Partition, Topic, TPayload
 
 
 class MemoryMessageStorage(MessageStorage[TPayload]):
@@ -52,7 +52,9 @@ class MemoryMessageStorage(MessageStorage[TPayload]):
         except IndexError as e:
             raise PartitionDoesNotExist(partition) from e
 
-    def consume(self, partition: Partition, offset: int) -> Optional[Message[TPayload]]:
+    def consume(
+        self, partition: Partition, offset: int
+    ) -> Optional[BrokerPayload[TPayload]]:
         messages = self.__get_messages(partition)
 
         try:
@@ -62,7 +64,7 @@ class MemoryMessageStorage(MessageStorage[TPayload]):
                 return None
             else:
                 raise OffsetOutOfRange()
-        return Message(BrokerPayload(payload, partition, offset, timestamp))
+        return BrokerPayload(payload, partition, offset, timestamp)
 
     def produce(
         self, partition: Partition, payload: TPayload, timestamp: datetime

--- a/arroyo/backends/local/storages/memory.py
+++ b/arroyo/backends/local/storages/memory.py
@@ -8,7 +8,7 @@ from arroyo.backends.local.storages.abstract import (
     TopicExists,
 )
 from arroyo.errors import OffsetOutOfRange
-from arroyo.types import BrokerPayload, Partition, Topic, TPayload
+from arroyo.types import BrokerValue, Partition, Topic, TPayload
 
 
 class MemoryMessageStorage(MessageStorage[TPayload]):
@@ -54,7 +54,7 @@ class MemoryMessageStorage(MessageStorage[TPayload]):
 
     def consume(
         self, partition: Partition, offset: int
-    ) -> Optional[BrokerPayload[TPayload]]:
+    ) -> Optional[BrokerValue[TPayload]]:
         messages = self.__get_messages(partition)
 
         try:
@@ -64,14 +64,14 @@ class MemoryMessageStorage(MessageStorage[TPayload]):
                 return None
             else:
                 raise OffsetOutOfRange()
-        return BrokerPayload(payload, partition, offset, timestamp)
+        return BrokerValue(payload, partition, offset, timestamp)
 
     def produce(
         self, partition: Partition, payload: TPayload, timestamp: datetime
-    ) -> BrokerPayload[TPayload]:
+    ) -> BrokerValue[TPayload]:
         messages = self.__get_messages(partition)
 
         offset = len(messages)
         messages.append((payload, timestamp))
 
-        return BrokerPayload(payload, partition, offset, timestamp)
+        return BrokerValue(payload, partition, offset, timestamp)

--- a/arroyo/backends/local/storages/memory.py
+++ b/arroyo/backends/local/storages/memory.py
@@ -8,7 +8,7 @@ from arroyo.backends.local.storages.abstract import (
     TopicExists,
 )
 from arroyo.errors import OffsetOutOfRange
-from arroyo.types import BrokerPayload, Message, Partition, Position, Topic, TPayload
+from arroyo.types import BrokerPayload, Message, Partition, Topic, TPayload
 
 
 class MemoryMessageStorage(MessageStorage[TPayload]):
@@ -52,9 +52,7 @@ class MemoryMessageStorage(MessageStorage[TPayload]):
         except IndexError as e:
             raise PartitionDoesNotExist(partition) from e
 
-    def consume(
-        self, partition: Partition, offset: int
-    ) -> Optional[Message[BrokerPayload[TPayload]]]:
+    def consume(self, partition: Partition, offset: int) -> Optional[Message[TPayload]]:
         messages = self.__get_messages(partition)
 
         try:
@@ -64,11 +62,7 @@ class MemoryMessageStorage(MessageStorage[TPayload]):
                 return None
             else:
                 raise OffsetOutOfRange()
-
-        return Message(
-            BrokerPayload(partition, offset, timestamp, payload),
-            {partition: Position(offset, timestamp)},
-        )
+        return Message(BrokerPayload(payload, partition, offset, timestamp))
 
     def produce(
         self, partition: Partition, payload: TPayload, timestamp: datetime
@@ -78,4 +72,4 @@ class MemoryMessageStorage(MessageStorage[TPayload]):
         offset = len(messages)
         messages.append((payload, timestamp))
 
-        return BrokerPayload(partition, offset, timestamp, payload)
+        return BrokerPayload(payload, partition, offset, timestamp)

--- a/arroyo/processing/processor.py
+++ b/arroyo/processing/processor.py
@@ -14,7 +14,7 @@ from arroyo.processing.strategies.abstract import (
     ProcessingStrategy,
     ProcessingStrategyFactory,
 )
-from arroyo.types import BrokerPayload, Message, Partition, Position, Topic, TPayload
+from arroyo.types import BrokerValue, Message, Partition, Position, Topic, TPayload
 from arroyo.utils.metrics import get_metrics
 
 logger = logging.getLogger(__name__)
@@ -76,7 +76,7 @@ class StreamProcessor(Generic[TPayload]):
 
         self.__processing_strategy: Optional[ProcessingStrategy[TPayload]] = None
 
-        self.__message: Optional[BrokerPayload[TPayload]] = None
+        self.__message: Optional[BrokerValue[TPayload]] = None
 
         # If the consumer is in the paused state, this is when the last call to
         # ``pause`` occurred or the time the pause metric was last recorded.

--- a/arroyo/processing/processor.py
+++ b/arroyo/processing/processor.py
@@ -14,7 +14,7 @@ from arroyo.processing.strategies.abstract import (
     ProcessingStrategy,
     ProcessingStrategyFactory,
 )
-from arroyo.types import BrokerPayload, Message, Partition, Position, Topic, TPayload
+from arroyo.types import Message, Partition, Position, Topic, TPayload
 from arroyo.utils.metrics import get_metrics
 
 logger = logging.getLogger(__name__)
@@ -67,18 +67,16 @@ class StreamProcessor(Generic[TPayload]):
         self,
         consumer: Consumer[TPayload],
         topic: Topic,
-        processor_factory: ProcessingStrategyFactory[BrokerPayload[TPayload]],
+        processor_factory: ProcessingStrategyFactory[TPayload],
         commit_policy: CommitPolicy,
     ) -> None:
         self.__consumer = consumer
         self.__processor_factory = processor_factory
         self.__metrics_buffer = MetricsBuffer()
 
-        self.__processing_strategy: Optional[
-            ProcessingStrategy[BrokerPayload[TPayload]]
-        ] = None
+        self.__processing_strategy: Optional[ProcessingStrategy[TPayload]] = None
 
-        self.__message: Optional[Message[BrokerPayload[TPayload]]] = None
+        self.__message: Optional[Message[TPayload]] = None
 
         # If the consumer is in the paused state, this is when the last call to
         # ``pause`` occurred or the time the pause metric was last recorded.

--- a/arroyo/processing/processor.py
+++ b/arroyo/processing/processor.py
@@ -14,7 +14,7 @@ from arroyo.processing.strategies.abstract import (
     ProcessingStrategy,
     ProcessingStrategyFactory,
 )
-from arroyo.types import Message, Partition, Position, Topic, TPayload
+from arroyo.types import BrokerPayload, Message, Partition, Position, Topic, TPayload
 from arroyo.utils.metrics import get_metrics
 
 logger = logging.getLogger(__name__)
@@ -67,16 +67,18 @@ class StreamProcessor(Generic[TPayload]):
         self,
         consumer: Consumer[TPayload],
         topic: Topic,
-        processor_factory: ProcessingStrategyFactory[TPayload],
+        processor_factory: ProcessingStrategyFactory[BrokerPayload[TPayload]],
         commit_policy: CommitPolicy,
     ) -> None:
         self.__consumer = consumer
         self.__processor_factory = processor_factory
         self.__metrics_buffer = MetricsBuffer()
 
-        self.__processing_strategy: Optional[ProcessingStrategy[TPayload]] = None
+        self.__processing_strategy: Optional[
+            ProcessingStrategy[BrokerPayload[TPayload]]
+        ] = None
 
-        self.__message: Optional[Message[TPayload]] = None
+        self.__message: Optional[Message[BrokerPayload[TPayload]]] = None
 
         # If the consumer is in the paused state, this is when the last call to
         # ``pause`` occurred or the time the pause metric was last recorded.

--- a/arroyo/processing/strategies/batching.py
+++ b/arroyo/processing/strategies/batching.py
@@ -140,14 +140,14 @@ class BatchProcessingStrategy(ProcessingStrategy[TPayload]):
 
         start = time.time()
 
-        payload = message.data
-        if isinstance(payload, BrokerValue):
+        value = message.value
+        if isinstance(value, BrokerValue):
             self.__metrics.timing(
                 "receive_latency",
-                (start - payload.timestamp.timestamp()) * 1000,
+                (start - value.timestamp.timestamp()) * 1000,
                 tags={
-                    "topic": payload.partition.topic.name,
-                    "partition": str(payload.partition.index),
+                    "topic": value.partition.topic.name,
+                    "partition": str(value.partition.index),
                 },
             )
 

--- a/arroyo/processing/strategies/batching.py
+++ b/arroyo/processing/strategies/batching.py
@@ -17,7 +17,7 @@ from typing import (
 )
 
 from arroyo.processing.strategies.abstract import ProcessingStrategy
-from arroyo.types import BrokerPayload, Message, Partition, Position, TPayload
+from arroyo.types import BrokerValue, Message, Partition, Position, TPayload
 from arroyo.utils.metrics import get_metrics
 
 logger = logging.getLogger(__name__)
@@ -141,7 +141,7 @@ class BatchProcessingStrategy(ProcessingStrategy[TPayload]):
         start = time.time()
 
         payload = message.data
-        if isinstance(payload, BrokerPayload):
+        if isinstance(payload, BrokerValue):
             self.__metrics.timing(
                 "receive_latency",
                 (start - payload.timestamp.timestamp()) * 1000,

--- a/arroyo/processing/strategies/dead_letter_queue/policies/produce.py
+++ b/arroyo/processing/strategies/dead_letter_queue/policies/produce.py
@@ -12,7 +12,7 @@ from arroyo.processing.strategies.dead_letter_queue.invalid_messages import (
 from arroyo.processing.strategies.dead_letter_queue.policies.abstract import (
     DeadLetterQueuePolicy,
 )
-from arroyo.types import Message, Topic
+from arroyo.types import BrokerPayload, Topic
 from arroyo.utils.metrics import get_metrics
 
 MAX_QUEUE_SIZE = 5000
@@ -30,7 +30,7 @@ class ProduceInvalidMessagePolicy(DeadLetterQueuePolicy):
         self.__metrics = get_metrics()
         self.__dead_letter_topic = dead_letter_topic
         self.__producer = producer
-        self.__futures: Deque[Future[Message[KafkaPayload]]] = deque()
+        self.__futures: Deque[Future[BrokerPayload[KafkaPayload]]] = deque()
 
     def handle_invalid_messages(self, e: InvalidMessages) -> None:
         """

--- a/arroyo/processing/strategies/dead_letter_queue/policies/produce.py
+++ b/arroyo/processing/strategies/dead_letter_queue/policies/produce.py
@@ -12,7 +12,7 @@ from arroyo.processing.strategies.dead_letter_queue.invalid_messages import (
 from arroyo.processing.strategies.dead_letter_queue.policies.abstract import (
     DeadLetterQueuePolicy,
 )
-from arroyo.types import BrokerPayload, Topic
+from arroyo.types import BrokerValue, Topic
 from arroyo.utils.metrics import get_metrics
 
 MAX_QUEUE_SIZE = 5000
@@ -30,7 +30,7 @@ class ProduceInvalidMessagePolicy(DeadLetterQueuePolicy):
         self.__metrics = get_metrics()
         self.__dead_letter_topic = dead_letter_topic
         self.__producer = producer
-        self.__futures: Deque[Future[BrokerPayload[KafkaPayload]]] = deque()
+        self.__futures: Deque[Future[BrokerValue[KafkaPayload]]] = deque()
 
     def handle_invalid_messages(self, e: InvalidMessages) -> None:
         """

--- a/arroyo/processing/strategies/produce.py
+++ b/arroyo/processing/strategies/produce.py
@@ -8,14 +8,14 @@ from arroyo.backends.abstract import Producer
 from arroyo.processing.strategies.abstract import MessageRejected, ProcessingStrategy
 from arroyo.processing.strategies.commit import CommitOffsets
 from arroyo.types import (
-    BrokerPayload,
+    BrokerValue,
     Commit,
     Message,
     Partition,
-    Payload,
     Position,
     Topic,
     TPayload,
+    Value,
 )
 
 logger = logging.getLogger(__name__)
@@ -56,7 +56,7 @@ class Produce(ProcessingStrategy[TPayload]):
         self.__max_buffer_size = max_buffer_size
 
         self.__queue: Deque[
-            Tuple[Mapping[Partition, Position], Future[BrokerPayload[TPayload]]]
+            Tuple[Mapping[Partition, Position], Future[BrokerValue[TPayload]]]
         ] = deque()
 
         self.__closed = False
@@ -68,7 +68,7 @@ class Produce(ProcessingStrategy[TPayload]):
             if not future.done():
                 break
 
-            message = Message(Payload(future.result().payload, committable))
+            message = Message(Value(future.result().payload, committable))
 
             self.__queue.popleft()
             self.__next_step.poll()
@@ -108,7 +108,7 @@ class Produce(ProcessingStrategy[TPayload]):
 
             committable, future = self.__queue.popleft()
 
-            message = Message(Payload(future.result().payload, committable))
+            message = Message(Value(future.result().payload, committable))
 
             self.__next_step.poll()
             self.__next_step.submit(message)

--- a/arroyo/processing/strategies/run_task.py
+++ b/arroyo/processing/strategies/run_task.py
@@ -73,7 +73,7 @@ class RunTaskInThreads(ProcessingStrategy[TPayload], Generic[TPayload, TResult])
 
             self.__queue.popleft()
 
-            payload = message.data.replace(result)
+            payload = message.value.replace(result)
 
             next_message = Message(payload)
 
@@ -93,7 +93,7 @@ class RunTaskInThreads(ProcessingStrategy[TPayload], Generic[TPayload, TResult])
 
             result = future.result(remaining)
 
-            payload = message.data.replace(result)
+            payload = message.value.replace(result)
 
             next_message = Message(payload)
             self.__next_step.poll()

--- a/arroyo/processing/strategies/transform.py
+++ b/arroyo/processing/strategies/transform.py
@@ -66,8 +66,8 @@ class TransformStep(ProcessingStep[TPayload]):
         assert not self.__closed
 
         result = self.__transform_function(message)
-        payload = message.data.replace(result)
-        self.__next_step.submit(Message(payload))
+        value = message.value.replace(result)
+        self.__next_step.submit(Message(value))
 
     def close(self) -> None:
         self.__closed = True

--- a/arroyo/processing/strategies/transform.py
+++ b/arroyo/processing/strategies/transform.py
@@ -273,7 +273,7 @@ def parallel_transform_worker_apply(
             raise
 
         try:
-            payload = message.data.replace(result)
+            payload = message.value.replace(result)
             valid_messages_transformed.append(Message(payload))
         except ValueTooLarge:
             # If the output batch cannot accept the transformed message when

--- a/arroyo/processing/strategies/transform.py
+++ b/arroyo/processing/strategies/transform.py
@@ -29,7 +29,7 @@ from arroyo.processing.strategies.dead_letter_queue.invalid_messages import (
     InvalidMessage,
     InvalidMessages,
 )
-from arroyo.types import BatchPayload, BrokerPayload, Message, Payload, TPayload
+from arroyo.types import BrokerPayload, Message, Payload, TPayload
 from arroyo.utils.metrics import Gauge, get_metrics
 
 logger = logging.getLogger(__name__)
@@ -75,8 +75,8 @@ class TransformStep(ProcessingStep[TPayload]):
             )
             self.__next_step.submit(Message(broker_payload))
         else:
-            batch_payload = BatchPayload(result, message.committable)
-            self.__next_step.submit(Message(batch_payload))
+            payload = Payload(result, message.committable)
+            self.__next_step.submit(Message(payload))
 
     def close(self) -> None:
         self.__closed = True
@@ -291,7 +291,7 @@ def parallel_transform_worker_apply(
                     message.data.timestamp,
                 )
             else:
-                payload = BatchPayload(result, message.committable)
+                payload = Payload(result, message.committable)
 
             valid_messages_transformed.append(Message(payload))
         except ValueTooLarge:

--- a/arroyo/processing/strategies/transform.py
+++ b/arroyo/processing/strategies/transform.py
@@ -29,7 +29,7 @@ from arroyo.processing.strategies.dead_letter_queue.invalid_messages import (
     InvalidMessage,
     InvalidMessages,
 )
-from arroyo.types import BatchPayload, BrokerPayload, Committable, Message, TPayload
+from arroyo.types import BatchPayload, BrokerPayload, Message, Payload, TPayload
 from arroyo.utils.metrics import Gauge, get_metrics
 
 logger = logging.getLogger(__name__)
@@ -282,7 +282,7 @@ def parallel_transform_worker_apply(
             raise
 
         try:
-            payload: Committable[TTransformed]
+            payload: Payload[TTransformed]
             if isinstance(message.data, BrokerPayload):
                 payload = BrokerPayload(
                     result,

--- a/arroyo/processing/strategies/transform.py
+++ b/arroyo/processing/strategies/transform.py
@@ -67,10 +67,8 @@ class TransformStep(ProcessingStep[TPayload]):
 
         self.__next_step.submit(
             Message(
-                message.partition,
-                message.offset,
                 self.__transform_function(message),
-                message.timestamp,
+                message.committable,
             )
         )
 
@@ -278,9 +276,7 @@ def parallel_transform_worker_apply(
             raise
 
         try:
-            valid_messages_transformed.append(
-                Message(message.partition, message.offset, result, message.timestamp)
-            )
+            valid_messages_transformed.append(Message(result, message.committable))
         except ValueTooLarge:
             # If the output batch cannot accept the transformed message when
             # the batch is empty, we'll never be able to write it and should

--- a/arroyo/processing/strategies/transform.py
+++ b/arroyo/processing/strategies/transform.py
@@ -29,7 +29,7 @@ from arroyo.processing.strategies.dead_letter_queue.invalid_messages import (
     InvalidMessage,
     InvalidMessages,
 )
-from arroyo.types import BrokerPayload, Message, Payload, TPayload
+from arroyo.types import BasePayload, BrokerPayload, Message, Payload, TPayload
 from arroyo.utils.metrics import Gauge, get_metrics
 
 logger = logging.getLogger(__name__)
@@ -282,7 +282,7 @@ def parallel_transform_worker_apply(
             raise
 
         try:
-            payload: Payload[TTransformed]
+            payload: BasePayload[TTransformed]
             if isinstance(message.data, BrokerPayload):
                 payload = BrokerPayload(
                     result,

--- a/arroyo/types.py
+++ b/arroyo/types.py
@@ -60,7 +60,7 @@ class Position:
     timestamp: datetime
 
 
-@dataclass(order=True)
+@dataclass(unsafe_hash=True)
 class BrokerPayload(Generic[TPayload]):
     """
     A payload received from the consumer or producer after it is done producing.

--- a/arroyo/types.py
+++ b/arroyo/types.py
@@ -26,23 +26,13 @@ class Partition:
 TPayload = TypeVar("TPayload")
 
 
-class Payload(Generic[TPayload]):
-    @property
-    def payload(self) -> TPayload:
-        pass
-
-    @property
-    def committable(self) -> Mapping[Partition, Position]:
-        pass
-
-
 @dataclass(unsafe_hash=True)
 class Message(Generic[TPayload]):
     """
     Contains a payload and partitions to be committed after processing.
     Can either represent a single message from a Kafka broker (BrokerPayload)
-    or a number of messages grouped together for a batch processing step
-    (BatchPayload).
+    or something else, such as a number of messages grouped together for a
+    batch processing step (Payload).
     """
 
     __slots__ = ["data"]
@@ -90,7 +80,7 @@ class Position:
 
 
 @dataclass(unsafe_hash=True)
-class BatchPayload(Payload[TPayload]):
+class Payload(Generic[TPayload]):
     """
     Any other payload that may not map 1:1 to a single message from a
     consumer. May represent a batch spanning many partitions.

--- a/arroyo/types.py
+++ b/arroyo/types.py
@@ -26,7 +26,7 @@ class Partition:
 T = TypeVar("T", covariant=True)
 
 
-class Committable(Protocol[T]):
+class Payload(Protocol[T]):
     @property
     def payload(self) -> T:
         pass
@@ -50,11 +50,11 @@ class Message(Generic[TPayload]):
 
     __slots__ = ["data"]
 
-    data: Committable[TPayload]
+    data: Payload[TPayload]
 
     def __init__(
         self,
-        data: Committable[TPayload],
+        data: Payload[TPayload],
     ) -> None:
         self.data = data
 
@@ -93,7 +93,7 @@ class Position:
 
 
 @dataclass(unsafe_hash=True)
-class BatchPayload(Committable[TPayload]):
+class BatchPayload(Payload[TPayload]):
     """
     Any other payload that may not map 1:1 to a single message from a
     consumer. May represent a batch spanning many partitions.
@@ -119,7 +119,7 @@ class BatchPayload(Committable[TPayload]):
 
 
 @dataclass(unsafe_hash=True)
-class BrokerPayload(Committable[TPayload]):
+class BrokerPayload(Payload[TPayload]):
     """
     A payload received from the consumer or producer after it is done producing.
     Partition, offset, and timestamp values are present.

--- a/arroyo/types.py
+++ b/arroyo/types.py
@@ -32,31 +32,46 @@ class Message(Generic[TPayload]):
     Represents a single message within a partition.
     """
 
-    __slots__ = ["partition", "offset", "payload", "timestamp"]
+    __slots__ = ["payload", "committable"]
 
-    partition: Partition
-    offset: int
     payload: TPayload
-    timestamp: datetime
+    committable: Mapping[Partition, Position]
 
     def __init__(
         self,
-        partition: Partition,
-        offset: int,
         payload: TPayload,
-        timestamp: datetime,
+        committable: Mapping[Partition, Position],
     ) -> None:
-        self.partition = partition
-        self.offset = offset
         self.payload = payload
-        self.timestamp = timestamp
+        self.committable = committable
 
     def __repr__(self) -> str:
         # XXX: Field values can't be excluded from ``__repr__`` with
         # ``dataclasses.field(repr=False)`` as this class is defined with
         # ``__slots__`` for performance reasons. The class variable names
         # would conflict with the instance slot names, causing an error.
-        return f"{type(self).__name__}(partition={self.partition!r}, offset={self.offset!r})"
+        return f"{type(self).__name__}({self.committable!r})"
+
+
+@dataclass(order=True, unsafe_hash=True)
+class Position:
+    __slots__ = ["offset", "timestamp"]
+    offset: int
+    timestamp: datetime
+
+
+@dataclass(order=True)
+class BrokerPayload(Generic[TPayload]):
+    """
+    A payload received from the consumer or producer after it is done producing.
+    Partition, offset, and timestamp values are present.
+    """
+
+    __slots__ = ["partition", "offset", "timestamp", "payload"]
+    partition: Partition
+    offset: int
+    timestamp: datetime
+    payload: TPayload
 
     @property
     def next_offset(self) -> int:
@@ -65,13 +80,6 @@ class Message(Generic[TPayload]):
     @property
     def position_to_commit(self) -> Position:
         return Position(self.next_offset, self.timestamp)
-
-
-@dataclass(frozen=True)
-class Position:
-    __slots__ = ["offset", "timestamp"]
-    offset: int
-    timestamp: datetime
 
 
 class Commit(Protocol):

--- a/arroyo/types.py
+++ b/arroyo/types.py
@@ -23,20 +23,17 @@ class Partition:
     index: int
 
 
-T = TypeVar("T", covariant=True)
+TPayload = TypeVar("TPayload")
 
 
-class Payload(Protocol[T]):
+class Payload(Generic[TPayload]):
     @property
-    def payload(self) -> T:
+    def payload(self) -> TPayload:
         pass
 
     @property
     def committable(self) -> Mapping[Partition, Position]:
         pass
-
-
-TPayload = TypeVar("TPayload")
 
 
 @dataclass(unsafe_hash=True)

--- a/arroyo/types.py
+++ b/arroyo/types.py
@@ -37,11 +37,11 @@ class Message(Generic[TPayload]):
 
     __slots__ = ["data"]
 
-    data: Payload[TPayload]
+    data: BasePayload[TPayload]
 
     def __init__(
         self,
-        data: Payload[TPayload],
+        data: BasePayload[TPayload],
     ) -> None:
         self.data = data
 
@@ -79,8 +79,18 @@ class Position:
             object.__setattr__(self, slot, value)
 
 
+class BasePayload(Generic[TPayload]):
+    @property
+    def payload(self) -> TPayload:
+        pass
+
+    @property
+    def committable(self) -> Mapping[Partition, Position]:
+        pass
+
+
 @dataclass(unsafe_hash=True)
-class Payload(Generic[TPayload]):
+class Payload(BasePayload[TPayload]):
     """
     Any other payload that may not map 1:1 to a single message from a
     consumer. May represent a batch spanning many partitions.
@@ -106,7 +116,7 @@ class Payload(Generic[TPayload]):
 
 
 @dataclass(unsafe_hash=True)
-class BrokerPayload(Payload[TPayload]):
+class BrokerPayload(BasePayload[TPayload]):
     """
     A payload received from the consumer or producer after it is done producing.
     Partition, offset, and timestamp values are present.

--- a/arroyo/types.py
+++ b/arroyo/types.py
@@ -39,7 +39,7 @@ class Message(Generic[TPayload]):
 
     __slots__ = ["value"]
 
-    data: BaseValue[TPayload]
+    value: BaseValue[TPayload]
 
     def __init__(
         self,

--- a/examples/transform_and_produce/__init__.py
+++ b/examples/transform_and_produce/__init__.py
@@ -9,14 +9,14 @@ from arroyo.processing.strategies.abstract import (
     ProcessingStrategy,
     ProcessingStrategyFactory,
 )
-from arroyo.types import BrokerPayload, Commit, Message, Partition, Topic
+from arroyo.types import Commit, Message, Partition, Topic
 
 logger = logging.getLogger(__name__)
 
 
-def hash_password(message: Message[BrokerPayload[KafkaPayload]]) -> KafkaPayload:
+def hash_password(message: Message[KafkaPayload]) -> KafkaPayload:
     # Expected format of the message is {"username": "<username>", "password": "<password>"}
-    auth = json.loads(message.payload.payload.value)
+    auth = json.loads(message.payload.value)
     hashed = hashlib.sha256(auth["password"].encode("utf-8")).hexdigest()
     data = json.dumps({"username": auth["username"], "password": hashed}).encode(
         "utf-8"
@@ -24,9 +24,7 @@ def hash_password(message: Message[BrokerPayload[KafkaPayload]]) -> KafkaPayload
     return KafkaPayload(key=None, value=data, headers=[])
 
 
-class HashPasswordAndProduceStrategyFactory(
-    ProcessingStrategyFactory[BrokerPayload[KafkaPayload]]
-):
+class HashPasswordAndProduceStrategyFactory(ProcessingStrategyFactory[KafkaPayload]):
     """
     A factory which builds the strategy.
 
@@ -46,7 +44,7 @@ class HashPasswordAndProduceStrategyFactory(
         self,
         commit: Commit,
         partitions: Mapping[Partition, int],
-    ) -> ProcessingStrategy[BrokerPayload[KafkaPayload]]:
+    ) -> ProcessingStrategy[KafkaPayload]:
 
         return TransformStep(
             function=hash_password,

--- a/tests/backends/mixins.py
+++ b/tests/backends/mixins.py
@@ -77,14 +77,16 @@ class StreamsTestMixin(ABC, Generic[TPayload]):
             with assert_changes(
                 lambda: assignment_callback.called, False, True
             ), assert_changes(
-                consumer.tell, {}, {Partition(topic, 0): messages[1].next_offset}
+                consumer.tell,
+                {},
+                {Partition(topic, 0): messages[1].next_offset},
             ):
                 message = consumer.poll(10.0)  # XXX: getting the subcription is slow
 
             assert isinstance(message, Message)
-            assert message.partition == Partition(topic, 0)
-            assert message.offset == messages[1].offset
-            assert message.payload == messages[1].payload
+            assert message.payload.partition == Partition(topic, 0)
+            assert message.payload.offset == messages[1].offset
+            assert message.payload == messages[1]
 
             consumer.seek({Partition(topic, 0): messages[0].offset})
             assert consumer.tell() == {Partition(topic, 0): messages[0].offset}
@@ -104,18 +106,14 @@ class StreamsTestMixin(ABC, Generic[TPayload]):
 
             message = consumer.poll(5.0)
             assert isinstance(message, Message)
-            assert message.partition == Partition(topic, 0)
-            assert message.offset == messages[0].offset
-            assert message.payload == messages[0].payload
+            assert message.payload.partition == Partition(topic, 0)
+            assert message.payload.offset == messages[0].offset
+            assert message.payload.payload == messages[0].payload
 
             assert consumer.commit_positions() == {}
 
             consumer.stage_positions(
-                {
-                    message.partition: Position(
-                        message.next_offset, messages[1].timestamp
-                    )
-                }
+                {message.payload.partition: message.payload.position_to_commit}
             )
 
             with pytest.raises(ConsumerError):
@@ -128,7 +126,9 @@ class StreamsTestMixin(ABC, Generic[TPayload]):
                 )
 
             assert consumer.commit_positions() == {
-                Partition(topic, 0): Position(message.next_offset, message.timestamp)
+                Partition(topic, 0): Position(
+                    message.payload.next_offset, message.payload.timestamp
+                )
             }
 
             assert consumer.tell() == {Partition(topic, 0): messages[1].offset}
@@ -193,15 +193,16 @@ class StreamsTestMixin(ABC, Generic[TPayload]):
 
             message = consumer.poll(10.0)  # XXX: getting the subscription is slow
             assert isinstance(message, Message)
-            assert message.partition == Partition(topic, 0)
-            assert message.offset == messages[1].offset
-            assert message.payload == messages[1].payload
+            assert message.payload.partition == Partition(topic, 0)
+            assert message.payload.offset == messages[1].offset
+            assert message.payload.payload == messages[1].payload
+            assert message.payload == messages[1]
 
             try:
                 assert consumer.poll(1.0) is None
             except EndOfPartition as error:
                 assert error.partition == Partition(topic, 0)
-                assert error.offset == message.next_offset
+                assert error.offset == message.payload.next_offset
             else:
                 raise AssertionError("expected EndOfPartition error")
 
@@ -248,6 +249,7 @@ class StreamsTestMixin(ABC, Generic[TPayload]):
             def on_assign(partitions: Mapping[Partition, int]) -> None:
                 # NOTE: This will eventually need to be controlled by a generalized
                 # consumer auto offset reset setting.
+
                 assert (
                     partitions
                     == consumer.tell()
@@ -266,64 +268,71 @@ class StreamsTestMixin(ABC, Generic[TPayload]):
             else:
                 raise Exception("assignment never received")
 
-            assert message == messages[0]
+            assert message.payload == messages[0]
 
             # The first call to ``poll`` should raise ``EndOfPartition``. It
             # should be otherwise be safe to try to read the first missing
             # offset (index) in the partition.
             with assert_does_not_change(
-                consumer.tell, {message.partition: message.next_offset}
+                consumer.tell, {message.payload.partition: message.payload.next_offset}
             ), pytest.raises(EndOfPartition):
-                consumer.poll(1.0) is None
+                assert consumer.poll(1.0) is None
 
             # It should be otherwise be safe to try to read the first missing
             # offset (index) in the partition.
             with assert_does_not_change(
-                consumer.tell, {message.partition: message.next_offset}
+                consumer.tell, {message.payload.partition: message.payload.next_offset}
             ):
                 assert consumer.poll(1.0) is None
 
             with assert_changes(
                 consumer.tell,
-                {message.partition: message.next_offset},
-                {message.partition: message.offset},
+                {message.payload.partition: message.payload.next_offset},
+                {message.payload.partition: message.payload.offset},
             ):
-                consumer.seek({message.partition: message.offset})
+                consumer.seek({message.payload.partition: message.payload.offset})
 
             with assert_changes(
                 consumer.tell,
-                {message.partition: message.offset},
-                {message.partition: message.next_offset},
+                {message.payload.partition: message.payload.offset},
+                {message.payload.partition: message.payload.next_offset},
             ):
-                assert consumer.poll(1.0) == messages[0]
+                message = consumer.poll()
+                assert message is not None
+                assert message.payload == messages[0]
 
             # Seeking beyond the first missing index should work but subsequent
             # reads should error. (We don't know if this offset is valid or not
             # until we try to fetch a message.)
             with assert_changes(
                 consumer.tell,
-                {message.partition: message.next_offset},
-                {message.partition: message.next_offset + 1},
+                {message.payload.partition: message.payload.next_offset},
+                {message.payload.partition: message.payload.next_offset + 1},
             ):
-                consumer.seek({message.partition: message.next_offset + 1})
+                consumer.seek(
+                    {message.payload.partition: message.payload.next_offset + 1}
+                )
 
             # Offsets should not be advanced after a failed poll.
             with assert_does_not_change(
-                consumer.tell, {message.partition: message.next_offset + 1}
+                consumer.tell,
+                {message.payload.partition: message.payload.next_offset + 1},
             ), pytest.raises(ConsumerError):
                 consumer.poll(1.0)
 
             # Trying to seek on an unassigned partition should error.
             with assert_does_not_change(
-                consumer.tell, {message.partition: message.next_offset + 1}
+                consumer.tell,
+                {message.payload.partition: message.payload.next_offset + 1},
             ), pytest.raises(ConsumerError):
-                consumer.seek({message.partition: 0, Partition(topic, -1): 0})
+                consumer.seek({message.payload.partition: 0, Partition(topic, -1): 0})
 
             # Trying to seek to a negative offset should error.
             with assert_does_not_change(
-                consumer.tell, {message.partition: message.next_offset + 1}
+                consumer.tell,
+                {message.payload.partition: message.payload.next_offset + 1},
             ), pytest.raises(ConsumerError):
-                consumer.seek({message.partition: -1})
+                consumer.seek({message.payload.partition: -1})
 
     def test_pause_resume(self) -> None:
         payloads = self.get_payloads()
@@ -338,7 +347,9 @@ class StreamsTestMixin(ABC, Generic[TPayload]):
 
             consumer.subscribe([topic])
 
-            assert consumer.poll(10.0) == messages[0]
+            message = consumer.poll(10.0)
+            assert message is not None
+            assert message.payload == messages[0]
             assert consumer.paused() == []
 
             # XXX: Unfortunately, there is really no way to prove that this
@@ -352,7 +363,9 @@ class StreamsTestMixin(ABC, Generic[TPayload]):
             with assert_changes(consumer.paused, [Partition(topic, 0)], []):
                 consumer.resume([Partition(topic, 0)])
 
-            assert consumer.poll(5.0) == messages[1]
+            message = consumer.poll(5.0)
+            assert message is not None
+            assert message.payload == messages[1]
 
             # Calling ``seek`` should have a side effect, even if no messages
             # are consumed before calling ``pause``.
@@ -366,7 +379,9 @@ class StreamsTestMixin(ABC, Generic[TPayload]):
                 assert consumer.poll(1.0) is None
                 consumer.resume([Partition(topic, 0)])
 
-            assert consumer.poll(5.0) == messages[3]
+            message = consumer.poll(5.0)
+            assert message is not None
+            assert message.payload == messages[3]
 
             # It is still allowable to call ``seek`` on a paused partition.
             # When consumption resumes, we would expect to see the side effect
@@ -381,7 +396,9 @@ class StreamsTestMixin(ABC, Generic[TPayload]):
                 assert consumer.poll(1.0) is None
                 consumer.resume([Partition(topic, 0)])
 
-            assert consumer.poll(5.0) == messages[0]
+            message = consumer.poll(5.0)
+            assert message is not None
+            assert message.payload == messages[0]
 
             with assert_does_not_change(consumer.paused, []), pytest.raises(
                 ConsumerError
@@ -417,9 +434,9 @@ class StreamsTestMixin(ABC, Generic[TPayload]):
 
             # It doesn't really matter which message is fetched first -- we
             # just want to know the assignment occurred.
-            assert (
-                consumer_a.poll(10.0) in messages
-            )  # XXX: getting the subcription is slow
+            message = consumer_a.poll(10.0)
+            assert message is not None
+            assert message.payload in messages  # XXX: getting the subcription is slow
 
             assert len(consumer_a.tell()) == 2
             assert len(consumer_b.tell()) == 0

--- a/tests/backends/mixins.py
+++ b/tests/backends/mixins.py
@@ -425,9 +425,8 @@ class StreamsTestMixin(ABC, Generic[TPayload]):
 
             # It doesn't really matter which message is fetched first -- we
             # just want to know the assignment occurred.
-            message = consumer_a.poll(10.0)
-            assert message is not None
-            assert message.payload in messages  # XXX: getting the subcription is slow
+            payload = consumer_a.poll(10.0)
+            assert payload in messages  # XXX: getting the subcription is slow
 
             assert len(consumer_a.tell()) == 2
             assert len(consumer_b.tell()) == 0

--- a/tests/backends/mixins.py
+++ b/tests/backends/mixins.py
@@ -82,6 +82,7 @@ class StreamsTestMixin(ABC, Generic[TPayload]):
                 {Partition(topic, 0): messages[1].next_offset},
             ):
                 payload = consumer.poll(10.0)  # XXX: getting the subcription is slow
+
             assert isinstance(payload, BrokerPayload)
             assert payload.committable == messages[1].committable
             assert payload.partition == Partition(topic, 0)
@@ -342,8 +343,7 @@ class StreamsTestMixin(ABC, Generic[TPayload]):
 
             consumer.subscribe([topic])
 
-            payload = consumer.poll(10.0)
-            assert payload == messages[0]
+            assert consumer.poll(10.0) == messages[0]
             assert consumer.paused() == []
 
             # XXX: Unfortunately, there is really no way to prove that this
@@ -357,8 +357,7 @@ class StreamsTestMixin(ABC, Generic[TPayload]):
             with assert_changes(consumer.paused, [Partition(topic, 0)], []):
                 consumer.resume([Partition(topic, 0)])
 
-            payload = consumer.poll(5.0)
-            assert payload == messages[1]
+            assert consumer.poll(5.0) == messages[1]
 
             # Calling ``seek`` should have a side effect, even if no messages
             # are consumed before calling ``pause``.
@@ -372,8 +371,7 @@ class StreamsTestMixin(ABC, Generic[TPayload]):
                 assert consumer.poll(1.0) is None
                 consumer.resume([Partition(topic, 0)])
 
-            payload = consumer.poll(5.0)
-            assert payload == messages[3]
+            assert consumer.poll(5.0) == messages[3]
 
             # It is still allowable to call ``seek`` on a paused partition.
             # When consumption resumes, we would expect to see the side effect
@@ -388,8 +386,7 @@ class StreamsTestMixin(ABC, Generic[TPayload]):
                 assert consumer.poll(1.0) is None
                 consumer.resume([Partition(topic, 0)])
 
-            payload = consumer.poll(5.0)
-            assert payload == messages[0]
+            assert consumer.poll(5.0) == messages[0]
 
             with assert_does_not_change(consumer.paused, []), pytest.raises(
                 ConsumerError
@@ -425,8 +422,9 @@ class StreamsTestMixin(ABC, Generic[TPayload]):
 
             # It doesn't really matter which message is fetched first -- we
             # just want to know the assignment occurred.
-            payload = consumer_a.poll(10.0)
-            assert payload in messages  # XXX: getting the subcription is slow
+            assert (
+                consumer_a.poll(10.0) in messages
+            )  # XXX: getting the subcription is slow
 
             assert len(consumer_a.tell()) == 2
             assert len(consumer_b.tell()) == 0

--- a/tests/backends/test_commit.py
+++ b/tests/backends/test_commit.py
@@ -7,7 +7,6 @@ from arroyo.types import Partition, Topic
 
 def test_encode_decode() -> None:
     topic = Topic("topic")
-
     commit_codec = CommitCodec()
 
     offset_to_commit = 5

--- a/tests/backends/test_commit.py
+++ b/tests/backends/test_commit.py
@@ -7,6 +7,7 @@ from arroyo.types import Partition, Topic
 
 def test_encode_decode() -> None:
     topic = Topic("topic")
+
     commit_codec = CommitCodec()
 
     offset_to_commit = 5

--- a/tests/backends/test_kafka.py
+++ b/tests/backends/test_kafka.py
@@ -119,7 +119,7 @@ class KafkaStreamsTestCase(StreamsTestMixin[KafkaPayload], TestCase):
 
                 message = consumer.poll(10.0)
                 assert isinstance(message, Message)
-                assert message.payload.payload.value == b"0"
+                assert message.payload.value == b"0"
 
     def test_auto_offset_reset_latest(self) -> None:
         with self.get_topic() as topic:
@@ -163,8 +163,8 @@ class KafkaStreamsTestCase(StreamsTestMixin[KafkaPayload], TestCase):
                 consumer.subscribe([topic])
                 result_message = consumer.poll(10.0)
                 assert result_message is not None
-                assert result_message.payload.payload.key == b"a"
-                assert result_message.payload.payload.value == b"0"
+                assert result_message.payload.key == b"a"
+                assert result_message.payload.value == b"0"
 
                 # make sure we reset our offset now
                 consumer.commit_positions()

--- a/tests/backends/test_kafka.py
+++ b/tests/backends/test_kafka.py
@@ -18,7 +18,7 @@ from arroyo.backends.kafka.configuration import build_kafka_configuration
 from arroyo.backends.kafka.consumer import as_kafka_configuration_bool
 from arroyo.commit import Commit
 from arroyo.errors import ConsumerError, EndOfPartition
-from arroyo.types import BrokerPayload, Partition, Position, Topic
+from arroyo.types import BrokerValue, Partition, Position, Topic
 from tests.backends.mixins import StreamsTestMixin
 
 commit_codec = CommitCodec()
@@ -117,9 +117,9 @@ class KafkaStreamsTestCase(StreamsTestMixin[KafkaPayload], TestCase):
             with closing(self.get_consumer(auto_offset_reset="earliest")) as consumer:
                 consumer.subscribe([topic])
 
-                payload = consumer.poll(10.0)
-                assert isinstance(payload, BrokerPayload)
-                assert payload.payload.value == b"0"
+                value = consumer.poll(10.0)
+                assert isinstance(value, BrokerValue)
+                assert value.payload.value == b"0"
 
     def test_auto_offset_reset_latest(self) -> None:
         with self.get_topic() as topic:

--- a/tests/backends/test_kafka.py
+++ b/tests/backends/test_kafka.py
@@ -141,7 +141,7 @@ class KafkaStreamsTestCase(StreamsTestMixin[KafkaPayload], TestCase):
         payload = KafkaPayload(b"a", b"0", [])
         with self.get_topic() as topic:
             with closing(self.get_producer()) as producer:
-                _ = producer.produce(topic, payload).result(5.0)
+                message = producer.produce(topic, payload).result(5.0)
 
             # write a nonsense offset
             with closing(self.get_consumer(strict_offset_reset=False)) as consumer:
@@ -151,7 +151,11 @@ class KafkaStreamsTestCase(StreamsTestMixin[KafkaPayload], TestCase):
                 partition = Partition(topic, 0)
 
                 consumer.stage_positions(
-                    {partition: Position(offset=1000000, timestamp=datetime.now())},
+                    {
+                        partition: Position(
+                            offset=message.offset + 1000, timestamp=message.timestamp
+                        )
+                    },
                 )
                 consumer.commit_positions()
 

--- a/tests/backends/test_kafka.py
+++ b/tests/backends/test_kafka.py
@@ -18,7 +18,7 @@ from arroyo.backends.kafka.configuration import build_kafka_configuration
 from arroyo.backends.kafka.consumer import as_kafka_configuration_bool
 from arroyo.commit import Commit
 from arroyo.errors import ConsumerError, EndOfPartition
-from arroyo.types import Message, Partition, Position, Topic
+from arroyo.types import BrokerPayload, Partition, Position, Topic
 from tests.backends.mixins import StreamsTestMixin
 
 commit_codec = CommitCodec()
@@ -117,9 +117,9 @@ class KafkaStreamsTestCase(StreamsTestMixin[KafkaPayload], TestCase):
             with closing(self.get_consumer(auto_offset_reset="earliest")) as consumer:
                 consumer.subscribe([topic])
 
-                message = consumer.poll(10.0)
-                assert isinstance(message, Message)
-                assert message.payload.value == b"0"
+                payload = consumer.poll(10.0)
+                assert isinstance(payload, BrokerPayload)
+                assert payload.payload.value == b"0"
 
     def test_auto_offset_reset_latest(self) -> None:
         with self.get_topic() as topic:

--- a/tests/processing/strategies/test_batching.py
+++ b/tests/processing/strategies/test_batching.py
@@ -11,17 +11,17 @@ from arroyo.processing.strategies.batching import (
     AbstractBatchWorker,
     BatchProcessingStrategyFactory,
 )
-from arroyo.types import Message, Topic
+from arroyo.types import BrokerPayload, Message, Topic
 
 
-class FakeWorker(AbstractBatchWorker[int, int]):
+class FakeWorker(AbstractBatchWorker[BrokerPayload[int], int]):
     def __init__(self) -> None:
         self.processed: MutableSequence[int] = []
         self.flushed: MutableSequence[Sequence[int]] = []
 
-    def process_message(self, message: Message[int]) -> int:
-        self.processed.append(message.payload)
-        return message.payload
+    def process_message(self, message: Message[BrokerPayload[int]]) -> int:
+        self.processed.append(message.payload.payload)
+        return message.payload.payload
 
     def flush_batch(self, batch: Sequence[int]) -> None:
         self.flushed.append(batch)

--- a/tests/processing/strategies/test_batching.py
+++ b/tests/processing/strategies/test_batching.py
@@ -11,17 +11,17 @@ from arroyo.processing.strategies.batching import (
     AbstractBatchWorker,
     BatchProcessingStrategyFactory,
 )
-from arroyo.types import BrokerPayload, Message, Topic
+from arroyo.types import Message, Topic
 
 
-class FakeWorker(AbstractBatchWorker[BrokerPayload[int], int]):
+class FakeWorker(AbstractBatchWorker[int, int]):
     def __init__(self) -> None:
         self.processed: MutableSequence[int] = []
         self.flushed: MutableSequence[Sequence[int]] = []
 
-    def process_message(self, message: Message[BrokerPayload[int]]) -> int:
-        self.processed.append(message.payload.payload)
-        return message.payload.payload
+    def process_message(self, message: Message[int]) -> int:
+        self.processed.append(message.payload)
+        return message.payload
 
     def flush_batch(self, batch: Sequence[int]) -> None:
         self.flushed.append(batch)

--- a/tests/processing/strategies/test_batching.py
+++ b/tests/processing/strategies/test_batching.py
@@ -7,7 +7,7 @@ from arroyo.processing.strategies.batching import (
     AbstractBatchWorker,
     BatchProcessingStrategy,
 )
-from arroyo.types import Message, Partition, Topic
+from arroyo.types import BrokerPayload, Message, Partition, Topic
 
 
 class FakeWorker(AbstractBatchWorker[int, int]):
@@ -34,7 +34,9 @@ class TestConsumer(object):
         )
 
         for i in [1, 2, 3]:
-            message = Message(Partition(topic, 0), i, i, datetime.utcnow())
+            message = Message(
+                BrokerPayload(i, Partition(topic, 0), i, datetime.utcnow())
+            )
             strategy.submit(message)
             strategy.poll()
 
@@ -62,21 +64,21 @@ class TestConsumer(object):
         )
 
         for i in [1, 2, 3]:
-            message = Message(Partition(topic, 0), i, i, t1)
+            message = Message(BrokerPayload(i, Partition(topic, 0), i, t1))
             strategy.submit(message)
 
         mock_time.return_value = time.mktime(t2.timetuple())
         strategy.poll()
 
         for i in [4, 5, 6]:
-            message = Message(Partition(topic, 0), i, i, t2)
+            message = Message(BrokerPayload(i, Partition(topic, 0), i, t2))
             strategy.submit(message)
 
         mock_time.return_value = time.mktime(t3.timetuple())
         strategy.poll()
 
         for i in [7, 8, 9]:
-            message = Message(Partition(topic, 0), i, i, t3)
+            message = Message(BrokerPayload(i, Partition(topic, 0), i, t3))
             strategy.submit(message)
             strategy.poll()
 

--- a/tests/processing/strategies/test_batching.py
+++ b/tests/processing/strategies/test_batching.py
@@ -7,7 +7,7 @@ from arroyo.processing.strategies.batching import (
     AbstractBatchWorker,
     BatchProcessingStrategy,
 )
-from arroyo.types import BrokerPayload, Message, Partition, Topic
+from arroyo.types import BrokerValue, Message, Partition, Topic
 
 
 class FakeWorker(AbstractBatchWorker[int, int]):
@@ -34,9 +34,7 @@ class TestConsumer(object):
         )
 
         for i in [1, 2, 3]:
-            message = Message(
-                BrokerPayload(i, Partition(topic, 0), i, datetime.utcnow())
-            )
+            message = Message(BrokerValue(i, Partition(topic, 0), i, datetime.utcnow()))
             strategy.submit(message)
             strategy.poll()
 
@@ -64,21 +62,21 @@ class TestConsumer(object):
         )
 
         for i in [1, 2, 3]:
-            message = Message(BrokerPayload(i, Partition(topic, 0), i, t1))
+            message = Message(BrokerValue(i, Partition(topic, 0), i, t1))
             strategy.submit(message)
 
         mock_time.return_value = time.mktime(t2.timetuple())
         strategy.poll()
 
         for i in [4, 5, 6]:
-            message = Message(BrokerPayload(i, Partition(topic, 0), i, t2))
+            message = Message(BrokerValue(i, Partition(topic, 0), i, t2))
             strategy.submit(message)
 
         mock_time.return_value = time.mktime(t3.timetuple())
         strategy.poll()
 
         for i in [7, 8, 9]:
-            message = Message(BrokerPayload(i, Partition(topic, 0), i, t3))
+            message = Message(BrokerValue(i, Partition(topic, 0), i, t3))
             strategy.submit(message)
             strategy.poll()
 

--- a/tests/processing/strategies/test_collect.py
+++ b/tests/processing/strategies/test_collect.py
@@ -10,7 +10,7 @@ import pytest
 
 from arroyo.processing.strategies import ProcessingStrategy
 from arroyo.processing.strategies.collect import CollectStep, ParallelCollectStep
-from arroyo.types import Message, Partition, Position, Topic
+from arroyo.types import BrokerPayload, Message, Partition, Position, Topic
 from tests.assertions import assert_changes, assert_does_not_change
 
 
@@ -18,7 +18,7 @@ def message_generator(
     partition: Partition, starting_offset: int = 0
 ) -> Iterator[Message[int]]:
     for i in itertools.count(starting_offset):
-        yield Message(i, {partition: Position(i + 1, datetime.now())})
+        yield Message(BrokerPayload(i, partition, i, datetime.utcnow()))
 
 
 @pytest.mark.parametrize("parallel", [0, 1])

--- a/tests/processing/strategies/test_collect.py
+++ b/tests/processing/strategies/test_collect.py
@@ -10,7 +10,7 @@ import pytest
 
 from arroyo.processing.strategies import ProcessingStrategy
 from arroyo.processing.strategies.collect import CollectStep, ParallelCollectStep
-from arroyo.types import BrokerPayload, Message, Partition, Position, Topic
+from arroyo.types import BrokerValue, Message, Partition, Position, Topic
 from tests.assertions import assert_changes, assert_does_not_change
 
 
@@ -18,7 +18,7 @@ def message_generator(
     partition: Partition, starting_offset: int = 0
 ) -> Iterator[Message[int]]:
     for i in itertools.count(starting_offset):
-        yield Message(BrokerPayload(i, partition, i, datetime.utcnow()))
+        yield Message(BrokerValue(i, partition, i, datetime.utcnow()))
 
 
 @pytest.mark.parametrize("parallel", [0, 1])

--- a/tests/processing/strategies/test_collect.py
+++ b/tests/processing/strategies/test_collect.py
@@ -4,7 +4,7 @@ from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime
 from threading import Semaphore
 from typing import Iterator, Mapping, Optional
-from unittest.mock import Mock, call
+from unittest.mock import ANY, Mock, call
 
 import pytest
 
@@ -18,7 +18,7 @@ def message_generator(
     partition: Partition, starting_offset: int = 0
 ) -> Iterator[Message[int]]:
     for i in itertools.count(starting_offset):
-        yield Message(partition, i, i, datetime.now())
+        yield Message(i, {partition: Position(i + 1, datetime.now())})
 
 
 @pytest.mark.parametrize("parallel", [0, 1])
@@ -54,9 +54,8 @@ def test_collect(parallel: int) -> None:
         collect_step.poll()
         # Give the threadpool some time to do processing
         time.sleep(1) if parallel else None
-        assert commit_function.call_args == call(
-            {partition: Position(2, second_message.timestamp)}
-        )
+
+        assert commit_function.call_args == call({partition: Position(2, ANY)})
 
     step_factory.return_value = inner_step = Mock()
 

--- a/tests/processing/strategies/test_commit.py
+++ b/tests/processing/strategies/test_commit.py
@@ -3,7 +3,7 @@ from typing import Any
 from unittest.mock import Mock
 
 from arroyo.processing.strategies.commit import CommitOffsets
-from arroyo.types import Message, Partition, Payload, Position, Topic
+from arroyo.types import Message, Partition, Position, Topic, Value
 
 
 def test_commit() -> None:
@@ -11,9 +11,7 @@ def test_commit() -> None:
     strategy: CommitOffsets[Any] = CommitOffsets(commit_func)
 
     strategy.submit(
-        Message(
-            Payload(b"", {Partition(Topic("topic"), 1): Position(5, datetime.now())})
-        )
+        Message(Value(b"", {Partition(Topic("topic"), 1): Position(5, datetime.now())}))
     )
 
     assert commit_func.call_count == 1

--- a/tests/processing/strategies/test_dead_letter_queue.py
+++ b/tests/processing/strategies/test_dead_letter_queue.py
@@ -30,7 +30,7 @@ from arroyo.processing.strategies.dead_letter_queue.policies.produce import (
 from arroyo.processing.strategies.dead_letter_queue.policies.raise_e import (
     RaiseInvalidMessagePolicy,
 )
-from arroyo.types import BrokerPayload, Message, Partition, Position, Topic
+from arroyo.types import BrokerValue, Message, Partition, Position, Topic
 
 NO_KEY = "No key"
 BAD_PAYLOAD = "Bad payload"
@@ -41,7 +41,7 @@ def kafka_message_to_invalid_kafka_message(
     message: Message[KafkaPayload], reason: str
 ) -> InvalidKafkaMessage:
     consumer_payload = message.data
-    assert isinstance(consumer_payload, BrokerPayload)
+    assert isinstance(consumer_payload, BrokerValue)
     return InvalidKafkaMessage(
         payload=consumer_payload.payload.value,
         timestamp=consumer_payload.timestamp,
@@ -155,7 +155,7 @@ def processing_step() -> ProcessingStrategy[KafkaPayload]:
 def valid_message() -> Message[KafkaPayload]:
     partition = Partition(Topic(""), 0)
     position = Position(0, NOW)
-    valid_payload = BrokerPayload(
+    valid_payload = BrokerValue(
         KafkaPayload(b"Key", b"Value", []),
         partition,
         position.offset,
@@ -168,7 +168,7 @@ def valid_message() -> Message[KafkaPayload]:
 def invalid_message_no_key() -> Message[KafkaPayload]:
     partition = Partition(Topic(""), 0)
     position = Position(0, NOW)
-    invalid_payload = BrokerPayload(
+    invalid_payload = BrokerValue(
         KafkaPayload(None, b"Value", []), partition, position.offset, position.timestamp
     )
     return Message(invalid_payload)
@@ -179,7 +179,7 @@ def invalid_message_bad_value() -> Message[KafkaPayload]:
     partition = Partition(Topic(""), 0)
     position = Position(0, NOW)
 
-    invalid_payload = BrokerPayload(
+    invalid_payload = BrokerValue(
         KafkaPayload(key=b"Key", value=b"\xff", headers=[]),
         partition,
         position.offset,

--- a/tests/processing/strategies/test_dead_letter_queue.py
+++ b/tests/processing/strategies/test_dead_letter_queue.py
@@ -350,7 +350,9 @@ def test_produce_invalid_messages(
     dlq_produce.submit(invalid_message_no_key)
     dlq_produce.submit(invalid_message_bad_value)
 
-    produced_message = consumer.poll()
+    payload = consumer.poll()
+    assert payload is not None
+    produced_message = Message(payload)
     assert_produced_message_is_expected(
         produced_message,
         {
@@ -366,7 +368,9 @@ def test_produce_invalid_messages(
         },
     )
 
-    produced_message = consumer.poll()
+    payload = consumer.poll()
+    assert payload is not None
+    produced_message = Message(payload)
     assert_produced_message_is_expected(
         produced_message,
         {

--- a/tests/processing/strategies/test_filter.py
+++ b/tests/processing/strategies/test_filter.py
@@ -2,7 +2,7 @@ from datetime import datetime
 from unittest.mock import Mock, call
 
 from arroyo.processing.strategies.filter import FilterStep
-from arroyo.types import Message, Partition, Topic
+from arroyo.types import Message, Partition, Position, Topic
 from tests.assertions import assert_changes, assert_does_not_change
 
 
@@ -14,12 +14,16 @@ def test_filter() -> None:
 
     filter_step = FilterStep(test_function, next_step)
 
-    fail_message = Message(Partition(Topic("topic"), 0), 0, False, datetime.now())
+    fail_message = Message(
+        False, {Partition(Topic("topic"), 0): Position(0, datetime.now())}
+    )
 
     with assert_does_not_change(lambda: int(next_step.submit.call_count), 0):
         filter_step.submit(fail_message)
 
-    pass_message = Message(Partition(Topic("topic"), 0), 0, True, datetime.now())
+    pass_message = Message(
+        True, {Partition(Topic("topic"), 0): Position(0, datetime.now())}
+    )
 
     with assert_changes(lambda: int(next_step.submit.call_count), 0, 1):
         filter_step.submit(pass_message)

--- a/tests/processing/strategies/test_filter.py
+++ b/tests/processing/strategies/test_filter.py
@@ -2,7 +2,7 @@ from datetime import datetime
 from unittest.mock import Mock, call
 
 from arroyo.processing.strategies.filter import FilterStep
-from arroyo.types import Message, Partition, Position, Topic
+from arroyo.types import BatchPayload, Message, Partition, Position, Topic
 from tests.assertions import assert_changes, assert_does_not_change
 
 
@@ -15,14 +15,14 @@ def test_filter() -> None:
     filter_step = FilterStep(test_function, next_step)
 
     fail_message = Message(
-        False, {Partition(Topic("topic"), 0): Position(0, datetime.now())}
+        BatchPayload(False, {Partition(Topic("topic"), 0): Position(0, datetime.now())})
     )
 
     with assert_does_not_change(lambda: int(next_step.submit.call_count), 0):
         filter_step.submit(fail_message)
 
     pass_message = Message(
-        True, {Partition(Topic("topic"), 0): Position(0, datetime.now())}
+        BatchPayload(True, {Partition(Topic("topic"), 0): Position(0, datetime.now())})
     )
 
     with assert_changes(lambda: int(next_step.submit.call_count), 0, 1):

--- a/tests/processing/strategies/test_filter.py
+++ b/tests/processing/strategies/test_filter.py
@@ -2,7 +2,7 @@ from datetime import datetime
 from unittest.mock import Mock, call
 
 from arroyo.processing.strategies.filter import FilterStep
-from arroyo.types import BatchPayload, Message, Partition, Position, Topic
+from arroyo.types import Message, Partition, Payload, Position, Topic
 from tests.assertions import assert_changes, assert_does_not_change
 
 
@@ -15,14 +15,14 @@ def test_filter() -> None:
     filter_step = FilterStep(test_function, next_step)
 
     fail_message = Message(
-        BatchPayload(False, {Partition(Topic("topic"), 0): Position(0, datetime.now())})
+        Payload(False, {Partition(Topic("topic"), 0): Position(0, datetime.now())})
     )
 
     with assert_does_not_change(lambda: int(next_step.submit.call_count), 0):
         filter_step.submit(fail_message)
 
     pass_message = Message(
-        BatchPayload(True, {Partition(Topic("topic"), 0): Position(0, datetime.now())})
+        Payload(True, {Partition(Topic("topic"), 0): Position(0, datetime.now())})
     )
 
     with assert_changes(lambda: int(next_step.submit.call_count), 0, 1):

--- a/tests/processing/strategies/test_filter.py
+++ b/tests/processing/strategies/test_filter.py
@@ -2,7 +2,7 @@ from datetime import datetime
 from unittest.mock import Mock, call
 
 from arroyo.processing.strategies.filter import FilterStep
-from arroyo.types import Message, Partition, Payload, Position, Topic
+from arroyo.types import Message, Partition, Position, Topic, Value
 from tests.assertions import assert_changes, assert_does_not_change
 
 
@@ -15,14 +15,14 @@ def test_filter() -> None:
     filter_step = FilterStep(test_function, next_step)
 
     fail_message = Message(
-        Payload(False, {Partition(Topic("topic"), 0): Position(0, datetime.now())})
+        Value(False, {Partition(Topic("topic"), 0): Position(0, datetime.now())})
     )
 
     with assert_does_not_change(lambda: int(next_step.submit.call_count), 0):
         filter_step.submit(fail_message)
 
     pass_message = Message(
-        Payload(True, {Partition(Topic("topic"), 0): Position(0, datetime.now())})
+        Value(True, {Partition(Topic("topic"), 0): Position(0, datetime.now())})
     )
 
     with assert_changes(lambda: int(next_step.submit.call_count), 0, 1):

--- a/tests/processing/strategies/test_produce.py
+++ b/tests/processing/strategies/test_produce.py
@@ -5,7 +5,7 @@ from arroyo.backends.kafka import KafkaPayload
 from arroyo.backends.local.backend import LocalBroker
 from arroyo.backends.local.storages.memory import MemoryMessageStorage
 from arroyo.processing.strategies.produce import ProduceAndCommit
-from arroyo.types import BatchPayload, Message, Partition, Position, Topic
+from arroyo.types import Message, Partition, Payload, Position, Topic
 from arroyo.utils.clock import TestingClock
 
 
@@ -26,9 +26,7 @@ def test_produce_result() -> None:
     value = b'{"something": "something"}'
     data = KafkaPayload(None, value, [])
 
-    message = Message(
-        BatchPayload(data, {Partition(orig_topic, 0): Position(1, epoch)})
-    )
+    message = Message(Payload(data, {Partition(orig_topic, 0): Position(1, epoch)}))
 
     strategy.submit(message)
 

--- a/tests/processing/strategies/test_produce.py
+++ b/tests/processing/strategies/test_produce.py
@@ -5,7 +5,7 @@ from arroyo.backends.kafka import KafkaPayload
 from arroyo.backends.local.backend import LocalBroker
 from arroyo.backends.local.storages.memory import MemoryMessageStorage
 from arroyo.processing.strategies.produce import Produce, ProduceAndCommit
-from arroyo.types import Message, Partition, Payload, Position, Topic
+from arroyo.types import Message, Partition, Position, Topic, Value
 from arroyo.utils.clock import TestingClock
 
 
@@ -26,7 +26,7 @@ def test_produce() -> None:
     value = b'{"something": "something"}'
     data = KafkaPayload(None, value, [])
 
-    message = Message(Payload(data, {Partition(orig_topic, 0): Position(1, epoch)}))
+    message = Message(Value(data, {Partition(orig_topic, 0): Position(1, epoch)}))
 
     strategy.submit(message)
 
@@ -63,7 +63,7 @@ def test_produce_and_commit() -> None:
     value = b'{"something": "something"}'
     data = KafkaPayload(None, value, [])
 
-    message = Message(Payload(data, {Partition(orig_topic, 0): Position(1, epoch)}))
+    message = Message(Value(data, {Partition(orig_topic, 0): Position(1, epoch)}))
 
     strategy.submit(message)
 

--- a/tests/processing/strategies/test_produce.py
+++ b/tests/processing/strategies/test_produce.py
@@ -5,7 +5,7 @@ from arroyo.backends.kafka import KafkaPayload
 from arroyo.backends.local.backend import LocalBroker
 from arroyo.backends.local.storages.memory import MemoryMessageStorage
 from arroyo.processing.strategies.produce import ProduceAndCommit
-from arroyo.types import Message, Partition, Position, Topic
+from arroyo.types import BatchPayload, Message, Partition, Position, Topic
 from arroyo.utils.clock import TestingClock
 
 
@@ -27,15 +27,14 @@ def test_produce_result() -> None:
     data = KafkaPayload(None, value, [])
 
     message = Message(
-        data,
-        {Partition(orig_topic, 0): Position(1, epoch)},
+        BatchPayload(data, {Partition(orig_topic, 0): Position(1, epoch)})
     )
 
     strategy.submit(message)
 
     produced_message = broker_storage.consume(Partition(result_topic, 0), 0)
     assert produced_message is not None
-    assert produced_message.payload.payload.value == value
+    assert produced_message.payload.value == value
     assert broker_storage.consume(Partition(result_topic, 0), 1) is None
     assert commit.call_count == 0
     strategy.poll()

--- a/tests/processing/strategies/test_produce.py
+++ b/tests/processing/strategies/test_produce.py
@@ -5,7 +5,7 @@ from arroyo.backends.kafka import KafkaPayload
 from arroyo.backends.local.backend import LocalBroker
 from arroyo.backends.local.storages.memory import MemoryMessageStorage
 from arroyo.processing.strategies.produce import ProduceAndCommit
-from arroyo.types import Message, Partition, Topic
+from arroyo.types import Message, Partition, Position, Topic
 from arroyo.utils.clock import TestingClock
 
 
@@ -27,17 +27,15 @@ def test_produce_result() -> None:
     data = KafkaPayload(None, value, [])
 
     message = Message(
-        Partition(orig_topic, 0),
-        1,
         data,
-        epoch,
+        {Partition(orig_topic, 0): Position(1, epoch)},
     )
 
     strategy.submit(message)
 
     produced_message = broker_storage.consume(Partition(result_topic, 0), 0)
     assert produced_message is not None
-    assert produced_message.payload.value == value
+    assert produced_message.payload.payload.value == value
     assert broker_storage.consume(Partition(result_topic, 0), 1) is None
     assert commit.call_count == 0
     strategy.poll()

--- a/tests/processing/strategies/test_run_task.py
+++ b/tests/processing/strategies/test_run_task.py
@@ -3,7 +3,7 @@ from datetime import datetime
 from unittest import mock
 
 from arroyo.processing.strategies.run_task import RunTaskInThreads
-from arroyo.types import BrokerPayload, Message, Partition, Topic
+from arroyo.types import BrokerValue, Message, Partition, Topic
 
 
 def test_run_task() -> None:
@@ -13,9 +13,9 @@ def test_run_task() -> None:
     strategy = RunTaskInThreads(mock_func, 2, 4, next_step)
     partition = Partition(Topic("topic"), 0)
 
-    strategy.submit(Message(BrokerPayload(b"hello", partition, 0, datetime.now())))
+    strategy.submit(Message(BrokerValue(b"hello", partition, 0, datetime.now())))
     strategy.poll()
-    strategy.submit(Message(BrokerPayload(b"world", partition, 1, datetime.now())))
+    strategy.submit(Message(BrokerValue(b"world", partition, 1, datetime.now())))
     strategy.poll()
 
     # Wait for async functions to finish

--- a/tests/processing/strategies/test_run_task.py
+++ b/tests/processing/strategies/test_run_task.py
@@ -3,7 +3,7 @@ from datetime import datetime
 from unittest import mock
 
 from arroyo.processing.strategies.run_task import RunTaskInThreads
-from arroyo.types import Message, Partition, Position, Topic
+from arroyo.types import BrokerPayload, Message, Partition, Topic
 
 
 def test_run_task() -> None:
@@ -13,9 +13,9 @@ def test_run_task() -> None:
     strategy = RunTaskInThreads(mock_func, 2, 4, commit_func)
     partition = Partition(Topic("topic"), 0)
 
-    strategy.submit(Message(b"hello", {partition: Position(0, datetime.now())}))
+    strategy.submit(Message(BrokerPayload(b"hello", partition, 0, datetime.now())))
     strategy.poll()
-    strategy.submit(Message(b"world", {partition: Position(1, datetime.now())}))
+    strategy.submit(Message(BrokerPayload(b"world", partition, 1, datetime.now())))
     strategy.poll()
 
     # Wait for async functions to finish

--- a/tests/processing/strategies/test_run_task.py
+++ b/tests/processing/strategies/test_run_task.py
@@ -3,7 +3,7 @@ from datetime import datetime
 from unittest import mock
 
 from arroyo.processing.strategies.run_task import RunTaskInThreads
-from arroyo.types import Message, Partition, Topic
+from arroyo.types import Message, Partition, Position, Topic
 
 
 def test_run_task() -> None:
@@ -13,9 +13,9 @@ def test_run_task() -> None:
     strategy = RunTaskInThreads(mock_func, 2, 4, commit_func)
     partition = Partition(Topic("topic"), 0)
 
-    strategy.submit(Message(partition, 0, b"hello", datetime.now()))
+    strategy.submit(Message(b"hello", {partition: Position(0, datetime.now())}))
     strategy.poll()
-    strategy.submit(Message(partition, 1, b"world", datetime.now()))
+    strategy.submit(Message(b"world", {partition: Position(1, datetime.now())}))
     strategy.poll()
 
     # Wait for async functions to finish

--- a/tests/processing/test_processor.py
+++ b/tests/processing/test_processor.py
@@ -63,7 +63,7 @@ def test_stream_processor_lifecycle() -> None:
 
     # If ``Consumer.poll`` **does** return a message, we should poll the
     # processing strategy and submit the message for processing.
-    consumer.poll.return_value = message.data
+    consumer.poll.return_value = message.value
     with assert_changes(lambda: int(strategy.poll.call_count), 1, 2), assert_changes(
         lambda: int(strategy.submit.call_count), 0, 1
     ):
@@ -73,7 +73,7 @@ def test_stream_processor_lifecycle() -> None:
     # If the message is rejected by the processing strategy, the consumer
     # should be paused and the message should be held for later.
     consumer.tell.return_value = offsets
-    consumer.poll.return_value = message.data
+    consumer.poll.return_value = message.value
     strategy.submit.side_effect = MessageRejected()
     with assert_changes(lambda: int(consumer.pause.call_count), 0, 1):
         processor._run_once()

--- a/tests/processing/test_processor.py
+++ b/tests/processing/test_processor.py
@@ -63,7 +63,7 @@ def test_stream_processor_lifecycle() -> None:
 
     # If ``Consumer.poll`` **does** return a message, we should poll the
     # processing strategy and submit the message for processing.
-    consumer.poll.return_value = message
+    consumer.poll.return_value = message.data
     with assert_changes(lambda: int(strategy.poll.call_count), 1, 2), assert_changes(
         lambda: int(strategy.submit.call_count), 0, 1
     ):
@@ -73,7 +73,7 @@ def test_stream_processor_lifecycle() -> None:
     # If the message is rejected by the processing strategy, the consumer
     # should be paused and the message should be held for later.
     consumer.tell.return_value = offsets
-    consumer.poll.return_value = message
+    consumer.poll.return_value = message.data
     strategy.submit.side_effect = MessageRejected()
     with assert_changes(lambda: int(consumer.pause.call_count), 0, 1):
         processor._run_once()

--- a/tests/processing/test_processor.py
+++ b/tests/processing/test_processor.py
@@ -11,7 +11,7 @@ from arroyo.processing.strategies.abstract import (
     ProcessingStrategy,
     ProcessingStrategyFactory,
 )
-from arroyo.types import BrokerPayload, Commit, Message, Partition, Topic
+from arroyo.types import BrokerValue, Commit, Message, Partition, Topic
 from tests.assertions import assert_changes, assert_does_not_change
 from tests.metrics import TestingMetricsBackend, Timing
 
@@ -41,7 +41,7 @@ def test_stream_processor_lifecycle() -> None:
     now = datetime.now()
     payload = 0
 
-    message = Message(BrokerPayload(payload, partition, offset, now))
+    message = Message(BrokerValue(payload, partition, offset, now))
 
     subscribe_args, subscribe_kwargs = consumer.subscribe.call_args
     assert subscribe_args[0] == [topic]
@@ -135,7 +135,7 @@ def test_stream_processor_termination_on_error() -> None:
     offset = 0
     now = datetime.now()
 
-    consumer.poll.return_value = Message(BrokerPayload(0, partition, offset, now))
+    consumer.poll.return_value = Message(BrokerValue(0, partition, offset, now))
 
     exception = NotImplementedError("error")
 
@@ -351,11 +351,11 @@ def test_stream_processor_commit_policy() -> None:
     assert run_commit_policy_test(
         topic,
         [
-            Message(BrokerPayload(0, Partition(topic, 0), 0, datetime.now())),
-            Message(BrokerPayload(0, Partition(topic, 0), 1, datetime.now())),
-            Message(BrokerPayload(0, Partition(topic, 0), 2, datetime.now())),
-            Message(BrokerPayload(0, Partition(topic, 0), 5, datetime.now())),
-            Message(BrokerPayload(0, Partition(topic, 0), 10, datetime.now())),
+            Message(BrokerValue(0, Partition(topic, 0), 0, datetime.now())),
+            Message(BrokerValue(0, Partition(topic, 0), 1, datetime.now())),
+            Message(BrokerValue(0, Partition(topic, 0), 2, datetime.now())),
+            Message(BrokerValue(0, Partition(topic, 0), 5, datetime.now())),
+            Message(BrokerValue(0, Partition(topic, 0), 10, datetime.now())),
         ],
         commit_every_second_message,
     ) == [
@@ -379,10 +379,10 @@ def test_stream_processor_commit_policy_multiple_partitions() -> None:
     assert run_commit_policy_test(
         topic,
         [
-            Message(BrokerPayload(0, Partition(topic, 0), 200, datetime.now())),
-            Message(BrokerPayload(0, Partition(topic, 1), 400, datetime.now())),
-            Message(BrokerPayload(0, Partition(topic, 0), 400, datetime.now())),
-            Message(BrokerPayload(0, Partition(topic, 1), 400, datetime.now())),
+            Message(BrokerValue(0, Partition(topic, 0), 200, datetime.now())),
+            Message(BrokerValue(0, Partition(topic, 1), 400, datetime.now())),
+            Message(BrokerValue(0, Partition(topic, 0), 400, datetime.now())),
+            Message(BrokerValue(0, Partition(topic, 1), 400, datetime.now())),
         ],
         commit_every_second_message,
     ) == [
@@ -402,7 +402,7 @@ def test_stream_processor_commit_policy_always() -> None:
 
     assert run_commit_policy_test(
         topic,
-        [Message(BrokerPayload(0, Partition(topic, 0), 200, datetime.now()))],
+        [Message(BrokerValue(0, Partition(topic, 0), 200, datetime.now()))],
         IMMEDIATE,
     ) == [
         # IMMEDIATE policy can commit on the first message (even

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -1,7 +1,7 @@
 import pickle
 from datetime import datetime
 
-from arroyo.types import BrokerPayload, Message, Partition, Payload, Position, Topic
+from arroyo.types import BrokerValue, Message, Partition, Position, Topic, Value
 
 
 def test_topic_contains_partition() -> None:
@@ -15,11 +15,11 @@ def test_message() -> None:
     now = datetime.now()
 
     # Broker payload
-    message = Message(BrokerPayload(b"", partition, 0, now))
+    message = Message(BrokerValue(b"", partition, 0, now))
     assert pickle.loads(pickle.dumps(message)) == message
 
     # Generic payload
-    message = Message(Payload(b"", {partition: Position(1, now)}))
+    message = Message(Value(b"", {partition: Position(1, now)}))
     assert pickle.loads(pickle.dumps(message)) == message
 
 
@@ -33,21 +33,21 @@ def test_position() -> None:
     _ = {position}
 
 
-def test_broker_payload() -> None:
+def test_broker_value() -> None:
     partition = Partition(Topic("topic"), 0)
     offset = 5
     now = datetime.now()
 
-    broker_payload = BrokerPayload(
+    broker_value = BrokerValue(
         b"asdf",
         partition,
         offset,
         now,
     )
 
-    assert broker_payload.committable == {partition: Position(offset + 1, now)}
+    assert broker_value.committable == {partition: Position(offset + 1, now)}
 
-    assert pickle.loads(pickle.dumps(broker_payload)) == broker_payload
+    assert pickle.loads(pickle.dumps(broker_value)) == broker_value
 
     # Hashable
-    _ = {broker_payload}
+    _ = {broker_value}

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -20,6 +20,16 @@ def test_message_pickling() -> None:
     assert pickle.loads(pickle.dumps(message)) == message
 
 
+def test_position() -> None:
+    position = Position(1, datetime.now())
+
+    # Pickleable
+    assert pickle.loads(pickle.dumps(position)) == position
+
+    # Hashable
+    _ = {position}
+
+
 def test_broker_payload() -> None:
     partition = Partition(Topic("topic"), 0)
     offset = 5
@@ -39,13 +49,3 @@ def test_broker_payload() -> None:
 
     # Hashable
     _ = {broker_payload}
-
-
-def test_position() -> None:
-    position = Position(1, datetime.now())
-
-    # Pickleable
-    assert pickle.loads(pickle.dumps(position)) == position
-
-    # Hashable
-    _ = {position}

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -1,7 +1,7 @@
 import pickle
 from datetime import datetime
 
-from arroyo.types import Message, Partition, Topic
+from arroyo.types import BrokerPayload, Message, Partition, Position, Topic
 
 
 def test_topic_contains_partition() -> None:
@@ -11,5 +11,28 @@ def test_topic_contains_partition() -> None:
 
 
 def test_message_pickling() -> None:
-    message = Message(Partition(Topic("topic"), 0), 0, b"", datetime.now())
+    partition = Partition(Topic("topic"), 0)
+    now = datetime.now()
+
+    message = Message(
+        BrokerPayload(partition, 0, now, b""), {partition: Position(0, now)}
+    )
     assert pickle.loads(pickle.dumps(message)) == message
+
+
+def test_broker_payload() -> None:
+    partition = Partition(Topic("topic"), 0)
+    offset = 5
+    now = datetime.now()
+
+    broker_payload = BrokerPayload(
+        partition,
+        offset,
+        now,
+        b"asdf",
+    )
+
+    assert broker_payload.next_offset == offset + 1
+    assert broker_payload.position_to_commit == Position(offset + 1, now)
+
+    assert pickle.loads(pickle.dumps(broker_payload)) == broker_payload

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -36,3 +36,6 @@ def test_broker_payload() -> None:
     assert broker_payload.position_to_commit == Position(offset + 1, now)
 
     assert pickle.loads(pickle.dumps(broker_payload)) == broker_payload
+
+    # Hashable
+    _ = {broker_payload}

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -1,14 +1,7 @@
 import pickle
 from datetime import datetime
 
-from arroyo.types import (
-    BatchPayload,
-    BrokerPayload,
-    Message,
-    Partition,
-    Position,
-    Topic,
-)
+from arroyo.types import BrokerPayload, Message, Partition, Payload, Position, Topic
 
 
 def test_topic_contains_partition() -> None:
@@ -25,8 +18,8 @@ def test_message() -> None:
     message = Message(BrokerPayload(b"", partition, 0, now))
     assert pickle.loads(pickle.dumps(message)) == message
 
-    # Batch payload
-    message = Message(BatchPayload(b"", {partition: Position(1, now)}))
+    # Generic payload
+    message = Message(Payload(b"", {partition: Position(1, now)}))
     assert pickle.loads(pickle.dumps(message)) == message
 
 


### PR DESCRIPTION
This is an attempt to address the problems described in https://github.com/getsentry/arroyo/issues/125. It would be a major breaking change of Arroyo's API.

Today the `Message` interface is tied to a specific broker message (with a single partition, offset and timestamp). This doesn't make a lot of sense for strategies where the Message does not actually represent a single message but a batch of messages that have been grouped together - or, really, any scenario where a message no longer maps cleanly to a single underlying message from the Kafka broker.

This solution involves splitting the `Message` interface apart into `Message` and `BrokerPayload` to better serve the two distinct purposes. Now `Message` only has a `committable` property which is a mapping of partitions and offsets. This committable allows the message to easily span partitions. Since committing offsets is generally always the last step of a processing pipeline after all processing steps are done, this remains as part of the Message interface - it needs to always be passed through to every strategy so we know which offsets to commit at the very end after we are done with all the processing steps.

However messages received from the broker actually do map to a singular partition, offset and timestamp. The separate `BrokerPayload` class is introduced to address this. The first strategy in the pipeline will get a `Message[BrokerPayload[TPayload]]`; but thereafter the user can just pass a `Message[TPayload]` so the user can choose to include or exclude the BrokerPayload fields in later steps as needed.

I think that the main downside of this approach is that we are now storing additional information in every message about the partition and offset even when we are only dealing with singular messages (the committable is separate to the message's partition and offset data).