### PR TITLE
feat: Mark ConsumerStrategyFactory/KafkaConsumerStrategyFactory deprecated

### DIFF
--- a/arroyo/processing/strategies/factory.py
+++ b/arroyo/processing/strategies/factory.py
@@ -31,6 +31,9 @@ class StreamMessageFilter(Protocol[TPayload]):
 
 class ConsumerStrategyFactory(ProcessingStrategyFactory[TPayload]):
     """
+    Do not use for new consumers.
+    This is deprecated and will be removed in a future version.
+
     Builds a four step consumer strategy consisting of dead letter queue,
     filter, transform, and collect phases.
 
@@ -155,4 +158,9 @@ class ConsumerStrategyFactory(ProcessingStrategyFactory[TPayload]):
 
 
 class KafkaConsumerStrategyFactory(ConsumerStrategyFactory[KafkaPayload]):
+    """
+    Do not use for new consumers.
+    This is deprecated and will be removed in a future version.
+    """
+
     pass


### PR DESCRIPTION
This factory should not be part of Arroyo. It represents a very specific chain of processing steps that is too specific to the Snuba usage it was originally designed for and not generic enough for this library.