### PR TITLE
fix(commit_policy): Calculate elapsed timerange correctly

### DIFF
--- a/arroyo/processing/processor.py
+++ b/arroyo/processing/processor.py
@@ -162,10 +162,12 @@ class StreamProcessor(Generic[TPayload]):
             prev_offset = self.__committed_offsets.setdefault(partition, pos.offset - 1)
             messages_since_last_commit += pos.offset - prev_offset
 
+        start = time.time()
+        elapsed = start - self.__last_committed_time
+
         if force or self.__commit_policy.should_commit(
-            self.__last_committed_time, messages_since_last_commit
+            elapsed, messages_since_last_commit
         ):
-            start = time.time()
             self.__consumer.commit_positions()
             logger.debug(
                 "Waited %0.4f seconds for offsets to be committed to %r.",

--- a/tests/processing/test_processor.py
+++ b/tests/processing/test_processor.py
@@ -1,5 +1,5 @@
-from datetime import datetime
-from typing import Mapping, Optional, Sequence
+from datetime import datetime, timedelta
+from typing import Mapping, Optional, Sequence, cast
 from unittest import mock
 
 import pytest
@@ -337,7 +337,9 @@ def run_commit_policy_test(
 
     for message in given_messages:
         consumer.poll.return_value = message
-        processor._run_once()
+        message_timestamp = cast(BrokerValue[int], message.value).timestamp
+        with mock.patch("time.time", return_value=message_timestamp.timestamp()):
+            processor._run_once()
         commit_calls.append(commit.call_count)
 
     return commit_calls
@@ -411,4 +413,33 @@ def test_stream_processor_commit_policy_always() -> None:
         # Indirectly assert that an offset delta of 1 is passed to
         # the commit policy, not 0
         1
+    ]
+
+
+def test_stream_processor_commit_policy_every_two_seconds() -> None:
+    topic = Topic("topic")
+    commit_every_two_seconds = CommitPolicy(2, None)
+
+    now = datetime.now()
+
+    assert run_commit_policy_test(
+        topic,
+        [
+            Message(BrokerValue(0, Partition(topic, 0), 0, now)),
+            Message(BrokerValue(0, Partition(topic, 0), 1, now + timedelta(seconds=1))),
+            Message(BrokerValue(0, Partition(topic, 0), 2, now + timedelta(seconds=2))),
+            Message(BrokerValue(0, Partition(topic, 0), 3, now + timedelta(seconds=3))),
+            Message(BrokerValue(0, Partition(topic, 0), 4, now + timedelta(seconds=4))),
+            Message(BrokerValue(0, Partition(topic, 0), 5, now + timedelta(seconds=5))),
+            Message(BrokerValue(0, Partition(topic, 0), 6, now + timedelta(seconds=6))),
+        ],
+        commit_every_two_seconds,
+    ) == [
+        0,
+        0,
+        0,
+        1,
+        1,
+        2,
+        2,
     ]


### PR DESCRIPTION
The first argument to should_commit is a duration/timedelta, not an
absolute timestamp.

This might explain why we are seeing severe performance regression when
using commit policy.

Some tests are failing, but i wanted to open this PR early on to get
some validation that i'm not totally confused?
