### PR TITLE
ref(commit_policy): Improve performance of commit policy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 .venv
 .DS_Store
 .tox
+.benchmarks/

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: install lint setup-git tests docs
+.PHONY: install lint setup-git tests benchmarks docs
 
 setup-git:
 	pip install pre-commit==2.13.0
@@ -13,6 +13,9 @@ lint:
 
 tests:
 	pytest -vv
+
+benchmarks:
+	pytest -vv --benchmark-enable --benchmark-only
 
 docs:
 	pip install -U -r ./docs-requirements.txt

--- a/arroyo/backends/kafka/consumer.py
+++ b/arroyo/backends/kafka/consumer.py
@@ -584,7 +584,7 @@ class KafkaConsumer(Consumer[KafkaPayload]):
 
         return [*self.__paused]
 
-    def stage_positions(self, offsets: Mapping[Partition, int]) -> None:
+    def stage_offsets(self, offsets: Mapping[Partition, int]) -> None:
         # This method is on an extremely hot path since it is called
         # unconditionally before any commit policies are evaluated. Therefore
         # all of the validation happens in commit_positions.

--- a/arroyo/backends/local/backend.py
+++ b/arroyo/backends/local/backend.py
@@ -314,9 +314,8 @@ class LocalConsumer(Consumer[TPayload]):
 
     def stage_offsets(self, offsets: Mapping[Partition, int]) -> None:
         with self.__lock:
-            if self.__closed:
-                raise RuntimeError("consumer is closed")
-
+            # XXX: can we remove the locking? dictionary updates might be
+            # atomic
             self.__staged_offsets.update(offsets)
 
     def commit_offsets(self) -> Mapping[Partition, int]:

--- a/arroyo/commit.py
+++ b/arroyo/commit.py
@@ -1,14 +1,18 @@
-from dataclasses import dataclass
+import time
+from dataclasses import dataclass, field
 from datetime import datetime
-from typing import Optional
+from typing import Mapping, MutableMapping, Optional
 
-from arroyo.types import Partition
+from arroyo.types import Partition, Position
 
 
-@dataclass(frozen=True)
+@dataclass
 class CommitPolicy:
     min_commit_frequency_sec: Optional[float]
     min_commit_messages: Optional[int]
+
+    __committed_offsets: MutableMapping[Partition, int] = field(default_factory=dict)
+    __last_committed_time: float = field(default_factory=time.time)
 
     def __post_init__(self) -> None:
         assert (
@@ -16,20 +20,34 @@ class CommitPolicy:
             or self.min_commit_messages is not None
         ), "Must provide either min_commit_frequency_sec or min_commit_messages"
 
-    def should_commit(self, elapsed_time: float, elapsed_messages: int) -> bool:
-        if (
-            self.min_commit_frequency_sec is not None
-            and elapsed_time >= self.min_commit_frequency_sec
-        ):
-            return True
+    def should_commit(
+        self, now: float, positions: Mapping[Partition, Position]
+    ) -> bool:
+        if self.min_commit_frequency_sec is not None:
+            elapsed = now - self.__last_committed_time
+            if elapsed >= self.min_commit_frequency_sec:
+                return True
 
-        if (
-            self.min_commit_messages is not None
-            and elapsed_messages >= self.min_commit_messages
-        ):
-            return True
+        if self.min_commit_messages is not None:
+            messages_since_last_commit = 0
+            for partition, pos in positions.items():
+                prev_offset = self.__committed_offsets.setdefault(
+                    partition, pos.offset - 1
+                )
+                messages_since_last_commit += pos.offset - prev_offset
+
+            # XXX: is it faster to do this check in the loop and
+            # potentially early-return, or do it outside and keep
+            # the loop small?
+            if messages_since_last_commit >= self.min_commit_messages:
+                return True
 
         return False
+
+    def did_commit(self, now: float, positions: Mapping[Partition, Position]) -> None:
+        self.__last_committed_time = now
+        for partition, pos in positions.items():
+            self.__committed_offsets[partition] = pos.offset
 
 
 IMMEDIATE = CommitPolicy(None, 1)

--- a/arroyo/commit.py
+++ b/arroyo/commit.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import time
 from dataclasses import dataclass, field
 from datetime import datetime
@@ -6,13 +8,10 @@ from typing import Mapping, MutableMapping, Optional
 from arroyo.types import Partition
 
 
-@dataclass
+@dataclass(frozen=True)
 class CommitPolicy:
     min_commit_frequency_sec: Optional[float]
     min_commit_messages: Optional[int]
-
-    __committed_offsets: MutableMapping[Partition, int] = field(default_factory=dict)
-    __last_committed_time: float = field(default_factory=time.time)
 
     def __post_init__(self) -> None:
         assert (
@@ -20,13 +19,24 @@ class CommitPolicy:
             or self.min_commit_messages is not None
         ), "Must provide either min_commit_frequency_sec or min_commit_messages"
 
+    def get_state_machine(self) -> CommitPolicyState:
+        return CommitPolicyState(self)
+
+
+@dataclass
+class CommitPolicyState:
+    policy: CommitPolicy
+
+    __committed_offsets: MutableMapping[Partition, int] = field(default_factory=dict)
+    __last_committed_time: float = field(default_factory=time.time)
+
     def should_commit(self, now: float, offsets: Mapping[Partition, int]) -> bool:
-        if self.min_commit_frequency_sec is not None:
+        if self.policy.min_commit_frequency_sec is not None:
             elapsed = now - self.__last_committed_time
-            if elapsed >= self.min_commit_frequency_sec:
+            if elapsed >= self.policy.min_commit_frequency_sec:
                 return True
 
-        if self.min_commit_messages is not None:
+        if self.policy.min_commit_messages is not None:
             messages_since_last_commit = 0
             for partition, pos in offsets.items():
                 prev_offset = self.__committed_offsets.setdefault(partition, pos - 1)
@@ -35,7 +45,7 @@ class CommitPolicy:
             # XXX: is it faster to do this check in the loop and
             # potentially early-return, or do it outside and keep
             # the loop small?
-            if messages_since_last_commit >= self.min_commit_messages:
+            if messages_since_last_commit >= self.policy.min_commit_messages:
                 return True
 
         return False

--- a/arroyo/processing/processor.py
+++ b/arroyo/processing/processor.py
@@ -155,6 +155,8 @@ class StreamProcessor(Generic[TPayload]):
         If force is passed, commit immediately and do not throttle. This should
         be used during consumer shutdown where we do not want to wait before committing.
         """
+        self.__consumer.stage_positions(positions)
+
         messages_since_last_commit = 0
         for partition, pos in positions.items():
             prev_offset = self.__committed_offsets.setdefault(partition, pos.offset - 1)
@@ -166,7 +168,6 @@ class StreamProcessor(Generic[TPayload]):
         if force or self.__commit_policy.should_commit(
             elapsed, messages_since_last_commit
         ):
-            self.__consumer.stage_positions(positions)
             self.__consumer.commit_positions()
             logger.debug(
                 "Waited %0.4f seconds for offsets to be committed to %r.",

--- a/arroyo/processing/processor.py
+++ b/arroyo/processing/processor.py
@@ -84,7 +84,6 @@ class StreamProcessor(Generic[TPayload]):
 
         self.__commit_policy = commit_policy
         self.__last_committed_time: float = time.time()
-        self.__pre_staged_offsets: MutableMapping[Partition, Position] = {}
         self.__committed_offsets: MutableMapping[Partition, int] = {}
 
         self.__shutdown_requested = False
@@ -156,8 +155,6 @@ class StreamProcessor(Generic[TPayload]):
         If force is passed, commit immediately and do not throttle. This should
         be used during consumer shutdown where we do not want to wait before committing.
         """
-        self.__pre_staged_offsets.update(positions)
-
         messages_since_last_commit = 0
         for partition, pos in positions.items():
             prev_offset = self.__committed_offsets.setdefault(partition, pos.offset - 1)
@@ -169,8 +166,7 @@ class StreamProcessor(Generic[TPayload]):
         if force or self.__commit_policy.should_commit(
             elapsed, messages_since_last_commit
         ):
-            self.__consumer.stage_positions(self.__pre_staged_offsets)
-            self.__pre_staged_offsets.clear()
+            self.__consumer.stage_positions(positions)
             self.__consumer.commit_positions()
             logger.debug(
                 "Waited %0.4f seconds for offsets to be committed to %r.",

--- a/arroyo/processing/processor.py
+++ b/arroyo/processing/processor.py
@@ -155,8 +155,6 @@ class StreamProcessor(Generic[TPayload]):
         If force is passed, commit immediately and do not throttle. This should
         be used during consumer shutdown where we do not want to wait before committing.
         """
-        self.__consumer.stage_positions(positions)
-
         messages_since_last_commit = 0
         for partition, pos in positions.items():
             prev_offset = self.__committed_offsets.setdefault(partition, pos.offset - 1)
@@ -168,6 +166,7 @@ class StreamProcessor(Generic[TPayload]):
         if force or self.__commit_policy.should_commit(
             elapsed, messages_since_last_commit
         ):
+            self.__consumer.stage_positions(positions)
             self.__consumer.commit_positions()
             logger.debug(
                 "Waited %0.4f seconds for offsets to be committed to %r.",

--- a/arroyo/processing/processor.py
+++ b/arroyo/processing/processor.py
@@ -82,7 +82,7 @@ class StreamProcessor(Generic[TPayload]):
         # ``pause`` occurred or the time the pause metric was last recorded.
         self.__paused_timestamp: Optional[float] = None
 
-        self.__commit_policy = commit_policy
+        self.__commit_policy_state = commit_policy.get_state_machine()
 
         self.__shutdown_requested = False
 
@@ -154,7 +154,7 @@ class StreamProcessor(Generic[TPayload]):
         self.__consumer.stage_offsets(offsets)
         now = time.time()
 
-        if force or self.__commit_policy.should_commit(
+        if force or self.__commit_policy_state.should_commit(
             now,
             offsets,
         ):
@@ -164,7 +164,7 @@ class StreamProcessor(Generic[TPayload]):
                 time.time() - now,
                 self.__consumer,
             )
-            self.__commit_policy.did_commit(now, offsets)
+            self.__commit_policy_state.did_commit(now, offsets)
 
     def run(self) -> None:
         "The main run loop, see class docstring for more information."

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+addopts = --benchmark-disable

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,3 +1,3 @@
 pytest==7.1.2
-pytest-benchmark=4.0.0
+pytest-benchmark==4.0.0
 mypy==0.961

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,2 +1,3 @@
 pytest==7.1.2
+pytest-benchmark=4.0.0
 mypy==0.961

--- a/tests/backends/mixins.py
+++ b/tests/backends/mixins.py
@@ -114,10 +114,12 @@ class StreamsTestMixin(ABC, Generic[TPayload]):
 
             consumer.stage_offsets(value.committable)
 
-            with pytest.raises(ConsumerError):
-                consumer.stage_offsets({Partition(Topic("invalid"), 0): 0})
-
             assert consumer.commit_offsets() == {Partition(topic, 0): value.next_offset}
+
+            consumer.stage_offsets({Partition(Topic("invalid"), 0): 0})
+
+            with pytest.raises(ConsumerError):
+                consumer.commit_offsets()
 
             assert consumer.tell() == {Partition(topic, 0): messages[1].offset}
 
@@ -165,8 +167,8 @@ class StreamsTestMixin(ABC, Generic[TPayload]):
             with pytest.raises(RuntimeError):
                 consumer.paused()
 
-            with pytest.raises(RuntimeError):
-                consumer.stage_offsets({})
+            # stage_positions does not validate anything
+            consumer.stage_offsets({})
 
             with pytest.raises(RuntimeError):
                 consumer.commit_offsets()

--- a/tests/processing/test_processor.py
+++ b/tests/processing/test_processor.py
@@ -441,11 +441,11 @@ def test_stream_processor_commit_policy_every_two_seconds() -> None:
     ) == [
         0,
         0,
-        0,
         1,
         1,
         2,
         2,
+        3,
     ]
 
 

--- a/tests/processing/test_processor.py
+++ b/tests/processing/test_processor.py
@@ -1,5 +1,5 @@
 from datetime import datetime, timedelta
-from typing import Mapping, Optional, Sequence, cast
+from typing import Any, Mapping, Optional, Sequence, cast
 from unittest import mock
 
 import pytest
@@ -443,3 +443,38 @@ def test_stream_processor_commit_policy_every_two_seconds() -> None:
         2,
         2,
     ]
+
+
+def test_commit_policy_bench(benchmark: Any) -> None:
+    topic = Topic("topic")
+    commit_never = CommitPolicy(1000, None)
+    now = datetime.now()
+
+    def commit_policy_never_commits() -> None:
+        run_commit_policy_test(
+            topic,
+            [
+                Message(BrokerValue(0, Partition(topic, 0), 0, now)),
+                Message(
+                    BrokerValue(0, Partition(topic, 0), 1, now + timedelta(seconds=1))
+                ),
+                Message(
+                    BrokerValue(0, Partition(topic, 0), 2, now + timedelta(seconds=2))
+                ),
+                Message(
+                    BrokerValue(0, Partition(topic, 0), 3, now + timedelta(seconds=3))
+                ),
+                Message(
+                    BrokerValue(0, Partition(topic, 0), 4, now + timedelta(seconds=4))
+                ),
+                Message(
+                    BrokerValue(0, Partition(topic, 0), 5, now + timedelta(seconds=5))
+                ),
+                Message(
+                    BrokerValue(0, Partition(topic, 0), 6, now + timedelta(seconds=6))
+                ),
+            ],
+            commit_never,
+        )
+
+    benchmark(commit_policy_never_commits)

--- a/tests/processing/test_processor.py
+++ b/tests/processing/test_processor.py
@@ -441,11 +441,11 @@ def test_stream_processor_commit_policy_every_two_seconds() -> None:
     ) == [
         0,
         0,
+        0,
         1,
         1,
         2,
         2,
-        3,
     ]
 
 

--- a/tests/test_commit.py
+++ b/tests/test_commit.py
@@ -1,3 +1,5 @@
+import time
+
 import pytest
 
 from arroyo.commit import IMMEDIATE, ONCE_PER_SECOND, CommitPolicy
@@ -8,37 +10,37 @@ def test_commit_policy() -> None:
     partition = Partition(Topic("test"), 0)
 
     state = IMMEDIATE.get_state_machine()
-    time = 0.5
+    ts = time.time() + 0.5
     offset = 1
-    assert state.should_commit(time, {partition: offset}) is True
-    time += 2
+    assert state.should_commit(ts, {partition: offset}) is True
+    ts += 2
     offset += 1
-    assert state.should_commit(time, {partition: offset}) is True
-    time += 0.5
+    assert state.should_commit(ts, {partition: offset}) is True
+    ts += 0.5
     offset += 5
-    assert state.should_commit(time, {partition: offset}) is True
+    assert state.should_commit(ts, {partition: offset}) is True
 
     state = ONCE_PER_SECOND.get_state_machine()
-    time = 0.5
+    ts = time.time() + 0.5
     offset = 10
-    assert state.should_commit(time, {partition: offset}) is False
-    time += 1
+    assert state.should_commit(ts, {partition: offset}) is False
+    ts += 1
     offset += 10
-    assert state.should_commit(time, {partition: offset}) is True
-    time += 1.5
+    assert state.should_commit(ts, {partition: offset}) is True
+    ts += 1.5
     offset += 10
-    assert state.should_commit(time, {partition: offset}) is True
+    assert state.should_commit(ts, {partition: offset}) is True
 
     state = CommitPolicy(2, 100).get_state_machine()
-    time = 1
+    ts = time.time() + 1
     offset = 99
-    assert state.should_commit(time, {partition: offset}) is False
-    time += 2
+    assert state.should_commit(ts, {partition: offset}) is False
+    ts += 2
     offset += 1
-    assert state.should_commit(time, {partition: offset}) is True
-    time += 1
+    assert state.should_commit(ts, {partition: offset}) is True
+    ts += 1
     offset += 101
-    assert state.should_commit(time, {partition: offset}) is True
+    assert state.should_commit(ts, {partition: offset}) is True
 
     with pytest.raises(Exception):
         CommitPolicy(None, None)


### PR DESCRIPTION
in QE environment, looking at the metrics in https://github.com/getsentry/sentry/pull/42291 show that using commit policies as part of https://github.com/getsentry/sentry/pull/41664 show a slowdown from avg 1 microsecond to 10 microseconds on every `Processor.commit` call

this PR moves a bunch of expensive logic from staging into commit to make the common case of not-committing faster, and skips a bunch of logic related to counting offsets if message-based commit policy is not configured

the result is that we are now at 4 microseconds avg instead, with the commit pre-master merge where #165 wasn't applied yet. I cannot test with that change because sentry fails to import Position then

the benchmarks only run once by default. to enable them, pass either `--benchmark-enable` to pytest to run them alongside tests, or `--benchmark-enable --benchmark-only` to run just the (currently singular) benchmark. Alternatively, run `make benchmarks`

There is also a workflow to compare benchmark results, using `--benchmark-save=baseline` and `--benchmark-compare=baseline`, see the documentation for pytest-benchmark or `pytest --help`.