### PR TITLE
fix: Prevent repeated calls to consumer.pause() if already paused

### DIFF
--- a/arroyo/processing/processor.py
+++ b/arroyo/processing/processor.py
@@ -258,7 +258,9 @@ class StreamProcessor(Generic[TStrategyPayload]):
                             e,
                             self.__message,
                         )
-                        self.__consumer.pause([*self.__consumer.tell().keys()])
+
+                        if self.__paused_timestamp is not None:
+                            self.__consumer.pause([*self.__consumer.tell().keys()])
 
                         self.__paused_timestamp = time.time()
                     else:

--- a/arroyo/processing/processor.py
+++ b/arroyo/processing/processor.py
@@ -259,7 +259,7 @@ class StreamProcessor(Generic[TStrategyPayload]):
                             self.__message,
                         )
 
-                        if self.__paused_timestamp is not None:
+                        if self.__paused_timestamp is None:
                             self.__consumer.pause([*self.__consumer.tell().keys()])
 
                         self.__paused_timestamp = time.time()


### PR DESCRIPTION
Let's prevent excessive calls to pause if we are already paused anyway.