### PR TITLE
ref: Add more timings to decoder.json, add non-strict validation mode

### DIFF
--- a/arroyo/processing/strategies/decoder/json.py
+++ b/arroyo/processing/strategies/decoder/json.py
@@ -1,5 +1,5 @@
 import time
-from typing import Optional
+from typing import Mapping, Optional
 
 import fastjsonschema  # pip install sentry-arroyo[json]
 import rapidjson
@@ -9,8 +9,17 @@ from arroyo.utils.metrics import get_metrics
 
 
 class JsonCodec(Codec[object]):
-    def __init__(self, json_schema: Optional[object] = None) -> None:
+    def __init__(
+        self,
+        json_schema: Optional[object] = None,
+        json_schema_name: Optional[str] = None,
+    ) -> None:
         self.__metrics = get_metrics()
+        self.__metrics_tags: Mapping[str, str]
+        if json_schema_name:
+            self.__metrics_tags = {"schema_name": json_schema_name}
+        else:
+            self.__metrics_tags = {}
 
         if json_schema is not None:
             self.__validate = fastjsonschema.compile(json_schema)
@@ -23,12 +32,18 @@ class JsonCodec(Codec[object]):
 
         after_decoded = time.time() - start
 
-        self.__metrics.timing("arroyo.strategies.decoder.json.loads", after_decoded)
+        self.__metrics.timing(
+            "arroyo.strategies.decoder.json.loads",
+            after_decoded,
+            tags=self.__metrics_tags,
+        )
 
         if validate:
             self.validate(decoded)
             self.__metrics.timing(
-                "arroyo.strategies.decoder.json.validate", time.time() - after_decoded
+                "arroyo.strategies.decoder.json.validate",
+                time.time() - after_decoded,
+                tags=self.__metrics_tags,
             )
         return decoded
 

--- a/arroyo/processing/strategies/decoder/json.py
+++ b/arroyo/processing/strategies/decoder/json.py
@@ -1,22 +1,35 @@
+import time
 from typing import Optional
 
 import fastjsonschema  # pip install sentry-arroyo[json]
 import rapidjson
 
 from arroyo.processing.strategies.decoder.base import Codec, ValidationError
+from arroyo.utils.metrics import get_metrics
 
 
 class JsonCodec(Codec[object]):
     def __init__(self, json_schema: Optional[object] = None) -> None:
+        self.__metrics = get_metrics()
+
         if json_schema is not None:
             self.__validate = fastjsonschema.compile(json_schema)
         else:
             self.__validate = lambda _: _
 
     def decode(self, raw_data: bytes, validate: bool) -> object:
+        start = time.time()
         decoded = rapidjson.loads(raw_data)
+
+        after_decoded = time.time() - start
+
+        self.__metrics.timing("arroyo.strategies.decoder.json.loads", after_decoded)
+
         if validate:
             self.validate(decoded)
+            self.__metrics.timing(
+                "arroyo.strategies.decoder.json.validate", time.time() - after_decoded
+            )
         return decoded
 
     def validate(self, data: object) -> None:


### PR DESCRIPTION
I want this to figure out how fast validation vs JSON decoding alone is. The non-strict mode is for avoiding consumer crashes while the schema is not entirely fleshed out yet.
