### PR TITLE
fix: RunTaskWithMultiprocessing support for filtered message

### DIFF
--- a/arroyo/processing/strategies/run_task.py
+++ b/arroyo/processing/strategies/run_task.py
@@ -61,7 +61,7 @@ class RunTask(
         self, message: Message[Union[FilteredPayload, TStrategyPayload]]
     ) -> None:
         if isinstance(message.payload, FilteredPayload):
-            self.__next_step.submit(cast(Message[TResult], message))
+            self.__next_step.submit(cast(Message[FilteredPayload], message))
         else:
             result = self.__function(cast(Message[TStrategyPayload], message))
             value = message.value.replace(result)
@@ -430,7 +430,7 @@ class RunTaskWithMultiprocessing(
     def __init__(
         self,
         function: Callable[[Message[TStrategyPayload]], TResult],
-        next_step: ProcessingStrategy[TResult],
+        next_step: ProcessingStrategy[Union[FilteredPayload, TResult]],
         num_processes: int,
         max_batch_size: int,
         max_batch_time: float,


### PR DESCRIPTION
Noticed this when working on the DLQ feature. RunTask and RunTask in threads take a next_step which is `ProcessingStrategy[Union[FilteredPayload, TResult]]` but RunTaskWithMultiprocessing did not. Not sure if there was a reason for the difference. This PR brings the API for all of these strategies in line.