### PR TITLE
feat: Add unfold strategy

### DIFF
--- a/arroyo/processing/strategies/__init__.py
+++ b/arroyo/processing/strategies/__init__.py
@@ -14,6 +14,7 @@ from arroyo.processing.strategies.run_task import (
     RunTaskWithMultiprocessing,
 )
 from arroyo.processing.strategies.transform import ParallelTransformStep, TransformStep
+from arroyo.processing.strategies.unfold import Unfold
 
 __all__ = [
     "CommitOffsets",
@@ -25,6 +26,7 @@ __all__ = [
     "ProcessingStrategyFactory",
     "Produce",
     "Reduce",
+    "Unfold",
     "RunTask",
     "RunTaskInThreads",
     "BatchStep",

--- a/arroyo/processing/strategies/batching.py
+++ b/arroyo/processing/strategies/batching.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import MutableSequence, Optional, Sequence, Union
+from typing import MutableSequence, Optional, Union
 
 from arroyo.processing.strategies.abstract import ProcessingStrategy
 from arroyo.processing.strategies.reduce import Reduce

--- a/arroyo/processing/strategies/unfold.py
+++ b/arroyo/processing/strategies/unfold.py
@@ -1,0 +1,104 @@
+import time
+from collections import deque
+from typing import Callable, Collection, Deque, Generic, Optional, TypeVar, Union, cast
+
+from arroyo.processing.strategies.abstract import MessageRejected, ProcessingStrategy
+from arroyo.types import FilteredPayload, Message, Value
+
+TInput = TypeVar("TInput")
+TOutput = TypeVar("TOutput")
+
+
+class Unfold(
+    ProcessingStrategy[Union[FilteredPayload, TInput]], Generic[TInput, TOutput]
+):
+    """
+    Unfold receives a message and explodes it to generate a collection of
+    messages submitting them one by one to the next step. The generated
+    messages are created according to the generator function provided by the user.
+
+    The generator function provided must return a collection (i.e. a class that
+    implements sized + iterable).
+
+    If this step receives a `MessageRejected` exception from the next
+    step it keeps the remaining messages and attempts to submit
+    them on subsequent calls to `poll`
+    """
+
+    def __init__(
+        self,
+        generator: Callable[[TInput], Collection[TOutput]],
+        next_step: ProcessingStrategy[Union[FilteredPayload, TOutput]],
+    ) -> None:
+        self.__generator = generator
+        self.__next_step = next_step
+        self.__closed = False
+        # If we get MessageRejected from the next step, we put the pending messages here
+        self.__pending: Deque[Message[TOutput]] = deque()
+
+    def submit(self, message: Message[Union[FilteredPayload, TInput]]) -> None:
+        assert not self.__closed
+        if self.__pending:
+            raise MessageRejected
+
+        if isinstance(message.payload, FilteredPayload):
+            self.__next_step.submit(
+                cast(Message[Union[FilteredPayload, TOutput]], message)
+            )
+            return
+
+        iterable = self.__generator(message.payload)
+        num_messages = len(iterable)
+
+        store_remaining_messages = False
+
+        for idx, value in enumerate(iterable):
+            # Last message is special because offsets can be committed along with it
+            if idx == num_messages - 1:
+                next_message = Message(Value(value, message.committable))
+            else:
+                next_message = Message(Value(value, {}))
+
+            if store_remaining_messages == False:
+                try:
+                    self.__next_step.submit(next_message)
+                except MessageRejected:
+                    # All remaining messages are stored in self.__pending ready for
+                    # the next call to `poll`.
+                    store_remaining_messages = True
+                    self.__pending.append(next_message)
+            else:
+                self.__pending.append(next_message)
+
+    def __flush(self) -> None:
+        while self.__pending:
+            try:
+                message = self.__pending[0]
+                self.__next_step.submit(message)
+                self.__pending.popleft()
+            except MessageRejected:
+                pass
+
+    def poll(self) -> None:
+        self.__flush()
+        self.__next_step.poll()
+
+    def close(self) -> None:
+        self.__closed = True
+
+    def terminate(self) -> None:
+        self.__closed = True
+        self.__next_step.terminate()
+
+    def join(self, timeout: Optional[float] = None) -> None:
+        deadline = time.time() + timeout if timeout is not None else None
+        while deadline is None or time.time() < deadline:
+            if self.__pending:
+                self.__flush()
+            else:
+                break
+
+        self.__next_step.close()
+        self.__next_step.join(
+            timeout=max(deadline - time.time(), 0) if deadline is not None else None
+        )

--- a/docs/source/strategies.rst
+++ b/docs/source/strategies.rst
@@ -40,7 +40,7 @@ Accumulate messages into a batch and pass to the next step.
    :members:
    :undoc-members:
 
-Reducers
+Reduce (Fold)
 -----------------------------
 
 Accumulate messages based on a custom accumulator function
@@ -49,6 +49,14 @@ Accumulate messages based on a custom accumulator function
    :members:
    :undoc-members:
 
+Unfold
+-----------------------------
+
+Generates a sequence of messages from a single message based on a custom generator function
+
+.. automodule:: arroyo.processing.strategies.unfold
+   :members:
+   :undoc-members:
 
 Task Runners
 -----------------------------

--- a/tests/processing/strategies/test_batching.py
+++ b/tests/processing/strategies/test_batching.py
@@ -289,14 +289,16 @@ def test_unbatch_step() -> None:
         ),
     )
 
+    partition = Partition(Topic("test"), 1)
+
     next_step = Mock()
     unbatch_step = UnbatchStep[str](next_step)
     unbatch_step.submit(msg)
     next_step.submit.assert_has_calls(
         [
-            call(message(1, 1, "Message 1")),
-            call(message(1, 2, "Message 2")),
-            call(message(1, 3, "Message 3")),
+            call(Message(Value("Message 1", {}))),
+            call(Message(Value("Message 2", {}))),
+            call(Message(Value("Message 3", {partition: 4}))),
         ]
     )
 
@@ -315,9 +317,9 @@ def test_unbatch_step() -> None:
     unbatch_step.poll()
     next_step.submit.assert_has_calls(
         [
-            call(message(1, 1, "Message 1")),
-            call(message(1, 2, "Message 2")),
-            call(message(1, 3, "Message 3")),
+            call(Message(Value("Message 1", {}))),
+            call(Message(Value("Message 2", {}))),
+            call(Message(Value("Message 3", {partition: 4}))),
         ]
     )
 
@@ -328,9 +330,9 @@ def test_unbatch_step() -> None:
 
     next_step.submit.assert_has_calls(
         [
-            call(message(1, 1, "Message 1")),
-            call(message(1, 2, "Message 2")),
-            call(message(1, 3, "Message 3")),
+            call(Message(Value("Message 1", {}))),
+            call(Message(Value("Message 2", {}))),
+            call(Message(Value("Message 3", {partition: 4}))),
         ]
     )
 
@@ -362,10 +364,12 @@ def test_batch_unbatch() -> None:
         final_step.submit.assert_not_called()
         pipeline.poll()
 
+    partition = Partition(Topic("test"), 1)
+
     final_step.submit.assert_has_calls(
         [
-            call(message(1, 1, "Transformed")),
-            call(message(1, 2, "Transformed")),
-            call(message(1, 3, "Transformed")),
+            call(Message(Value("Transformed", {}))),
+            call(Message(Value("Transformed", {}))),
+            call(Message(Value("Transformed", {partition: 4}))),
         ]
     )

--- a/tests/processing/strategies/test_unfold.py
+++ b/tests/processing/strategies/test_unfold.py
@@ -1,0 +1,60 @@
+from typing import Sequence
+from unittest.mock import Mock, call
+
+from arroyo.processing.strategies import MessageRejected
+from arroyo.processing.strategies.unfold import Unfold
+from arroyo.types import Message, Partition, Topic, Value
+
+
+def generator(num: int) -> Sequence[int]:
+    return [i for i in range(num)]
+
+
+def test_unfold() -> None:
+    partition = Partition(Topic("topic"), 0)
+
+    message = Message(Value(2, {partition: 1}))
+    next_step = Mock()
+
+    strategy = Unfold(generator, next_step)
+    strategy.submit(message)
+
+    assert next_step.submit.call_args_list == [
+        call(Message(Value(0, committable={}))),
+        call(Message(Value(1, committable={partition: 1}))),
+    ]
+
+    strategy.close()
+    strategy.join()
+
+
+def test_message_rejected() -> None:
+    partition = Partition(Topic("topic"), 0)
+
+    next_step = Mock()
+    next_step.submit.side_effect = MessageRejected()
+
+    strategy = Unfold(generator, next_step)
+
+    message = Message(Value(2, {partition: 1}))
+    strategy.submit(message)
+
+    assert next_step.submit.call_count == 1
+
+    # Message doesn't actually go through since it was rejected
+    assert next_step.submit.call_args_list == [
+        call(Message(Value(0, committable={}))),
+    ]
+
+    # clear the side effect, both messages should be submitted now
+    next_step.submit.reset_mock(side_effect=True)
+
+    strategy.poll()
+
+    assert next_step.submit.call_args_list == [
+        call(Message(Value(0, committable={}))),
+        call(Message(Value(1, committable={partition: 1}))),
+    ]
+
+    strategy.close()
+    strategy.join()


### PR DESCRIPTION
This strategy is the opposite of Reduce. The objective is to provide a more flexible way to extract a number of messages from a single message than UnbatchStep currently allows. With UnbatchStep, the input message must be `ValuesBatch`, which is an array of BaseValue from the BatchStep. Unfold allows for any user defined type and user provided generation function.

This change is motivated by a recent attempt to use Batch/Unbatch in the Sentry indexer (https://github.com/getsentry/sentry/pull/44721). The other strategies in the pipeline expected a slightly different format to what the BatchStep outputs. Switching out single steps in this pipeline without changing the rest would be easier if we were able to define both custom fold and unfold functions.