### PR TITLE
fix: Do not log error when consumer is already crashing

### DIFF
--- a/arroyo/utils/logging.py
+++ b/arroyo/utils/logging.py
@@ -1,4 +1,5 @@
 from logging import CRITICAL, DEBUG, ERROR, INFO, NOTSET, WARNING
+from typing import Callable, Optional
 
 PYTHON_TO_SYSLOG_MAP = {
     NOTSET: 7,
@@ -12,3 +13,13 @@ PYTHON_TO_SYSLOG_MAP = {
 
 def pylog_to_syslog_level(level: int) -> int:
     return PYTHON_TO_SYSLOG_MAP.get(level, 7)
+
+
+# A callback overwritten by testsuite so that we can assert there are no
+# internal errors.
+_handle_internal_error: Optional[Callable[[Exception], None]] = None
+
+
+def handle_internal_error(e: Exception) -> None:
+    if _handle_internal_error is not None:
+        _handle_internal_error(e)

--- a/tests/backends/test_kafka.py
+++ b/tests/backends/test_kafka.py
@@ -187,7 +187,7 @@ class TestKafkaStreams(StreamsTestMixin[KafkaPayload]):
             with closing(self.get_producer()) as producer:
                 producer.produce(topic, next(self.get_payloads())).result(5.0)
 
-            with closing(self.get_consumer(auto_offset_reset="latest")) as consumer:
+            with closing(self.get_consumer()) as consumer:
                 processor = StreamProcessor(consumer, topic, factory, IMMEDIATE)
 
                 with pytest.raises(RuntimeError):

--- a/tests/backends/test_kafka.py
+++ b/tests/backends/test_kafka.py
@@ -7,7 +7,7 @@ from contextlib import closing
 from datetime import datetime
 from pickle import PickleBuffer
 from typing import Any, Iterator, Mapping, MutableSequence, Optional
-from unittest import TestCase, mock
+from unittest import mock
 
 import pytest
 from confluent_kafka.admin import AdminClient, NewTopic
@@ -69,7 +69,7 @@ def get_topic(
         assert future.result() is None
 
 
-class KafkaStreamsTestCase(StreamsTestMixin[KafkaPayload], TestCase):
+class TestKafkaStreams(StreamsTestMixin[KafkaPayload]):
 
     configuration = build_kafka_configuration(
         {"bootstrap.servers": os.environ.get("DEFAULT_BROKERS", "localhost:9092")}

--- a/tests/backends/test_kafka.py
+++ b/tests/backends/test_kafka.py
@@ -7,7 +7,7 @@ from contextlib import closing
 from datetime import datetime
 from pickle import PickleBuffer
 from typing import Any, Iterator, Mapping, MutableSequence, Optional
-from unittest import TestCase
+from unittest import TestCase, mock
 
 import pytest
 from confluent_kafka.admin import AdminClient, NewTopic
@@ -16,8 +16,9 @@ from arroyo.backends.kafka import KafkaConsumer, KafkaPayload, KafkaProducer
 from arroyo.backends.kafka.commit import CommitCodec
 from arroyo.backends.kafka.configuration import build_kafka_configuration
 from arroyo.backends.kafka.consumer import as_kafka_configuration_bool
-from arroyo.commit import Commit
+from arroyo.commit import IMMEDIATE, Commit
 from arroyo.errors import ConsumerError, EndOfPartition
+from arroyo.processing.processor import StreamProcessor
 from arroyo.types import BrokerValue, Partition, Topic
 from tests.backends.mixins import StreamsTestMixin
 
@@ -175,6 +176,22 @@ class KafkaStreamsTestCase(StreamsTestMixin[KafkaPayload], TestCase):
 
                 with pytest.raises(ConsumerError):
                     consumer.poll(10.0)  # XXX: getting the subcription is slow
+
+    def test_consumer_stream_processor_shutdown(self) -> None:
+        strategy = mock.Mock()
+        strategy.poll.side_effect = RuntimeError("goodbye")
+        factory = mock.Mock()
+        factory.create_with_partitions.return_value = strategy
+
+        with self.get_topic() as topic:
+            with closing(self.get_producer()) as producer:
+                producer.produce(topic, next(self.get_payloads())).result(5.0)
+
+            with closing(self.get_consumer(auto_offset_reset="latest")) as consumer:
+                processor = StreamProcessor(consumer, topic, factory, IMMEDIATE)
+
+                with pytest.raises(RuntimeError):
+                    processor.run()
 
 
 def test_commit_codec() -> None:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,4 @@
-from typing import Iterator
+from typing import Generator, Iterator, List
 
 import pytest
 
@@ -25,3 +25,18 @@ def clear_metrics_state() -> Iterator[None]:
 @pytest.fixture
 def broker() -> Iterator[LocalBroker[TStrategyPayload]]:
     yield LocalBroker(MemoryMessageStorage(), TestingClock())
+
+
+@pytest.fixture(autouse=True)
+def assert_no_internal_errors(
+    monkeypatch: pytest.MonkeyPatch,
+) -> Generator[None, None, None]:
+    from arroyo.utils import logging
+
+    errors: List[Exception] = []
+    monkeypatch.setattr(logging, "_handle_internal_error", errors.append)
+
+    yield
+
+    for e in errors:
+        raise e

--- a/tests/processing/test_processor.py
+++ b/tests/processing/test_processor.py
@@ -110,9 +110,9 @@ def test_stream_processor_lifecycle() -> None:
     with assert_changes(lambda: int(strategy.close.call_count), 1, 2):
         revocation_callback([Partition(topic, 0)])
 
-    # Revocation should fail without an active assignment.
-    with pytest.raises(InvalidStateError):
-        revocation_callback([Partition(topic, 0)])
+    # Revocation should noop without an active assignment.
+    revocation_callback([Partition(topic, 0)])
+    revocation_callback([Partition(topic, 0)])
 
     # The processor should not accept non-heartbeat messages without an
     # assignment or active processor.


### PR DESCRIPTION
When the consumer is crashing, we are terminating the strategy in
`StreamProcessor.run`. Later, rdkafka does partition revocation. At that
point the strategy is already None.

I currently believe this behavior has been there since a very long time
and does not cause any practical issues in production we are currently
seeing (such as consumers stalling and not processing any messages), and
rather that we are seeing this as a side-effect of exception logging in
rdkafka callbacks having been improved recently.

However, we are seeing this exception now in Sentry, and it should be
fixed.
