### PR TITLE
feat: Introduce separate commit strategy

### DIFF
--- a/arroyo/processing/strategies/commit.py
+++ b/arroyo/processing/strategies/commit.py
@@ -1,0 +1,33 @@
+from typing import Optional
+
+from arroyo.processing.strategies.abstract import ProcessingStrategy
+from arroyo.types import Commit, Message, TPayload
+
+
+class CommitOffsets(ProcessingStrategy[TPayload]):
+    """
+    Just commits offsets.
+
+    This should always be used as the last step in a chain of processing
+    strategies. It commits offsets back to the broker after all prior
+    processing of that message is completed.
+    """
+
+    def __init__(self, commit: Commit) -> None:
+        self.__commit = commit
+
+    def poll(self) -> None:
+        pass
+
+    def submit(self, message: Message[TPayload]) -> None:
+        self.__commit({message.partition: message.position_to_commit})
+
+    def close(self) -> None:
+        pass
+
+    def terminate(self) -> None:
+        pass
+
+    def join(self, timeout: Optional[float] = None) -> None:
+        # Commit all previously staged offsets
+        self.__commit({}, force=True)

--- a/tests/processing/strategies/test_commit.py
+++ b/tests/processing/strategies/test_commit.py
@@ -1,0 +1,13 @@
+from datetime import datetime
+from typing import Any
+from unittest.mock import Mock
+
+from arroyo.processing.strategies.commit import CommitOffsets
+from arroyo.types import Message, Partition, Topic
+
+
+def test_commit() -> None:
+    commit_func = Mock()
+    strategy: CommitOffsets[Any] = CommitOffsets(commit_func)
+    strategy.submit(Message(Partition(Topic("topic"), 1), 5, b"", datetime.now()))
+    assert commit_func.call_count == 1

--- a/tests/processing/strategies/test_produce.py
+++ b/tests/processing/strategies/test_produce.py
@@ -4,12 +4,54 @@ from unittest import mock
 from arroyo.backends.kafka import KafkaPayload
 from arroyo.backends.local.backend import LocalBroker
 from arroyo.backends.local.storages.memory import MemoryMessageStorage
-from arroyo.processing.strategies.produce import ProduceAndCommit
+from arroyo.processing.strategies.produce import Produce, ProduceAndCommit
 from arroyo.types import Message, Partition, Topic
 from arroyo.utils.clock import TestingClock
 
 
-def test_produce_result() -> None:
+def test_produce() -> None:
+    epoch = datetime(1970, 1, 1)
+    orig_topic = Topic("orig-topic")
+    result_topic = Topic("result-topic")
+    clock = TestingClock()
+    broker_storage: MemoryMessageStorage[KafkaPayload] = MemoryMessageStorage()
+    broker: LocalBroker[KafkaPayload] = LocalBroker(broker_storage, clock)
+    broker.create_topic(result_topic, partitions=1)
+
+    producer = broker.get_producer()
+    next_step = mock.Mock()
+
+    strategy = Produce(producer, result_topic, next_step)
+
+    value = b'{"something": "something"}'
+    data = KafkaPayload(None, value, [])
+
+    message = Message(
+        Partition(orig_topic, 0),
+        1,
+        data,
+        epoch,
+    )
+
+    strategy.submit(message)
+
+    produced_message = broker_storage.consume(Partition(result_topic, 0), 0)
+    assert produced_message is not None
+    assert produced_message.payload.value == value
+    assert broker_storage.consume(Partition(result_topic, 0), 1) is None
+    assert next_step.submit.call_count == 0
+    assert next_step.poll.call_count == 0
+    strategy.poll()
+    assert next_step.submit.call_count == 1
+    assert next_step.poll.call_count == 1
+    strategy.submit(message)
+    strategy.poll()
+    assert next_step.submit.call_count == 2
+    assert next_step.poll.call_count == 2
+    strategy.join()
+
+
+def test_produce_and_commit() -> None:
     epoch = datetime(1970, 1, 1)
     orig_topic = Topic("orig-topic")
     result_topic = Topic("result-topic")

--- a/tests/processing/strategies/test_run_task.py
+++ b/tests/processing/strategies/test_run_task.py
@@ -8,9 +8,9 @@ from arroyo.types import Message, Partition, Topic
 
 def test_run_task() -> None:
     mock_func = mock.Mock()
-    commit_func = mock.Mock()
+    next_step = mock.Mock()
 
-    strategy = RunTaskInThreads(mock_func, 2, 4, commit_func)
+    strategy = RunTaskInThreads(mock_func, 2, 4, next_step)
     partition = Partition(Topic("topic"), 0)
 
     strategy.submit(Message(partition, 0, b"hello", datetime.now()))
@@ -22,17 +22,19 @@ def test_run_task() -> None:
     retries = 10
 
     for _i in range(0, retries):
-        if mock_func.call_count < 2 or commit_func.call_count < 2:
+        if mock_func.call_count < 2 or next_step.submit.call_count < 2:
             strategy.poll()
             time.sleep(0.1)
         else:
             break
 
     assert mock_func.call_count == 2
-    assert commit_func.call_count == 2
+    assert next_step.poll.call_count == 2
+    assert next_step.submit.call_count == 2
 
     strategy.join()
     strategy.close()
 
     assert mock_func.call_count == 2
-    assert commit_func.call_count == 3
+    assert next_step.poll.call_count == 2
+    assert next_step.submit.call_count == 2


### PR DESCRIPTION
Since Arroyo supports building consumers with at least once guarantees, committing is always the last step in a chain of processing strategies after all other actions have completed.

Many of the processing steps today include committing offsets such as `ProduceAndCommit`, `RunTaskInThreads` and `BatchProcessingStrategy`. These strategies today can only be used as a last step in a chain. On the other hand, others take a `next_step` argument  which means another step must come afterward and they cannot be the last step.

This change aims make all of the other strategies more flexible by moving committing into a separate strategy. This strategy should be the only one ever used as the last strategy in a sequence. Every other strategy will take a `next_step` and can thus be used at any stage in a sequence of strategies.

Closes https://github.com/getsentry/arroyo/issues/137.