### PR TITLE
Revert "fix: Prevent repeated calls to consumer.pause() if already pa…

### DIFF
--- a/arroyo/processing/processor.py
+++ b/arroyo/processing/processor.py
@@ -258,9 +258,7 @@ class StreamProcessor(Generic[TStrategyPayload]):
                             e,
                             self.__message,
                         )
-
-                        if self.__paused_timestamp is None:
-                            self.__consumer.pause([*self.__consumer.tell().keys()])
+                        self.__consumer.pause([*self.__consumer.tell().keys()])
 
                         self.__paused_timestamp = time.time()
                     else:


### PR DESCRIPTION
…used (#209)"

This reverts commit 1d34fa56310465c8183abb3618f178ffb4773352.

Caused errors like "InvalidStateError - received message when consumer was expected to be paused" when we tried this.