### PR TITLE
fix: Fix multiprocessing join

### DIFF
--- a/arroyo/processing/strategies/run_task.py
+++ b/arroyo/processing/strategies/run_task.py
@@ -613,6 +613,8 @@ class RunTaskWithMultiprocessing(
                     if deadline is not None
                     else None
                 )
+            except multiprocessing.TimeoutError:
+                pass
             except InvalidMessages as e:
                 invalid_messages += e.messages
 


### PR DESCRIPTION
We weren't catching the TimeoutError, leading to consumer to crash during join anytime the timeout is hit.