### PR TITLE
fix: Compute offset deltas for commit policy [SNS-1863]

### DIFF
--- a/arroyo/processing/processor.py
+++ b/arroyo/processing/processor.py
@@ -84,7 +84,7 @@ class StreamProcessor(Generic[TPayload]):
 
         self.__commit_policy = commit_policy
         self.__last_committed_time: float = time.time()
-        self.__messages_since_last_commit = 0
+        self.__previous_offsets_sum = 0
 
         self.__shutdown_requested = False
 
@@ -156,10 +156,11 @@ class StreamProcessor(Generic[TPayload]):
         be used during consumer shutdown where we do not want to wait before committing.
         """
         self.__consumer.stage_positions(positions)
-        self.__messages_since_last_commit += 1
+        offsets_sum = sum(pos.offset for pos in positions.values())
+        messages_since_last_commit = offsets_sum - self.__previous_offsets_sum
 
         if force or self.__commit_policy.should_commit(
-            self.__last_committed_time, self.__messages_since_last_commit
+            self.__last_committed_time, messages_since_last_commit
         ):
             start = time.time()
             self.__consumer.commit_positions()
@@ -169,7 +170,7 @@ class StreamProcessor(Generic[TPayload]):
                 self.__consumer,
             )
             self.__last_committed_time = start
-            self.__messages_since_last_commit = 0
+            self.__previous_offsets_sum = offsets_sum
 
     def run(self) -> None:
         "The main run loop, see class docstring for more information."

--- a/arroyo/processing/processor.py
+++ b/arroyo/processing/processor.py
@@ -159,10 +159,8 @@ class StreamProcessor(Generic[TPayload]):
 
         messages_since_last_commit = 0
         for partition, pos in positions.items():
-            if partition in self.__committed_offsets:
-                messages_since_last_commit += (
-                    pos.offset - self.__committed_offsets[partition]
-                )
+            prev_offset = self.__committed_offsets.setdefault(partition, pos.offset - 1)
+            messages_since_last_commit += pos.offset - prev_offset
 
         if force or self.__commit_policy.should_commit(
             self.__last_committed_time, messages_since_last_commit

--- a/tests/processing/test_processor.py
+++ b/tests/processing/test_processor.py
@@ -334,8 +334,19 @@ def test_stream_processor_commit_policy() -> None:
     processor._run_once()
     assert commit.call_count == 1
 
-    # Test force flag
+    # Does not commit third message
     message = Message(Partition(topic, 0), 1, 0, datetime.now())
     consumer.poll.return_value = message
     processor._run_once()
     assert commit.call_count == 1
+
+    # Should always commit if we are committing more than 2 messages at once.
+    message = Message(Partition(topic, 0), 4, 0, datetime.now())
+    consumer.poll.return_value = message
+    processor._run_once()
+    assert commit.call_count == 2
+
+    message = Message(Partition(topic, 0), 8, 0, datetime.now())
+    consumer.poll.return_value = message
+    processor._run_once()
+    assert commit.call_count == 3


### PR DESCRIPTION
Commit policies make decisions based on the number of messages
committed, but we're actually passing the number of commit calls we have
dropped since the last real commit.
