### PR TITLE
fix: Fix installation of sphinx-autodoc-typehints

### DIFF
--- a/docs-requirements.txt
+++ b/docs-requirements.txt
@@ -1,5 +1,5 @@
-sphinx==5.0.0
+sphinx>=5.3
 sphinxcontrib-mermaid==0.7.1
 sphinx-rtd-theme
-sphinx-autodoc-typehints[type_comments]>=1.8.0
+sphinx-autodoc-typehints[type-comment]>=1.19.3
 typing-extensions


### PR DESCRIPTION
Seems like the extra got randomly renamed in an effort to modernize
packaging: https://github.com/tox-dev/sphinx-autodoc-typehints/issues/263

Also relax requirements on sphinx so that there's no dep conflict