### PR TITLE
feat: Log exception if processing strategy exists on assignment

### DIFF
--- a/arroyo/processing/processor.py
+++ b/arroyo/processing/processor.py
@@ -119,6 +119,9 @@ class StreamProcessor(Generic[TPayload]):
             logger.info("New partitions assigned: %r", partitions)
             if partitions:
                 if self.__processing_strategy is not None:
+                    logger.exception(
+                        "Partition assignment while processing strategy active"
+                    )
                     _close_strategy()
                 _create_strategy(partitions)
 


### PR DESCRIPTION
This was added for incremental rebalancing where multiple assignments could happen without corresponding recovaction being first completed, but should never happen now that option was removed. Log an exception if it ever does.