### PR TITLE
build: Make json, msgpack and avro optional dependencies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ setup-git:
 	pre-commit install --install-hooks
 
 install:
-	pip install -e .
+	pip install -e .[avro,json,msgpack]
 	pip install -r requirements-test.txt
 
 lint:

--- a/arroyo/processing/strategies/decoder/__init__.py
+++ b/arroyo/processing/strategies/decoder/__init__.py
@@ -1,0 +1,19 @@
+from arroyo.processing.strategies.decoder.avro import AvroCodec
+from arroyo.processing.strategies.decoder.base import (
+    Codec,
+    DecodedKafkaMessage,
+    KafkaMessageDecoder,
+    ValidationError,
+)
+from arroyo.processing.strategies.decoder.json import JsonCodec
+from arroyo.processing.strategies.decoder.msgpack import MsgpackCodec
+
+__all__ = [
+    "AvroCodec",
+    "Codec",
+    "DecodedKafkaMessage",
+    "JsonCodec",
+    "KafkaMessageDecoder",
+    "MsgpackCodec",
+    "ValidationError",
+]

--- a/arroyo/processing/strategies/decoder/avro.py
+++ b/arroyo/processing/strategies/decoder/avro.py
@@ -1,0 +1,20 @@
+from io import BytesIO
+
+from avro.errors import SchemaResolutionException
+from avro.io import BinaryDecoder, DatumReader
+
+from arroyo.processing.strategies.decoder.base import Codec, ValidationError
+
+
+class AvroCodec(Codec[object]):
+    def __init__(self, avro_schema: object) -> None:
+        self.__schema = avro_schema
+        self.__reader = DatumReader(self.__schema)
+
+    def decode(self, raw_data: bytes, validate: bool) -> object:
+        assert validate is True, "Validation cannot be skipped for AvroCodec"
+        decoder = BinaryDecoder(BytesIO(raw_data))
+        try:
+            return self.__reader.read(decoder)
+        except SchemaResolutionException as exc:
+            raise ValidationError from exc

--- a/arroyo/processing/strategies/decoder/avro.py
+++ b/arroyo/processing/strategies/decoder/avro.py
@@ -1,6 +1,6 @@
 from io import BytesIO
 
-from avro.errors import SchemaResolutionException
+from avro.errors import SchemaResolutionException  # pip install sentry-arroyo[avro]
 from avro.io import BinaryDecoder, DatumReader
 
 from arroyo.processing.strategies.decoder.base import Codec, ValidationError

--- a/arroyo/processing/strategies/decoder/json.py
+++ b/arroyo/processing/strategies/decoder/json.py
@@ -1,6 +1,6 @@
 from typing import Optional
 
-import fastjsonschema
+import fastjsonschema  # pip install sentry-arroyo[json]
 import rapidjson
 
 from arroyo.processing.strategies.decoder.base import Codec, ValidationError

--- a/arroyo/processing/strategies/decoder/json.py
+++ b/arroyo/processing/strategies/decoder/json.py
@@ -1,0 +1,26 @@
+from typing import Optional
+
+import fastjsonschema
+import rapidjson
+
+from arroyo.processing.strategies.decoder.base import Codec, ValidationError
+
+
+class JsonCodec(Codec[object]):
+    def __init__(self, json_schema: Optional[object] = None) -> None:
+        if json_schema is not None:
+            self.__validate = fastjsonschema.compile(json_schema)
+        else:
+            self.__validate = lambda _: _
+
+    def decode(self, raw_data: bytes, validate: bool) -> object:
+        decoded = rapidjson.loads(raw_data)
+        if validate:
+            self.validate(decoded)
+        return decoded
+
+    def validate(self, data: object) -> None:
+        try:
+            self.__validate(data)
+        except Exception as exc:
+            raise ValidationError from exc

--- a/arroyo/processing/strategies/decoder/msgpack.py
+++ b/arroyo/processing/strategies/decoder/msgpack.py
@@ -1,6 +1,6 @@
 from typing import Optional
 
-import fastjsonschema
+import fastjsonschema  # pip install sentry-arroyo[msgpack]
 import msgpack
 
 from arroyo.processing.strategies.decoder.base import Codec, ValidationError

--- a/arroyo/processing/strategies/decoder/msgpack.py
+++ b/arroyo/processing/strategies/decoder/msgpack.py
@@ -1,0 +1,30 @@
+from typing import Optional
+
+import fastjsonschema
+import msgpack
+
+from arroyo.processing.strategies.decoder.base import Codec, ValidationError
+
+
+class MsgpackCodec(Codec[object]):
+    """
+    This codec assumes the schema is json.
+    """
+
+    def __init__(self, json_schema: Optional[object] = None) -> None:
+        if json_schema is not None:
+            self.__validate = fastjsonschema.compile(json_schema)
+        else:
+            self.__validate = lambda _: _
+
+    def decode(self, raw_data: bytes, validate: bool) -> object:
+        decoded = msgpack.unpackb(raw_data)
+        if validate:
+            self.validate(decoded)
+        return decoded
+
+    def validate(self, data: object) -> None:
+        try:
+            self.__validate(data)
+        except Exception as exc:
+            raise ValidationError from exc

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,1 @@
-avro>=1.11.1
 confluent-kafka>=1.9.0
-fastjsonschema>=2.16.2
-msgpack>=1.0.4
-python-rapidjson>=1.8

--- a/setup.py
+++ b/setup.py
@@ -2,10 +2,6 @@ from typing import Sequence
 
 from setuptools import find_packages, setup
 
-AVRO_REQUIREMENTS = ["avro>=1.11.1"]
-JSON_REQUIREMENTS = ["python-rapidjson>=1.8", "fastjsonschema>=2.16.2"]
-MSGPACK_REQUIREMENTS = ["msgpack>=1.0.4", "fastjsonschema>=2.16.2"]
-
 
 def get_requirements() -> Sequence[str]:
     with open("requirements.txt") as fp:
@@ -34,8 +30,8 @@ setup(
         "Topic :: Software Development :: Libraries :: Python Modules",
     ],
     extras_require={
-        "avro": AVRO_REQUIREMENTS,
-        "json": JSON_REQUIREMENTS,
-        "msgpack": MSGPACK_REQUIREMENTS,
+        "avro": ["avro>=1.11.1"],
+        "json": ["python-rapidjson>=1.8", "fastjsonschema>=2.16.2"],
+        "msgpack": ["msgpack>=1.0.4", "fastjsonschema>=2.16.2"],
     },
 )

--- a/setup.py
+++ b/setup.py
@@ -2,6 +2,10 @@ from typing import Sequence
 
 from setuptools import find_packages, setup
 
+AVRO_REQUIREMENTS = ["avro>=1.11.1"]
+JSON_REQUIREMENTS = ["python-rapidjson>=1.8", "fastjsonschema>=2.16.2"]
+MSGPACK_REQUIREMENTS = ["msgpack>=1.0.4", "fastjsonschema>=2.16.2"]
+
 
 def get_requirements() -> Sequence[str]:
     with open("requirements.txt") as fp:
@@ -29,4 +33,9 @@ setup(
         "Programming Language :: Python",
         "Topic :: Software Development :: Libraries :: Python Modules",
     ],
+    extras_require={
+        "avro": AVRO_REQUIREMENTS,
+        "json": JSON_REQUIREMENTS,
+        "msgpack": MSGPACK_REQUIREMENTS,
+    },
 )


### PR DESCRIPTION
These are only needed if the user is using this strategy and a particular encoding format, and are likely not needed by the majority of users.