### PR TITLE
feat: Remove BatchProcessingStrategyFactory from Arroyo

### DIFF
--- a/arroyo/processing/strategies/batching.py
+++ b/arroyo/processing/strategies/batching.py
@@ -16,10 +16,7 @@ from typing import (
     TypeVar,
 )
 
-from arroyo.processing.strategies.abstract import (
-    ProcessingStrategy,
-    ProcessingStrategyFactory,
-)
+from arroyo.processing.strategies.abstract import ProcessingStrategy
 from arroyo.types import Message, Partition, Position, TPayload
 from arroyo.utils.metrics import get_metrics
 
@@ -233,32 +230,3 @@ class BatchProcessingStrategy(ProcessingStrategy[TPayload]):
         logger.debug("Offset commit took %dms", commit_duration)
 
         self.__batch = None
-
-
-class BatchProcessingStrategyFactory(ProcessingStrategyFactory[TPayload]):
-    """
-    Do not use for new consumers.
-    This is deprecated and will be removed in a future version.
-    """
-
-    def __init__(
-        self,
-        worker: AbstractBatchWorker[TPayload, TResult],
-        max_batch_size: int,
-        max_batch_time: int,
-    ) -> None:
-        self.__worker = worker
-        self.__max_batch_size = max_batch_size
-        self.__max_batch_time = max_batch_time
-
-    def create_with_partitions(
-        self,
-        commit: Callable[[Mapping[Partition, Position]], None],
-        partitions: Mapping[Partition, int],
-    ) -> ProcessingStrategy[TPayload]:
-        return BatchProcessingStrategy(
-            commit,
-            self.__worker,
-            self.__max_batch_size,
-            self.__max_batch_time,
-        )

--- a/tests/processing/strategies/test_batching.py
+++ b/tests/processing/strategies/test_batching.py
@@ -1,17 +1,48 @@
 import time
 from datetime import datetime
-from typing import Any, MutableSequence, Sequence
+from typing import Any, Callable, Mapping, MutableSequence, Sequence, TypeVar
 from unittest.mock import patch
 
 from arroyo.backends.local.backend import LocalBroker as Broker
 from arroyo.backends.local.backend import LocalConsumer
 from arroyo.commit import IMMEDIATE
 from arroyo.processing.processor import StreamProcessor
+from arroyo.processing.strategies.abstract import (
+    ProcessingStrategy,
+    ProcessingStrategyFactory,
+)
 from arroyo.processing.strategies.batching import (
     AbstractBatchWorker,
-    BatchProcessingStrategyFactory,
+    BatchProcessingStrategy,
 )
-from arroyo.types import Message, Topic
+from arroyo.types import Message, Partition, Position, Topic
+
+TPayload = TypeVar("TPayload")
+TResult = TypeVar("TResult")
+
+
+class BatchProcessingStrategyFactory(ProcessingStrategyFactory[TPayload]):
+    def __init__(
+        self,
+        worker: AbstractBatchWorker[TPayload, TResult],
+        max_batch_size: int,
+        max_batch_time: int,
+    ) -> None:
+        self.__worker = worker
+        self.__max_batch_size = max_batch_size
+        self.__max_batch_time = max_batch_time
+
+    def create_with_partitions(
+        self,
+        commit: Callable[[Mapping[Partition, Position]], None],
+        partitions: Mapping[Partition, int],
+    ) -> ProcessingStrategy[TPayload]:
+        return BatchProcessingStrategy(
+            commit,
+            self.__worker,
+            self.__max_batch_size,
+            self.__max_batch_time,
+        )
 
 
 class FakeWorker(AbstractBatchWorker[int, int]):


### PR DESCRIPTION
Removes the BatchProcessingStrategyFactory from Arroyo. Eventually the underlying BatchProcessingStrategy and AbstractBatchWorker should be removed too, but these are still being used so we need to allow more time for deprecation of those.