### PR TITLE
docs: Add docstring for MessageRejected

### DIFF
--- a/arroyo/processing/strategies/abstract.py
+++ b/arroyo/processing/strategies/abstract.py
@@ -5,6 +5,12 @@ from arroyo.types import Commit, Message, Partition, TPayload
 
 
 class MessageRejected(Exception):
+    """
+    MessageRejected should be raised in a processing strategy's submit method
+    if it is unable to keep up with the rate of incoming messages. It tells
+    the consumer to slow down and retry the message later.
+    """
+
     pass
 
 


### PR DESCRIPTION
There was some misunderstanding about when this exception should be raised. Add a docstring to help clarify.