### PR TITLE
feat(decoders): Json decoder can be used without schema

### DIFF
--- a/arroyo/processing/strategies/decoder.py
+++ b/arroyo/processing/strategies/decoder.py
@@ -98,8 +98,11 @@ class Codec(ABC, Generic[T]):
 
 
 class JsonCodec(Codec[object]):
-    def __init__(self, json_schema: object) -> None:
-        self.__validate = fastjsonschema.compile(json_schema)
+    def __init__(self, json_schema: Optional[object] = None) -> None:
+        if json_schema is not None:
+            self.__validate = fastjsonschema.compile(json_schema)
+        else:
+            self.__validate = lambda _: _
 
     def decode(self, raw_data: bytes, validate: bool) -> object:
         decoded = rapidjson.loads(raw_data)

--- a/tests/processing/strategies/test_decoder.py
+++ b/tests/processing/strategies/test_decoder.py
@@ -72,3 +72,9 @@ def test_json_decoder() -> None:
         strategy.submit(invalid_message)
 
     strategy_skip_validation.submit(invalid_message)
+
+    # Json codec without schema should not fail with invalid message
+    json_codec_no_schema = JsonCodec()
+    strategy = KafkaMessageDecoder(json_codec_no_schema, True, next_step)
+    strategy.submit(valid_message)
+    strategy.submit(invalid_message)


### PR DESCRIPTION
We want to be able to use the same JsonCodec in scenarios where we have a schema as well as scenarios where a topic schema is not yet available. This change makes schema optional. Validation function always returns true if no schema is provided.