### PR TITLE
ref: Make stream processor / producer / consumer not generic

### DIFF
--- a/arroyo/backends/abstract.py
+++ b/arroyo/backends/abstract.py
@@ -3,14 +3,14 @@ from __future__ import annotations
 import logging
 from abc import ABC, abstractmethod, abstractproperty
 from concurrent.futures import Future
-from typing import Callable, Generic, Mapping, Optional, Sequence, Union
+from typing import Callable, Mapping, Optional, Sequence, Union
 
-from arroyo.types import BrokerValue, Partition, Topic, TStrategyPayload
+from arroyo.types import BrokerValue, KafkaPayload, Partition, Topic
 
 logger = logging.getLogger(__name__)
 
 
-class Consumer(Generic[TStrategyPayload], ABC):
+class Consumer(ABC):
     """
     This abstract class provides an interface for consuming messages from a
     multiplexed collection of partitioned topic streams.
@@ -64,7 +64,7 @@ class Consumer(Generic[TStrategyPayload], ABC):
     @abstractmethod
     def poll(
         self, timeout: Optional[float] = None
-    ) -> Optional[BrokerValue[TStrategyPayload]]:
+    ) -> Optional[BrokerValue[KafkaPayload]]:
         """
         Fetch a message from the consumer. If no message is available before
         the timeout, ``None`` is returned.
@@ -166,11 +166,11 @@ class Consumer(Generic[TStrategyPayload], ABC):
         raise NotImplementedError
 
 
-class Producer(Generic[TStrategyPayload], ABC):
+class Producer(ABC):
     @abstractmethod
     def produce(
-        self, destination: Union[Topic, Partition], payload: TStrategyPayload
-    ) -> Future[BrokerValue[TStrategyPayload]]:
+        self, destination: Union[Topic, Partition], payload: KafkaPayload
+    ) -> Future[BrokerValue[KafkaPayload]]:
         """
         Produce to a topic or partition.
         """

--- a/arroyo/backends/kafka/__init__.py
+++ b/arroyo/backends/kafka/__init__.py
@@ -1,5 +1,7 @@
+from arroyo.types import KafkaPayload
+
 from .configuration import build_kafka_configuration, build_kafka_consumer_configuration
-from .consumer import KafkaConsumer, KafkaPayload, KafkaProducer
+from .consumer import KafkaConsumer, KafkaProducer
 
 __all__ = [
     "build_kafka_configuration",

--- a/arroyo/backends/local/storages/abstract.py
+++ b/arroyo/backends/local/storages/abstract.py
@@ -1,8 +1,8 @@
 from abc import ABC, abstractmethod
 from datetime import datetime
-from typing import Generic, Iterator, Optional
+from typing import Iterator, Optional
 
-from arroyo.types import BrokerValue, Partition, Topic, TStrategyPayload
+from arroyo.types import BrokerValue, KafkaPayload, Partition, Topic
 
 
 class TopicExists(Exception):
@@ -20,7 +20,7 @@ class PartitionDoesNotExist(Exception):
         self.partition = partition
 
 
-class MessageStorage(ABC, Generic[TStrategyPayload]):
+class MessageStorage(ABC):
     @abstractmethod
     def create_topic(self, topic: Topic, partitions: int) -> None:
         """
@@ -61,7 +61,7 @@ class MessageStorage(ABC, Generic[TStrategyPayload]):
     @abstractmethod
     def consume(
         self, partition: Partition, offset: int
-    ) -> Optional[BrokerValue[TStrategyPayload]]:
+    ) -> Optional[BrokerValue[KafkaPayload]]:
         """
         Consume a message from the provided partition, reading from the given
         offset. If no message exists at the given offset when reading from
@@ -79,8 +79,8 @@ class MessageStorage(ABC, Generic[TStrategyPayload]):
 
     @abstractmethod
     def produce(
-        self, partition: Partition, payload: TStrategyPayload, timestamp: datetime
-    ) -> BrokerValue[TStrategyPayload]:
+        self, partition: Partition, payload: KafkaPayload, timestamp: datetime
+    ) -> BrokerValue[KafkaPayload]:
         """
         Produce a single message to the provided partition.
 

--- a/arroyo/backends/local/storages/file.py
+++ b/arroyo/backends/local/storages/file.py
@@ -24,17 +24,17 @@ from arroyo.backends.local.storages.abstract import (
     TopicExists,
 )
 from arroyo.errors import OffsetOutOfRange
-from arroyo.types import BrokerValue, Partition, Topic, TStrategyPayload
+from arroyo.types import BrokerValue, KafkaPayload, Partition, Topic
 from arroyo.utils.codecs import Codec
 
 
 @dataclass(unsafe_hash=True)
-class FileValue(BrokerValue[TStrategyPayload]):
+class FileValue(BrokerValue[KafkaPayload]):
     _next_offset: int
 
     def __init__(
         self,
-        payload: TStrategyPayload,
+        payload: KafkaPayload,
         partition: Partition,
         offset: int,
         timestamp: datetime,
@@ -48,8 +48,8 @@ class FileValue(BrokerValue[TStrategyPayload]):
         return self._next_offset
 
 
-class PickleCodec(Codec[bytes, Tuple[TStrategyPayload, datetime]]):
-    def encode(self, value: Tuple[TStrategyPayload, datetime]) -> bytes:
+class PickleCodec(Codec[bytes, Tuple[KafkaPayload, datetime]]):
+    def encode(self, value: Tuple[KafkaPayload, datetime]) -> bytes:
         return pickle.dumps(value)
 
     def decode(self, value: bytes) -> Any:
@@ -85,11 +85,11 @@ class InvalidChecksum(ValueError):
     pass
 
 
-class FileMessageStorage(MessageStorage[TStrategyPayload]):
+class FileMessageStorage(MessageStorage):
     def __init__(
         self,
         directory: str,
-        codec: Codec[bytes, Tuple[TStrategyPayload, datetime]] = PickleCodec(),
+        codec: Codec[bytes, Tuple[KafkaPayload, datetime]] = PickleCodec(),
     ) -> None:
         self.__directory = Path(directory)
         assert self.__directory.exists() and self.__directory.is_dir()
@@ -159,8 +159,8 @@ class FileMessageStorage(MessageStorage[TStrategyPayload]):
         return len(self.__get_file_partitions_for_topic(topic))
 
     def produce(
-        self, partition: Partition, payload: TStrategyPayload, timestamp: datetime
-    ) -> BrokerValue[TStrategyPayload]:
+        self, partition: Partition, payload: KafkaPayload, timestamp: datetime
+    ) -> BrokerValue[KafkaPayload]:
         encoded = self.__codec.encode((payload, timestamp))
         file = self.__get_file_partition(partition).writer
         offset = file.tell()
@@ -172,7 +172,7 @@ class FileMessageStorage(MessageStorage[TStrategyPayload]):
 
     def consume(
         self, partition: Partition, offset: int
-    ) -> Optional[BrokerValue[TStrategyPayload]]:
+    ) -> Optional[BrokerValue[KafkaPayload]]:
         file_partition = self.__get_file_partition(partition)
         file = file_partition.reader
 

--- a/arroyo/backends/local/storages/memory.py
+++ b/arroyo/backends/local/storages/memory.py
@@ -8,13 +8,13 @@ from arroyo.backends.local.storages.abstract import (
     TopicExists,
 )
 from arroyo.errors import OffsetOutOfRange
-from arroyo.types import BrokerValue, Partition, Topic, TStrategyPayload
+from arroyo.types import BrokerValue, KafkaPayload, Partition, Topic
 
 
-class MemoryMessageStorage(MessageStorage[TStrategyPayload]):
+class MemoryMessageStorage(MessageStorage):
     def __init__(self) -> None:
         self.__topics: MutableMapping[
-            Topic, Sequence[MutableSequence[Tuple[TStrategyPayload, datetime]]]
+            Topic, Sequence[MutableSequence[Tuple[KafkaPayload, datetime]]]
         ] = {}
 
     def create_topic(self, topic: Topic, partitions: int) -> None:
@@ -40,7 +40,7 @@ class MemoryMessageStorage(MessageStorage[TStrategyPayload]):
 
     def __get_messages(
         self, partition: Partition
-    ) -> MutableSequence[Tuple[TStrategyPayload, datetime]]:
+    ) -> MutableSequence[Tuple[KafkaPayload, datetime]]:
         # TODO: Maybe this should be enforced in the ``Partition`` constructor?
         if not partition.index >= 0:
             raise PartitionDoesNotExist(partition)
@@ -54,7 +54,7 @@ class MemoryMessageStorage(MessageStorage[TStrategyPayload]):
 
     def consume(
         self, partition: Partition, offset: int
-    ) -> Optional[BrokerValue[TStrategyPayload]]:
+    ) -> Optional[BrokerValue[KafkaPayload]]:
         messages = self.__get_messages(partition)
 
         try:
@@ -67,8 +67,8 @@ class MemoryMessageStorage(MessageStorage[TStrategyPayload]):
         return BrokerValue(payload, partition, offset, timestamp)
 
     def produce(
-        self, partition: Partition, payload: TStrategyPayload, timestamp: datetime
-    ) -> BrokerValue[TStrategyPayload]:
+        self, partition: Partition, payload: KafkaPayload, timestamp: datetime
+    ) -> BrokerValue[KafkaPayload]:
         messages = self.__get_messages(partition)
 
         offset = len(messages)

--- a/arroyo/processing/processor.py
+++ b/arroyo/processing/processor.py
@@ -4,7 +4,7 @@ import logging
 import time
 from collections import defaultdict
 from enum import Enum
-from typing import Generic, Mapping, MutableMapping, Optional, Sequence
+from typing import Mapping, MutableMapping, Optional, Sequence
 
 from arroyo.backends.abstract import Consumer
 from arroyo.commit import CommitPolicy
@@ -14,7 +14,7 @@ from arroyo.processing.strategies.abstract import (
     ProcessingStrategy,
     ProcessingStrategyFactory,
 )
-from arroyo.types import BrokerValue, Message, Partition, Topic, TStrategyPayload
+from arroyo.types import BrokerValue, KafkaPayload, Message, Partition, Topic
 from arroyo.utils.metrics import get_metrics
 
 logger = logging.getLogger(__name__)
@@ -55,7 +55,7 @@ class MetricsBuffer:
             self.flush()
 
 
-class StreamProcessor(Generic[TStrategyPayload]):
+class StreamProcessor:
     """
     A stream processor manages the relationship between a ``Consumer``
     instance and a ``ProcessingStrategy``, ensuring that processing
@@ -65,9 +65,9 @@ class StreamProcessor(Generic[TStrategyPayload]):
 
     def __init__(
         self,
-        consumer: Consumer[TStrategyPayload],
+        consumer: Consumer,
         topic: Topic,
-        processor_factory: ProcessingStrategyFactory[TStrategyPayload],
+        processor_factory: ProcessingStrategyFactory[KafkaPayload],
         commit_policy: CommitPolicy,
         join_timeout: Optional[float] = None,
     ) -> None:
@@ -75,11 +75,9 @@ class StreamProcessor(Generic[TStrategyPayload]):
         self.__processor_factory = processor_factory
         self.__metrics_buffer = MetricsBuffer()
 
-        self.__processing_strategy: Optional[
-            ProcessingStrategy[TStrategyPayload]
-        ] = None
+        self.__processing_strategy: Optional[ProcessingStrategy[KafkaPayload]] = None
 
-        self.__message: Optional[BrokerValue[TStrategyPayload]] = None
+        self.__message: Optional[BrokerValue[KafkaPayload]] = None
 
         # If the consumer is in the paused state, this is when the last call to
         # ``pause`` occurred or the time the pause metric was last recorded.

--- a/arroyo/processing/strategies/dead_letter_queue/policies/produce.py
+++ b/arroyo/processing/strategies/dead_letter_queue/policies/produce.py
@@ -4,7 +4,6 @@ from concurrent.futures import Future
 from typing import Deque, Optional
 
 from arroyo.backends.abstract import Producer
-from arroyo.backends.kafka.consumer import KafkaPayload
 from arroyo.processing.strategies.dead_letter_queue.invalid_messages import (
     InvalidMessage,
     InvalidMessages,
@@ -12,7 +11,7 @@ from arroyo.processing.strategies.dead_letter_queue.invalid_messages import (
 from arroyo.processing.strategies.dead_letter_queue.policies.abstract import (
     DeadLetterQueuePolicy,
 )
-from arroyo.types import BrokerValue, Topic
+from arroyo.types import BrokerValue, KafkaPayload, Topic
 from arroyo.utils.metrics import get_metrics
 
 MAX_QUEUE_SIZE = 5000
@@ -23,9 +22,7 @@ class ProduceInvalidMessagePolicy(DeadLetterQueuePolicy):
     Produces given InvalidMessages to a dead letter topic.
     """
 
-    def __init__(
-        self, producer: Producer[KafkaPayload], dead_letter_topic: Topic
-    ) -> None:
+    def __init__(self, producer: Producer, dead_letter_topic: Topic) -> None:
         self.__closed = False
         self.__metrics = get_metrics()
         self.__dead_letter_topic = dead_letter_topic

--- a/arroyo/types.py
+++ b/arroyo/types.py
@@ -2,9 +2,39 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from datetime import datetime
-from typing import Generic, Mapping, Protocol, TypeVar
+from pickle import PickleBuffer
+from typing import (
+    Any,
+    Generic,
+    Mapping,
+    NamedTuple,
+    Optional,
+    Protocol,
+    Sequence,
+    SupportsIndex,
+    Tuple,
+    Type,
+    TypeVar,
+)
 
 TReplaced = TypeVar("TReplaced")
+
+Headers = Sequence[Tuple[str, bytes]]
+
+
+class KafkaPayload(NamedTuple):
+    key: Optional[bytes]
+    value: bytes
+    headers: Headers
+
+    def __reduce_ex__(self, protocol: SupportsIndex) -> Tuple[Type[KafkaPayload], Any]:
+        if int(protocol) >= 5:
+            return (
+                type(self),
+                (self.key, PickleBuffer(self.value), self.headers),
+            )
+        else:
+            return type(self), (self.key, self.value, self.headers)
 
 
 @dataclass(order=True, unsafe_hash=True)

--- a/examples/transform_and_produce/batched.py
+++ b/examples/transform_and_produce/batched.py
@@ -2,7 +2,7 @@ import json
 import logging
 from typing import Any, Mapping, MutableSequence, Sequence
 
-from arroyo.backends.kafka.consumer import KafkaPayload, KafkaProducer
+from arroyo.backends.kafka.consumer import KafkaProducer
 from arroyo.processing.strategies import (
     BatchStep,
     CommitOffsets,
@@ -15,7 +15,15 @@ from arroyo.processing.strategies.abstract import (
     ProcessingStrategyFactory,
 )
 from arroyo.processing.strategies.batching import ValuesBatch
-from arroyo.types import BaseValue, Commit, Message, Partition, Topic, Value
+from arroyo.types import (
+    BaseValue,
+    Commit,
+    KafkaPayload,
+    Message,
+    Partition,
+    Topic,
+    Value,
+)
 
 logger = logging.getLogger(__name__)
 

--- a/examples/transform_and_produce/simple.py
+++ b/examples/transform_and_produce/simple.py
@@ -3,13 +3,13 @@ import json
 import logging
 from typing import Mapping
 
-from arroyo.backends.kafka.consumer import KafkaPayload, KafkaProducer
+from arroyo.backends.kafka.consumer import KafkaProducer
 from arroyo.processing.strategies import CommitOffsets, Produce, TransformStep
 from arroyo.processing.strategies.abstract import (
     ProcessingStrategy,
     ProcessingStrategyFactory,
 )
-from arroyo.types import Commit, Message, Partition, Topic
+from arroyo.types import Commit, KafkaPayload, Message, Partition, Topic
 
 logger = logging.getLogger(__name__)
 

--- a/tests/backends/mixins.py
+++ b/tests/backends/mixins.py
@@ -2,18 +2,18 @@ import time
 import uuid
 from abc import ABC, abstractmethod
 from contextlib import closing
-from typing import ContextManager, Generic, Iterator, Mapping, Optional, Sequence
+from typing import ContextManager, Iterator, Mapping, Optional, Sequence
 from unittest import mock
 
 import pytest
 
 from arroyo.backends.abstract import Consumer, Producer
 from arroyo.errors import ConsumerError, EndOfPartition, OffsetOutOfRange
-from arroyo.types import BrokerValue, Partition, Topic, TStrategyPayload
+from arroyo.types import BrokerValue, KafkaPayload, Partition, Topic
 from tests.assertions import assert_changes, assert_does_not_change
 
 
-class StreamsTestMixin(ABC, Generic[TStrategyPayload]):
+class StreamsTestMixin(ABC):
     @abstractmethod
     def get_topic(self, partitions: int = 1) -> ContextManager[Topic]:
         raise NotImplementedError
@@ -21,15 +21,15 @@ class StreamsTestMixin(ABC, Generic[TStrategyPayload]):
     @abstractmethod
     def get_consumer(
         self, group: Optional[str] = None, enable_end_of_partition: bool = True
-    ) -> Consumer[TStrategyPayload]:
+    ) -> Consumer:
         raise NotImplementedError
 
     @abstractmethod
-    def get_producer(self) -> Producer[TStrategyPayload]:
+    def get_producer(self) -> Producer:
         raise NotImplementedError
 
     @abstractmethod
-    def get_payloads(self) -> Iterator[TStrategyPayload]:
+    def get_payloads(self) -> Iterator[KafkaPayload]:
         raise NotImplementedError
 
     def test_consumer(self) -> None:

--- a/tests/backends/test_kafka.py
+++ b/tests/backends/test_kafka.py
@@ -68,7 +68,7 @@ def get_topic(
         assert future.result() is None
 
 
-class KafkaStreamsTestCase(StreamsTestMixin[KafkaPayload], TestCase):
+class KafkaStreamsTestCase(StreamsTestMixin, TestCase):
 
     configuration = build_kafka_configuration(
         {"bootstrap.servers": os.environ.get("DEFAULT_BROKERS", "localhost:9092")}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,7 +4,6 @@ import pytest
 
 from arroyo.backends.local.backend import LocalBroker
 from arroyo.backends.local.storages.memory import MemoryMessageStorage
-from arroyo.types import TStrategyPayload
 from arroyo.utils.clock import TestingClock
 from arroyo.utils.metrics import configure_metrics
 from tests.metrics import TestingMetricsBackend
@@ -21,5 +20,5 @@ def clear_metrics_state() -> Iterator[None]:
 
 
 @pytest.fixture
-def broker() -> Iterator[LocalBroker[TStrategyPayload]]:
+def broker() -> Iterator[LocalBroker]:
     yield LocalBroker(MemoryMessageStorage(), TestingClock())

--- a/tests/processing/strategies/test_dead_letter_queue.py
+++ b/tests/processing/strategies/test_dead_letter_queue.py
@@ -336,7 +336,7 @@ def test_produce_invalid_messages(
     invalid_message_no_key: Message[KafkaPayload],
     invalid_message_bad_value: Message[KafkaPayload],
     processing_step: FakeProcessingStep,
-    broker: LocalBroker[KafkaPayload],
+    broker: LocalBroker,
 ) -> None:
     producer = broker.get_producer()
     topic = Topic("test-dead-letter-topic")

--- a/tests/processing/strategies/test_produce.py
+++ b/tests/processing/strategies/test_produce.py
@@ -13,7 +13,7 @@ def test_produce() -> None:
     result_topic = Topic("result-topic")
     clock = TestingClock()
     broker_storage: MemoryMessageStorage[KafkaPayload] = MemoryMessageStorage()
-    broker: LocalBroker[KafkaPayload] = LocalBroker(broker_storage, clock)
+    broker: LocalBroker = LocalBroker(broker_storage, clock)
     broker.create_topic(result_topic, partitions=1)
 
     producer = broker.get_producer()
@@ -49,7 +49,7 @@ def test_produce_and_commit() -> None:
     result_topic = Topic("result-topic")
     clock = TestingClock()
     broker_storage: MemoryMessageStorage[KafkaPayload] = MemoryMessageStorage()
-    broker: LocalBroker[KafkaPayload] = LocalBroker(broker_storage, clock)
+    broker: LocalBroker = LocalBroker(broker_storage, clock)
     broker.create_topic(result_topic, partitions=1)
 
     producer = broker.get_producer()

--- a/tests/processing/strategies/test_produce.py
+++ b/tests/processing/strategies/test_produce.py
@@ -12,7 +12,7 @@ def test_produce() -> None:
     orig_topic = Topic("orig-topic")
     result_topic = Topic("result-topic")
     clock = TestingClock()
-    broker_storage: MemoryMessageStorage[KafkaPayload] = MemoryMessageStorage()
+    broker_storage = MemoryMessageStorage()
     broker: LocalBroker = LocalBroker(broker_storage, clock)
     broker.create_topic(result_topic, partitions=1)
 
@@ -48,7 +48,7 @@ def test_produce_and_commit() -> None:
     orig_topic = Topic("orig-topic")
     result_topic = Topic("result-topic")
     clock = TestingClock()
-    broker_storage: MemoryMessageStorage[KafkaPayload] = MemoryMessageStorage()
+    broker_storage = MemoryMessageStorage()
     broker: LocalBroker = LocalBroker(broker_storage, clock)
     broker.create_topic(result_topic, partitions=1)
 


### PR DESCRIPTION
Throwing this up as an alternative idea to https://github.com/getsentry/arroyo/pull/200.

I don't think there's any reason why stream processor, producer and consumer actually need to be generic. It makes typing more annoying for users and AFAIK there's no reason why we shouldn't enforce that a message consumed or produced needs to be a KafkaPayload - that is - a tuple of key, value (bytes) and headers.