### PR TITLE
feat(serializers): Add more decoders

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -13,6 +13,9 @@ ignore_missing_imports = True
 [mypy-fastjsonschema]
 ignore_missing_imports = True
 
+[mypy-msgpack]
+ignore_missing_imports = True
+
 [mypy-rapidjson]
 ignore_missing_imports = True
 

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,7 +1,7 @@
 [mypy]
 python_version = 3.8
 
-[mypy-setuptools]
+[mypy-avro.*]
 ignore_missing_imports = True
 
 [mypy-confluent_kafka]
@@ -14,4 +14,7 @@ ignore_missing_imports = True
 ignore_missing_imports = True
 
 [mypy-rapidjson]
+ignore_missing_imports = True
+
+[mypy-setuptools]
 ignore_missing_imports = True

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
+avro>=1.11.1
 confluent-kafka>=1.9.0
 fastjsonschema>=2.16.2
+msgpack>=1.0.4
 python-rapidjson>=1.8

--- a/tests/processing/strategies/serializers/test.avsc
+++ b/tests/processing/strategies/serializers/test.avsc
@@ -1,0 +1,10 @@
+{
+  "namespace": "test.avro",
+  "type": "record",
+  "name": "Test",
+  "fields": [
+    { "name": "event_id", "type": "string" },
+    { "name": "project_id", "type": ["int"] },
+    { "name": "group_id", "type": ["int", "null"] }
+  ]
+}

--- a/tests/processing/strategies/serializers/test.schema.json
+++ b/tests/processing/strategies/serializers/test.schema.json
@@ -1,0 +1,11 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "Test json schema",
+    "type": "object",
+    "properties": {
+        "event_id": {"type": "string", "description": "32 character hex string"},
+        "project_id": {"type": "integer", "description": "Project ID"},
+        "group_id": {"type": "integer", "description": "Group ID"}
+    },
+    "required": ["event_id", "project_id"]
+}

--- a/tests/processing/strategies/test_decoder.py
+++ b/tests/processing/strategies/test_decoder.py
@@ -1,24 +1,24 @@
+import io
+import json
+import os
 from unittest.mock import Mock
 
+import avro
+import avro.io
+import avro.schema
+import msgpack
 import pytest
 
 from arroyo.backends.kafka import KafkaPayload
 from arroyo.processing.strategies.decoder import (
+    AvroCodec,
     DecodedKafkaMessage,
     JsonCodec,
     KafkaMessageDecoder,
+    MsgpackCodec,
     ValidationError,
 )
 from arroyo.types import Message, Partition, Topic, Value
-
-schema = {
-    "type": "object",
-    "properties": {
-        "event_id": {"type": "string", "description": "32 character hex string"},
-        "project_id": {"type": "integer", "description": "Project ID"},
-        "group_id": {"type": "integer", "description": "Group ID"},
-    },
-}
 
 
 def make_kafka_message(raw_data: bytes) -> Message[KafkaPayload]:
@@ -35,46 +35,152 @@ def make_kafka_message(raw_data: bytes) -> Message[KafkaPayload]:
 
 
 def test_json_decoder() -> None:
-    next_step = Mock()
-    json_codec = JsonCodec(schema)
-    strategy = KafkaMessageDecoder(json_codec, True, next_step)
-    strategy_skip_validation = KafkaMessageDecoder(json_codec, False, next_step)
-
-    # Valid message
-    valid_message = make_kafka_message(
-        b'{"event_id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", "project_id": 1, "group_id": 2}'
+    schema_path = os.path.join(
+        os.path.dirname(__file__), "serializers", "test.schema.json"
     )
-    strategy.submit(valid_message)
 
-    assert next_step.submit.call_args[0][0] == Message(
-        Value(
-            DecodedKafkaMessage(
-                None,
+    with open(schema_path, mode="r") as f:
+        schema = json.loads(f.read())
+        next_step = Mock()
+        json_codec = JsonCodec(schema)
+        strategy = KafkaMessageDecoder(json_codec, True, next_step)
+        strategy_skip_validation = KafkaMessageDecoder(json_codec, False, next_step)
+
+        # Valid message
+        valid_message = make_kafka_message(
+            b'{"event_id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", "project_id": 1, "group_id": 2}'
+        )
+        strategy.submit(valid_message)
+
+        assert next_step.submit.call_args[0][0] == Message(
+            Value(
+                DecodedKafkaMessage(
+                    None,
+                    {
+                        "event_id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+                        "project_id": 1,
+                        "group_id": 2,
+                    },
+                    [],
+                ),
+                valid_message.committable,
+            ),
+        )
+
+        next_step.submit.reset_mock()
+
+        # Invalid message
+        invalid_message = make_kafka_message(
+            b'{"event_id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", "project_id": "bbb", "group_id": 2}'
+        )
+
+        with pytest.raises(ValidationError):
+            strategy.submit(invalid_message)
+
+        strategy_skip_validation.submit(invalid_message)
+
+        # Json codec without schema should not fail with invalid message
+        json_codec_no_schema = JsonCodec()
+        strategy = KafkaMessageDecoder(json_codec_no_schema, True, next_step)
+        strategy.submit(valid_message)
+        strategy.submit(invalid_message)
+
+
+def test_msgpack_decoder() -> None:
+    schema_path = os.path.join(
+        os.path.dirname(__file__), "serializers", "test.schema.json"
+    )
+
+    with open(schema_path, mode="r") as f:
+        schema = json.loads(f.read())
+        next_step = Mock()
+        msgpack_codec = MsgpackCodec(schema)
+
+        # Valid message
+        valid_message = make_kafka_message(
+            msgpack.packb(
                 {
                     "event_id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
                     "project_id": 1,
                     "group_id": 2,
-                },
-                [],
+                }
+            )
+        )
+
+        strategy = KafkaMessageDecoder(msgpack_codec, True, next_step)
+        strategy.submit(valid_message)
+
+        assert next_step.submit.call_args[0][0] == Message(
+            Value(
+                DecodedKafkaMessage(
+                    None,
+                    {
+                        "event_id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+                        "project_id": 1,
+                        "group_id": 2,
+                    },
+                    [],
+                ),
+                valid_message.committable,
             ),
-            valid_message.committable,
-        ),
-    )
+        )
 
-    next_step.submit.reset_mock()
 
-    # Invalid message
-    invalid_message = make_kafka_message(
-        b'{"event_id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", "project_id": "bbb", "group_id": 2}'
-    )
+def test_avro_decoder() -> None:
+    schema_path = os.path.join(os.path.dirname(__file__), "serializers", "test.avsc")
 
-    with pytest.raises(ValidationError):
-        strategy.submit(invalid_message)
+    with open(schema_path, mode="rb") as f:
+        schema = avro.schema.parse(f.read())
 
-    strategy_skip_validation.submit(invalid_message)
+        bytes_writer = io.BytesIO()
+        writer = avro.io.DatumWriter(schema)
+        data = {
+            "event_id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            "project_id": 1,
+            "group_id": 2,
+        }
+        writer.write(data, avro.io.BinaryEncoder(bytes_writer))
+        valid_message = make_kafka_message(bytes_writer.getvalue())
 
-    # Json codec without schema should not fail with invalid message
-    json_codec_no_schema = JsonCodec()
-    strategy = KafkaMessageDecoder(json_codec_no_schema, True, next_step)
-    strategy.submit(valid_message)
-    strategy.submit(invalid_message)
+        avro_codec = AvroCodec(schema)
+        next_step = Mock()
+        strategy = KafkaMessageDecoder(avro_codec, True, next_step)
+        strategy.submit(valid_message)
+
+        assert next_step.submit.call_args[0][0] == Message(
+            Value(
+                DecodedKafkaMessage(
+                    None,
+                    {
+                        "event_id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+                        "project_id": 1,
+                        "group_id": 2,
+                    },
+                    [],
+                ),
+                valid_message.committable,
+            ),
+        )
+
+        # Invalid schema
+        invalid_schema = avro.schema.parse(
+            json.dumps(
+                {
+                    "type": "record",
+                    "name": "Test",
+                    "fields": [{"name": "invalid_thing", "type": ["int"]}],
+                }
+            )
+        )
+
+        bytes_writer = io.BytesIO()
+        data = {"invalid_thing": 1}
+        avro.io.DatumWriter(invalid_schema).write(
+            data, avro.io.BinaryEncoder(bytes_writer)
+        )
+
+        # Invalid message
+        invalid_message = make_kafka_message(bytes_writer.getvalue())
+
+        with pytest.raises(ValidationError):
+            strategy.submit(invalid_message)


### PR DESCRIPTION
This change adds decoders for msgpack and avro alongside json (which already existed in the library).

Since Arroyo is supposed to be agnostic of the message serialization format, we want to support as many different formats as possible here.