### PR TITLE
feat: Configurable strategy join timeout

### DIFF
--- a/arroyo/processing/processor.py
+++ b/arroyo/processing/processor.py
@@ -69,6 +69,7 @@ class StreamProcessor(Generic[TPayload]):
         topic: Topic,
         processor_factory: ProcessingStrategyFactory[TPayload],
         commit_policy: CommitPolicy,
+        join_timeout: Optional[float] = None,
     ) -> None:
         self.__consumer = consumer
         self.__processor_factory = processor_factory
@@ -83,7 +84,7 @@ class StreamProcessor(Generic[TPayload]):
         self.__paused_timestamp: Optional[float] = None
 
         self.__commit_policy_state = commit_policy.get_state_machine()
-
+        self.__join_timeout = join_timeout
         self.__shutdown_requested = False
 
         def _close_strategy() -> None:
@@ -96,7 +97,7 @@ class StreamProcessor(Generic[TPayload]):
             self.__processing_strategy.close()
 
             logger.info("Waiting for %r to exit...", self.__processing_strategy)
-            self.__processing_strategy.join()
+            self.__processing_strategy.join(self.__join_timeout)
 
             logger.info(
                 "%r exited successfully, releasing assignment.",


### PR DESCRIPTION
This change allows the user to configure the join timeout of a consumer strategy.

Currently, the timeout is hardcoded to None. The implication of this is that consumers can take a long time to finish rebalancing. This time may stack up, especially during deployments where multiple rebalancings will occur back to back as consumers are gradually rolled out and shut down. In some scenarios, it may be better to abandon in-flight messages and just immediately shut down.

This change keeps same default as before, but now consumers can pass a custom strategy join timeout if they want recovation callbacks to finish faster.