### PR TITLE
feat: Increase log level during consumer shutdown

### DIFF
--- a/arroyo/processing/processor.py
+++ b/arroyo/processing/processor.py
@@ -94,13 +94,13 @@ class StreamProcessor(Generic[TPayload]):
                     "received unexpected revocation without active processing strategy"
                 )
 
-            logger.debug("Closing %r...", self.__processing_strategy)
+            logger.info("Closing %r...", self.__processing_strategy)
             self.__processing_strategy.close()
 
-            logger.debug("Waiting for %r to exit...", self.__processing_strategy)
+            logger.info("Waiting for %r to exit...", self.__processing_strategy)
             self.__processing_strategy.join()
 
-            logger.debug(
+            logger.info(
                 "%r exited successfully, releasing assignment.",
                 self.__processing_strategy,
             )


### PR DESCRIPTION
There were a couple of incidents recently where consumers appeared to get stuck during shutdown. We were not sure exactly where things got stuck since these messages were only logged at debug level. Increase the level to INFO.