### PR TITLE
ref: Clean up documentation

### DIFF
--- a/arroyo/processing/strategies/reduce.py
+++ b/arroyo/processing/strategies/reduce.py
@@ -174,3 +174,6 @@ class Reduce(
         self.__next_step.join(
             timeout=max(deadline - time.time(), 0) if deadline is not None else None
         )
+
+
+__all__ = ["Reduce"]

--- a/docs-requirements.txt
+++ b/docs-requirements.txt
@@ -1,5 +1,5 @@
 sphinx>=5.3
-sphinxcontrib-mermaid==0.7.1
-sphinx-rtd-theme
+sphinxcontrib-mermaid==0.8.1
+shibuya
 sphinx-autodoc-typehints[type-comment]>=1.19.3
 typing-extensions

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -37,8 +37,10 @@ source_suffix = ".rst"
 
 # -- Options for HTML output -------------------------------------------------
 
-html_theme = "sphinx_rtd_theme"
+html_theme = "shibuya"
 
 html_static_path = ["_static"]
 
 # html_logo = "_static/arroyo.png"
+
+autodoc_inherit_docstrings = False

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -6,8 +6,8 @@ Contents:
 .. toctree::
    :maxdepth: 1
 
-   getstarted
    what_for
+   getstarted
    architecture
    strategies
    offsets

--- a/docs/source/strategies.rst
+++ b/docs/source/strategies.rst
@@ -4,23 +4,11 @@ Processing Strategies
 The processing strategies are the components to be wired together to
 build a consumer.
 
-Processing Strategy Interface
------------------------------
-
-The abstract interface to be implemented when creating a new Processing Strategy
-
-.. automodule:: arroyo.processing.strategies.abstract
-   :members:
-   :undoc-members:
-   :show-inheritance:
-
-
 Filter
 -----------------------------
 
 .. automodule:: arroyo.processing.strategies.filter
    :members:
-   :undoc-members:
 
 
 Reduce (Fold)
@@ -30,7 +18,6 @@ Accumulate messages based on a custom accumulator function
 
 .. automodule:: arroyo.processing.strategies.reduce
    :members:
-   :undoc-members:
 
 Unfold
 -----------------------------
@@ -39,7 +26,6 @@ Generates a sequence of messages from a single message based on a custom generat
 
 .. automodule:: arroyo.processing.strategies.unfold
    :members:
-   :undoc-members:
 
 
 Batch and Unbatch
@@ -52,7 +38,6 @@ accumulator/generator functions.
 
 .. automodule:: arroyo.processing.strategies.batching
    :members:
-   :undoc-members:
 
 
 Run Task
@@ -60,7 +45,6 @@ Run Task
 
 .. automodule:: arroyo.processing.strategies.run_task
    :members:
-   :undoc-members:
 
 
 Run Task in Threads
@@ -68,7 +52,6 @@ Run Task in Threads
 
 .. automodule:: arroyo.processing.strategies.run_task_in_threads
    :members:
-   :undoc-members:
 
 
 Run Task with Multiprocessing
@@ -76,18 +59,6 @@ Run Task with Multiprocessing
 
 .. automodule:: arroyo.processing.strategies.run_task_with_multiprocessing
    :members:
-   :undoc-members:
-
-
-Transformers
------------------------------
-
-Transformation steps. They transform the messages one by one provided a processing
-function. Alias for RunTask strategies.
-
-.. automodule:: arroyo.processing.strategies.transform
-   :members:
-   :undoc-members:
 
 
 Producers
@@ -95,29 +66,7 @@ Producers
 
 .. automodule:: arroyo.processing.strategies.produce
    :members:
-   :undoc-members:
 
-
-Decoders
------------------------------
-
-Provides decoders and schema validation for messages
-
-.. automodule:: arroyo.processing.strategies.decoder
-   :members:
-   :undoc-members:
-
-
-Dead Letter Queue
------------------------------
-
-Arroyo's DLQ is subject to change, and will likely be redesigned from the
-ground up in an upcoming release.
-
-.. automodule:: arroyo.processing.strategies.dead_letter_queue
-   :members:
-   :undoc-members:
-   :show-inheritance:
 
 Commit offsets
 -----------------------------
@@ -127,4 +76,16 @@ that offsets are only committed once all processing is complete.
 
 .. automodule:: arroyo.processing.strategies.commit
    :members:
+
+
+Writing your own strategy
+-------------------------
+
+We normally don't recommend writing your own strategy, and encourage you to use
+built-in ones such as "reduce" or "run task" to plug in your application logic.
+Nevertheless, all arroyo strategies are written against the following interface:
+
+.. automodule:: arroyo.processing.strategies.abstract
+   :members:
    :undoc-members:
+   :show-inheritance:


### PR DESCRIPTION
while working on https://github.com/getsentry/arroyo/pull/220:

* swap out the docs theme for a nicer one
* remove a bunch of autogenerated documentation that isn't useful to
  arroyo users (join(), close(), MessageBatch)
* remove documentation for legacy DLQs, decoders, encoders and
  TransformStep. Codecs kind of moved into sentry-kafka-schemas,
  decoders and encoders ended up not being used (and also reference
  arroyo's own codecs), transform step is an alias for RunTask.
* Fix broken mermaid diagrams by upgrading the library
