### PR TITLE
fix(run_task_with_multiprocessing): Do not attempt to skip over invalid messages

### DIFF
--- a/arroyo/processing/strategies/run_task_with_multiprocessing.py
+++ b/arroyo/processing/strategies/run_task_with_multiprocessing.py
@@ -438,6 +438,7 @@ class RunTaskWithMultiprocessing(
 
             except MessageRejected:
                 result.next_index_to_process = idx
+                break
 
         if result.next_index_to_process != len(input_batch):
             self.__metrics.increment(

--- a/arroyo/types.py
+++ b/arroyo/types.py
@@ -63,6 +63,16 @@ class Message(Generic[TMessagePayload]):
         # ``dataclasses.field(repr=False)`` as this class is defined with
         # ``__slots__`` for performance reasons. The class variable names
         # would conflict with the instance slot names, causing an error.
+
+        if type(self.value) in (float, int):
+            # For the case where value is a float or int, the repr is small and
+            # therefore safe. This is very useful in tests.
+            #
+            # To prevent any nasty surprises with custom integer subtypes that
+            # may have modified reprs we do not use isinstance.
+            return f"{type(self).__name__}({self.value}, {self.committable!r})"
+
+        # For any other type we cannot be sure the repr is performant.
         return f"{type(self).__name__}({self.committable!r})"
 
     @property


### PR DESCRIPTION
This may have caused data inconsistencies in the past, and hangs on
join()
