### PR TITLE
fix(run_task): Fix bug where join() would not actually wait for tasks

### DIFF
--- a/arroyo/processing/strategies/run_task.py
+++ b/arroyo/processing/strategies/run_task.py
@@ -173,11 +173,8 @@ class RunTaskInThreads(
             next_message: Message[TResult]
 
             if future is not None:
-                if not future.done():
-                    break
-
                 # Will raise if the future errored
-                result = future.result()
+                result = future.result(remaining)
                 payload = message.value.replace(result)
                 next_message = Message(payload)
             else:


### PR DESCRIPTION
This was likely a copy-paste job from poll() while trying to fix merge
conflicts in https://github.com/getsentry/arroyo/pull/185

That PR inadvertently changed the code to be the same as in `poll()`, this PR restores the previous code.