### PR TITLE
feat: Add ability to assign consumer to a subset of partitions

### DIFF
--- a/arroyo/backends/abstract.py
+++ b/arroyo/backends/abstract.py
@@ -121,6 +121,14 @@ class Consumer(Generic[TStrategyPayload], ABC):
         raise NotImplementedError
 
     @abstractmethod
+    def assign(self, offsets: Mapping[Partition, int]) -> None:
+        """
+        Set the consumer partition assignment to the provided offsets and
+        start consuming.
+        """
+        raise NotImplementedError
+
+    @abstractmethod
     def seek(self, offsets: Mapping[Partition, int]) -> None:
         """
         Update the working offsets for the provided partitions.

--- a/arroyo/backends/local/backend.py
+++ b/arroyo/backends/local/backend.py
@@ -175,12 +175,16 @@ class LocalConsumer(Consumer[TStrategyPayload]):
     def group(self) -> str:
         return self.__group
 
+    def assign(self, offsets: Mapping[Partition, int]) -> None:
+        self.__offsets = {**offsets}
+
     def __assign(
         self, subscription: Subscription, offsets: Mapping[Partition, int]
     ) -> None:
-        self.__offsets = {**offsets}
         if subscription.assignment_callback is not None:
             subscription.assignment_callback(offsets)
+        else:
+            self.assign(offsets)
 
     def __revoke(
         self, subscription: Subscription, partitions: Sequence[Partition]

--- a/arroyo/processing/processor.py
+++ b/arroyo/processing/processor.py
@@ -119,6 +119,7 @@ class StreamProcessor(Generic[TStrategyPayload]):
             )
 
         def on_partitions_assigned(partitions: Mapping[Partition, int]) -> None:
+            self.__consumer.assign(partitions)
             logger.info("New partitions assigned: %r", partitions)
             if partitions:
                 if self.__processing_strategy is not None:

--- a/tests/backends/mixins.py
+++ b/tests/backends/mixins.py
@@ -241,6 +241,7 @@ class StreamsTestMixin(ABC, Generic[TStrategyPayload]):
             def on_assign(partitions: Mapping[Partition, int]) -> None:
                 # NOTE: This will eventually need to be controlled by a generalized
                 # consumer auto offset reset setting.
+                consumer.assign(partitions)
 
                 assert (
                     partitions

--- a/tests/backends/mixins.py
+++ b/tests/backends/mixins.py
@@ -50,6 +50,8 @@ class StreamsTestMixin(ABC, Generic[TStrategyPayload]):
             def _assignment_callback(partitions: Mapping[Partition, int]) -> None:
                 assert partitions == {Partition(topic, 0): messages[0].offset}
 
+                consumer.assign(partitions)
+
                 consumer.seek({Partition(topic, 0): messages[1].offset})
 
                 with pytest.raises(ConsumerError):


### PR DESCRIPTION
Today Arroyo's consumer only works with auto assignment, and doesn't support a consumer getting assigned a subset of partitions and offsets.

This change brings it closer to how the assignment callback works in the actual Kafka consumer API where auto assignment only happens if an assignment callback is not passed, otherwise the user should manually assign in the callback.

The immediate motivation for this change is to support a dead letter queue consumer implementation which will seek to specific partitions/offsets and fetch the invalid messages from those positions.