### PR TITLE
fix(produce): Fix closing next step

### DIFF
--- a/arroyo/processing/strategies/produce.py
+++ b/arroyo/processing/strategies/produce.py
@@ -77,7 +77,6 @@ class Produce(ProcessingStrategy[TPayload]):
 
     def close(self) -> None:
         self.__closed = True
-        self.__next_step.close()
 
     def terminate(self) -> None:
         self.__closed = True
@@ -101,6 +100,7 @@ class Produce(ProcessingStrategy[TPayload]):
             self.__next_step.poll()
             self.__next_step.submit(message)
 
+        self.__next_step.close()
         self.__next_step.join(remaining)
 
 


### PR DESCRIPTION
The next step must be closed in Produce's join() method, not close() since join() attempts to continue submitting messages to the next step if they are pending. This will not be possible if the next step is closed.