### PR TITLE
fix: Add metrics around RunTaskWithMultiprocessing + docs [SNS-2204]

### DIFF
--- a/arroyo/processing/strategies/run_task_with_multiprocessing.py
+++ b/arroyo/processing/strategies/run_task_with_multiprocessing.py
@@ -458,7 +458,7 @@ class RunTaskWithMultiprocessing(
                 result.next_index_to_process = idx
 
         if result.next_index_to_process != len(input_batch):
-            self.__metrics.increment("batch.output.overflow")
+            self.__metrics.increment("arroyo.strategies.run_task_with_multiprocessing.batch.output.overflow")
             logger.warning(
                 "Received incomplete batch (%0.2f%% complete), resubmitting...",
                 result.next_index_to_process / len(input_batch) * 100,

--- a/arroyo/processing/strategies/run_task_with_multiprocessing.py
+++ b/arroyo/processing/strategies/run_task_with_multiprocessing.py
@@ -458,7 +458,9 @@ class RunTaskWithMultiprocessing(
                 result.next_index_to_process = idx
 
         if result.next_index_to_process != len(input_batch):
-            self.__metrics.increment("arroyo.strategies.run_task_with_multiprocessing.batch.output.overflow")
+            self.__metrics.increment(
+                "arroyo.strategies.run_task_with_multiprocessing.batch.output.overflow"
+            )
             logger.warning(
                 "Received incomplete batch (%0.2f%% complete), resubmitting...",
                 result.next_index_to_process / len(input_batch) * 100,
@@ -543,7 +545,9 @@ class RunTaskWithMultiprocessing(
             self.__batch_builder.append(message)
         except ValueTooLarge as e:
             logger.debug("Caught %r, closing batch and retrying...", e)
-            self.__metrics.increment("batch.input.overflow")
+            self.__metrics.increment(
+                "arroyo.strategies.run_task_with_multiprocessing.batch.input.overflow"
+            )
             self.__submit_batch()
 
             # This may raise ``MessageRejected`` (if all of the shared memory

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,2 +1,3 @@
 [pytest]
 addopts = --benchmark-disable
+python_files = tests/assertions.py

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,2 @@
 [pytest]
 addopts = --benchmark-disable
-python_files = tests/assertions.py

--- a/tests/assertions.py
+++ b/tests/assertions.py
@@ -1,44 +1,31 @@
-import operator
 from contextlib import contextmanager
-from typing import Any, Callable, Iterator, TypeVar, cast
-
-T = TypeVar("T")
+from typing import Any, Callable, Iterator
 
 
 @contextmanager
 def assert_changes(
     callable: Callable[[], Any],
-    before: T,
-    after: T,
-    operator: Callable[[T, T], bool] = operator.eq,
+    before: Any,
+    after: Any,
 ) -> Iterator[None]:
-    actual = cast(T, callable())
-    assert operator(
-        actual, before
-    ), f"precondition ({operator}) on {callable} failed: expected: {before!r}, actual: {actual!r}"
+    actual = callable()
+    assert actual == before
 
     yield
 
     actual = callable()
-    assert operator(
-        actual, after
-    ), f"postcondition ({operator}) on {callable} failed: expected: {after!r}, actual: {actual!r}"
+    assert actual == after
 
 
 @contextmanager
 def assert_does_not_change(
     callable: Callable[[], Any],
-    value: T,
-    operator: Callable[[T, T], bool] = operator.eq,
+    value: Any,
 ) -> Iterator[None]:
-    actual = cast(T, callable())
-    assert operator(
-        actual, value
-    ), f"precondition ({operator}) on {callable} failed: expected: {value!r}, actual: {actual!r}"
+    actual = callable()
+    assert actual == value
 
     yield
 
     actual = callable()
-    assert operator(
-        actual, value
-    ), f"postcondition ({operator}) on {callable} failed: expected: {value!r}, actual: {actual!r}"
+    assert actual == value

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,8 @@ from typing import Iterator
 
 import pytest
 
+pytest.register_assert_rewrite("tests.assertions")
+
 from arroyo.backends.local.backend import LocalBroker
 from arroyo.backends.local.storages.memory import MemoryMessageStorage
 from arroyo.types import TStrategyPayload

--- a/tests/processing/strategies/test_run_task_with_multiprocessing.py
+++ b/tests/processing/strategies/test_run_task_with_multiprocessing.py
@@ -218,7 +218,11 @@ def test_parallel_transform_step() -> None:
         [
             GaugeCall("batches_in_progress", 0.0, tags=None),
             GaugeCall("transform.processes", 2.0, tags=None),
-            IncrementCall(name="batch.input.overflow", value=1, tags=None),
+            IncrementCall(
+                name="arroyo.strategies.run_task_with_multiprocessing.batch.input.overflow",
+                value=1,
+                tags=None,
+            ),
             GaugeCall("batches_in_progress", 1.0, tags=None),
             TimingCall("batch.size.msg", 3, None),
             TimingCall("batch.size.bytes", 16000, None),
@@ -253,7 +257,11 @@ def test_parallel_transform_step() -> None:
         lambda: metrics.calls,
         [],
         [
-            IncrementCall(name="batch.output.overflow", value=1, tags=None),
+            IncrementCall(
+                name="arroyo.strategies.run_task_with_multiprocessing.batch.output.overflow",
+                value=1,
+                tags=None,
+            ),
             GaugeCall("batches_in_progress", 1.0, tags=None),
             GaugeCall("batches_in_progress", 0.0, tags=None),
         ],

--- a/tests/processing/strategies/test_run_task_with_multiprocessing.py
+++ b/tests/processing/strategies/test_run_task_with_multiprocessing.py
@@ -23,6 +23,7 @@ from arroyo.processing.strategies.run_task_with_multiprocessing import (
 from arroyo.types import Message, Partition, Topic, Value
 from tests.assertions import assert_changes, assert_does_not_change
 from tests.metrics import Gauge as GaugeCall
+from tests.metrics import Increment as IncrementCall
 from tests.metrics import TestingMetricsBackend
 from tests.metrics import Timing as TimingCall
 
@@ -217,6 +218,7 @@ def test_parallel_transform_step() -> None:
         [
             GaugeCall("batches_in_progress", 0.0, tags=None),
             GaugeCall("transform.processes", 2.0, tags=None),
+            IncrementCall(name="batch.input.overflow", value=1, tags=None),
             GaugeCall("batches_in_progress", 1.0, tags=None),
             TimingCall("batch.size.msg", 3, None),
             TimingCall("batch.size.bytes", 16000, None),
@@ -250,7 +252,11 @@ def test_parallel_transform_step() -> None:
     ), assert_changes(
         lambda: metrics.calls,
         [],
-        [GaugeCall("batches_in_progress", value, tags=None) for value in [1.0, 0.0]],
+        [
+            IncrementCall(name="batch.output.overflow", value=1, tags=None),
+            GaugeCall("batches_in_progress", 1.0, tags=None),
+            GaugeCall("batches_in_progress", 0.0, tags=None),
+        ],
     ):
         transform_step.join()
 


### PR DESCRIPTION
I am investigating an issue where increasing the buffer size increased consumer lag, e2e latency metrics and avg batch size. Turns out that this behavior is intentional, and we just have to document it better and add instrumentation.