### PR TITLE
feat: Add RunTask strategy

### DIFF
--- a/arroyo/processing/strategies/__init__.py
+++ b/arroyo/processing/strategies/__init__.py
@@ -7,7 +7,7 @@ from arroyo.processing.strategies.collect import CollectStep, ParallelCollectSte
 from arroyo.processing.strategies.commit import CommitOffsets
 from arroyo.processing.strategies.filter import FilterStep
 from arroyo.processing.strategies.produce import Produce
-from arroyo.processing.strategies.run_task import RunTaskInThreads
+from arroyo.processing.strategies.run_task import RunTask, RunTaskInThreads
 from arroyo.processing.strategies.transform import ParallelTransformStep, TransformStep
 
 __all__ = [
@@ -21,5 +21,6 @@ __all__ = [
     "ProcessingStrategy",
     "ProcessingStrategyFactory",
     "Produce",
+    "RunTask",
     "RunTaskInThreads",
 ]

--- a/arroyo/processing/strategies/run_task.py
+++ b/arroyo/processing/strategies/run_task.py
@@ -14,6 +14,42 @@ TPayload = TypeVar("TPayload")
 TResult = TypeVar("TResult")
 
 
+class RunTask(ProcessingStrategy[TPayload]):
+    """
+    Basic strategy to run a custom processing function on a message.
+    """
+
+    def __init__(
+        self,
+        function: Callable[[Message[TPayload]], TResult],
+        next_step: ProcessingStrategy[TResult],
+    ) -> None:
+        self.__function = function
+        self.__next_step = next_step
+
+    def submit(self, message: Message[TPayload]) -> None:
+        self.__next_step.submit(
+            Message(
+                message.partition,
+                message.offset,
+                self.__function(message),
+                message.timestamp,
+            )
+        )
+
+    def poll(self) -> None:
+        self.__next_step.poll()
+
+    def join(self, timeout: Optional[float] = None) -> None:
+        self.__next_step.join(timeout)
+
+    def close(self) -> None:
+        self.__next_step.close()
+
+    def terminate(self) -> None:
+        self.__next_step.terminate()
+
+
 class RunTaskInThreads(ProcessingStrategy[TPayload]):
     """
     This strategy can be used to run IO-bound tasks in parallel.

--- a/arroyo/processing/strategies/transform.py
+++ b/arroyo/processing/strategies/transform.py
@@ -29,6 +29,7 @@ from arroyo.processing.strategies.dead_letter_queue.invalid_messages import (
     InvalidMessage,
     InvalidMessages,
 )
+from arroyo.processing.strategies.run_task import RunTask
 from arroyo.types import Message, TPayload
 from arroyo.utils.metrics import Gauge, get_metrics
 
@@ -43,49 +44,16 @@ class ChildProcessTerminated(RuntimeError):
     pass
 
 
-class TransformStep(ProcessingStep[TPayload]):
+class TransformStep(RunTask[TPayload]):
     """
     Transforms a message and submits the transformed value to the next
     processing step.
+
+    This is now an alias for RunTask, which explicitly allows side effects.
+    Kept for backwards compatibility.
     """
 
-    def __init__(
-        self,
-        function: Callable[[Message[TPayload]], TTransformed],
-        next_step: ProcessingStep[TTransformed],
-    ) -> None:
-        self.__transform_function = function
-        self.__next_step = next_step
-
-        self.__closed = False
-
-    def poll(self) -> None:
-        self.__next_step.poll()
-
-    def submit(self, message: Message[TPayload]) -> None:
-        assert not self.__closed
-
-        self.__next_step.submit(
-            Message(
-                message.partition,
-                message.offset,
-                self.__transform_function(message),
-                message.timestamp,
-            )
-        )
-
-    def close(self) -> None:
-        self.__closed = True
-
-    def terminate(self) -> None:
-        self.__closed = True
-
-        logger.debug("Terminating %r...", self.__next_step)
-        self.__next_step.terminate()
-
-    def join(self, timeout: Optional[float] = None) -> None:
-        self.__next_step.close()
-        self.__next_step.join(timeout)
+    pass
 
 
 # A serialized message is composed of a pickled ``Message`` instance (bytes)

--- a/docs/source/strategies.rst
+++ b/docs/source/strategies.rst
@@ -14,6 +14,15 @@ The abstract interface to be implemented when creating a new Processing Strategy
    :undoc-members:
    :show-inheritance:
 
+Task runners
+-----------------------------
+
+Strategies to run custom processing functions.
+
+.. automodule:: arroyo.processing.strategies.run_task
+   :members:
+   :undoc-members:
+
 Transformers
 -----------------------------
 

--- a/docs/source/strategies.rst
+++ b/docs/source/strategies.rst
@@ -14,15 +14,6 @@ The abstract interface to be implemented when creating a new Processing Strategy
    :undoc-members:
    :show-inheritance:
 
-Task runners
------------------------------
-
-Strategies to run custom processing functions.
-
-.. automodule:: arroyo.processing.strategies.run_task
-   :members:
-   :undoc-members:
-
 Transformers
 -----------------------------
 

--- a/tests/processing/strategies/test_run_task.py
+++ b/tests/processing/strategies/test_run_task.py
@@ -2,11 +2,45 @@ import time
 from datetime import datetime
 from unittest import mock
 
-from arroyo.processing.strategies.run_task import RunTaskInThreads
+from arroyo.processing.strategies.run_task import RunTask, RunTaskInThreads
 from arroyo.types import Message, Partition, Topic
 
 
 def test_run_task() -> None:
+    mock_func = mock.Mock()
+    next_step = mock.Mock()
+
+    strategy = RunTask(mock_func, next_step)
+    partition = Partition(Topic("topic"), 0)
+
+    strategy.submit(Message(partition, 0, b"hello", datetime.now()))
+    strategy.poll()
+    strategy.submit(Message(partition, 1, b"world", datetime.now()))
+    strategy.poll()
+
+    # Wait for async functions to finish
+    retries = 10
+
+    for _i in range(0, retries):
+        if mock_func.call_count < 2 or next_step.submit.call_count < 2:
+            strategy.poll()
+            time.sleep(0.1)
+        else:
+            break
+
+    assert mock_func.call_count == 2
+    assert next_step.poll.call_count == 2
+    assert next_step.submit.call_count == 2
+
+    strategy.join()
+    strategy.close()
+
+    assert mock_func.call_count == 2
+    assert next_step.poll.call_count == 2
+    assert next_step.submit.call_count == 2
+
+
+def test_run_task_in_threads() -> None:
     mock_func = mock.Mock()
     next_step = mock.Mock()
 

--- a/tests/processing/strategies/test_transform.py
+++ b/tests/processing/strategies/test_transform.py
@@ -55,6 +55,7 @@ def test_transform() -> None:
     with assert_changes(lambda: int(next_step.close.call_count), 0, 1), assert_changes(
         lambda: int(next_step.join.call_count), 0, 1
     ):
+        transform_step.close()
         transform_step.join()
 
 


### PR DESCRIPTION
This is the most basic strategy that Arroyo provides. The rationale behind this addition is to make the library even simpler and reduce the amount of boilerplate for simple use cases.

Specifically, I've noticed that many people are using the BatchProcessingStrategy and AbstractBatchWorker combination almost exclusively for non batching use cases, purely because it allowed for using Arroyo without requiring a custom processing strategy. This is supposed to provide an easy replacement in those scenarios that doesn't have the downside of
unnecessarily waiting for batches to get filled.

This implementation is almost identical to the previous transform step, however RunTask explicitly allows for side effects. Now TransformStep is simply an alias for RunTask which is kept for backward compatibility and for symmetry with the ParallelTransformStep.