### PR TITLE
feat: Remove ProduceAndCommit

### DIFF
--- a/arroyo/processing/strategies/__init__.py
+++ b/arroyo/processing/strategies/__init__.py
@@ -4,13 +4,15 @@ from arroyo.processing.strategies.abstract import (
     ProcessingStrategyFactory,
 )
 from arroyo.processing.strategies.collect import CollectStep, ParallelCollectStep
+from arroyo.processing.strategies.commit import CommitOffsets
 from arroyo.processing.strategies.filter import FilterStep
-from arroyo.processing.strategies.produce import ProduceAndCommit
+from arroyo.processing.strategies.produce import Produce
 from arroyo.processing.strategies.run_task import RunTaskInThreads
 from arroyo.processing.strategies.transform import ParallelTransformStep, TransformStep
 
 __all__ = [
     "CollectStep",
+    "CommitOffsets",
     "ParallelCollectStep",
     "FilterStep",
     "TransformStep",
@@ -18,6 +20,6 @@ __all__ = [
     "MessageRejected",
     "ProcessingStrategy",
     "ProcessingStrategyFactory",
-    "ProduceAndCommit",
+    "Produce",
     "RunTaskInThreads",
 ]

--- a/arroyo/processing/strategies/transform.py
+++ b/arroyo/processing/strategies/transform.py
@@ -300,8 +300,8 @@ def parallel_transform_worker_apply(
 class ParallelTransformStep(ProcessingStep[TPayload]):
     """
     Caution: MessageRejected is not properly handled by the ParallelTransform step. Exercise
-    caution if chaining this step before a strategy like `ProduceAndCommit` which raises
-    MessageRejected in order to apply backpressure.
+    caution if chaining this step before a strategy like `Produce` or `RunTaskInThreads` which
+    raise MessageRejected in order to apply backpressure.
     """
 
     def __init__(

--- a/examples/transform_and_produce/README.md
+++ b/examples/transform_and_produce/README.md
@@ -11,8 +11,8 @@ The process is fairly simple:
 - The consumer consumes messages from the `raw-topic`
 - This message is in the form `{"username": "<username>", "password": "<password>"}`
 - The message is submitted to the `TransformStrategy` which hashes the password string
-- The credentials are then submitted to the `ProduceAndCommitStep` which simply produces the given message to `hash-topic`
-- The `ProduceAndCommitStep` is also responsible for commiting the original offset back for the consumer
+- The credentials are then submitted to `Produce` which simply produces the given message to `hash-topic`
+- Finally the `CommitOffsets` step commits the original offset back for the consumer
 
 ### Usage
 

--- a/examples/transform_and_produce/__init__.py
+++ b/examples/transform_and_produce/__init__.py
@@ -4,7 +4,7 @@ import logging
 from typing import Mapping
 
 from arroyo.backends.kafka.consumer import KafkaPayload, KafkaProducer
-from arroyo.processing.strategies import ProduceAndCommit, TransformStep
+from arroyo.processing.strategies import CommitOffsets, Produce, TransformStep
 from arroyo.processing.strategies.abstract import (
     ProcessingStrategy,
     ProcessingStrategyFactory,
@@ -48,5 +48,5 @@ class HashPasswordAndProduceStrategyFactory(ProcessingStrategyFactory[KafkaPaylo
 
         return TransformStep(
             function=hash_password,
-            next_step=ProduceAndCommit(self.__producer, self.__topic, commit),
+            next_step=Produce(self.__producer, self.__topic, CommitOffsets(commit)),
         )


### PR DESCRIPTION
Now we have the `Produce` and `CommitOffsets` steps which can be easily chained together. We don't need `ProduceAndCommit` anymore.

Also updated the example to use `Produce` and `CommitOffsets`.