### PR TITLE
ref: Improve typing of CommitOffsets strategy

### DIFF
--- a/arroyo/processing/strategies/commit.py
+++ b/arroyo/processing/strategies/commit.py
@@ -1,10 +1,10 @@
-from typing import Optional
+from typing import Any, Optional
 
 from arroyo.processing.strategies.abstract import ProcessingStrategy
-from arroyo.types import Commit, Message, TPayload
+from arroyo.types import Commit, Message
 
 
-class CommitOffsets(ProcessingStrategy[TPayload]):
+class CommitOffsets(ProcessingStrategy[Any]):
     """
     Just commits offsets.
 
@@ -19,7 +19,7 @@ class CommitOffsets(ProcessingStrategy[TPayload]):
     def poll(self) -> None:
         pass
 
-    def submit(self, message: Message[TPayload]) -> None:
+    def submit(self, message: Message[Any]) -> None:
         self.__commit(message.committable)
 
     def close(self) -> None:

--- a/tests/processing/strategies/test_commit.py
+++ b/tests/processing/strategies/test_commit.py
@@ -1,5 +1,4 @@
 from datetime import datetime
-from typing import Any
 from unittest.mock import Mock
 
 from arroyo.processing.strategies.commit import CommitOffsets
@@ -8,7 +7,7 @@ from arroyo.types import Message, Partition, Position, Topic, Value
 
 def test_commit() -> None:
     commit_func = Mock()
-    strategy: CommitOffsets[Any] = CommitOffsets(commit_func)
+    strategy = CommitOffsets(commit_func)
 
     strategy.submit(
         Message(Value(b"", {Partition(Topic("topic"), 1): Position(5, datetime.now())}))


### PR DESCRIPTION
`CommitOffsets` can accept any message payload, since it doesn't do anything with it anyway. This removes the need for users to provide unnecessary type hinting when using the CommitOffsets policy.