### PR TITLE
ref: Don't alias ProcessingStrategy as ProcessingStep

### DIFF
--- a/arroyo/processing/strategies/dead_letter_queue/dead_letter_queue.py
+++ b/arroyo/processing/strategies/dead_letter_queue/dead_letter_queue.py
@@ -1,7 +1,7 @@
 import logging
 from typing import Optional
 
-from arroyo.processing.strategies.abstract import ProcessingStrategy as ProcessingStep
+from arroyo.processing.strategies.abstract import ProcessingStrategy
 from arroyo.processing.strategies.dead_letter_queue.invalid_messages import (
     InvalidMessages,
 )
@@ -16,7 +16,7 @@ logger = logging.getLogger(__name__)
 RECEIVED_MESSAGE_METRIC = "dlq.received_message"
 
 
-class DeadLetterQueue(ProcessingStep[TPayload]):
+class DeadLetterQueue(ProcessingStrategy[TPayload]):
     """
     DLQ Processing Step.
 
@@ -26,7 +26,7 @@ class DeadLetterQueue(ProcessingStep[TPayload]):
 
     def __init__(
         self,
-        next_step: ProcessingStep[TPayload],
+        next_step: ProcessingStrategy[TPayload],
         policy: DeadLetterQueuePolicy,
     ) -> None:
         self.__next_step = next_step

--- a/arroyo/processing/strategies/filter.py
+++ b/arroyo/processing/strategies/filter.py
@@ -1,13 +1,13 @@
 import logging
 from typing import Callable, Optional
 
-from arroyo.processing.strategies.abstract import ProcessingStrategy as ProcessingStep
+from arroyo.processing.strategies.abstract import ProcessingStrategy
 from arroyo.types import Message, TPayload
 
 logger = logging.getLogger(__name__)
 
 
-class FilterStep(ProcessingStep[TPayload]):
+class FilterStep(ProcessingStrategy[TPayload]):
     """
     Determines if a message should be submitted to the next processing step.
     """
@@ -15,7 +15,7 @@ class FilterStep(ProcessingStep[TPayload]):
     def __init__(
         self,
         function: Callable[[Message[TPayload]], bool],
-        next_step: ProcessingStep[TPayload],
+        next_step: ProcessingStrategy[TPayload],
     ):
         self.__test_function = function
         self.__next_step = next_step

--- a/arroyo/processing/strategies/run_task.py
+++ b/arroyo/processing/strategies/run_task.py
@@ -24,9 +24,7 @@ from typing import (
     TypeVar,
 )
 
-from arroyo.processing.strategies.abstract import MessageRejected
-from arroyo.processing.strategies.abstract import ProcessingStrategy
-from arroyo.processing.strategies.abstract import ProcessingStrategy as ProcessingStep
+from arroyo.processing.strategies.abstract import MessageRejected, ProcessingStrategy
 from arroyo.processing.strategies.dead_letter_queue.invalid_messages import (
     InvalidMessage,
     InvalidMessages,
@@ -381,11 +379,13 @@ def parallel_run_task_worker_apply(
     )
 
 
-class RunTaskWithMultiprocessing(ProcessingStep[TPayload], Generic[TPayload, TResult]):
+class RunTaskWithMultiprocessing(
+    ProcessingStrategy[TPayload], Generic[TPayload, TResult]
+):
     def __init__(
         self,
         function: Callable[[Message[TPayload]], TResult],
-        next_step: ProcessingStep[TResult],
+        next_step: ProcessingStrategy[TResult],
         num_processes: int,
         max_batch_size: int,
         max_batch_time: float,


### PR DESCRIPTION
We do this inconsistently, let's simply import this as ProcessingStrategy everywhere without the alias.