### PR TITLE
docs: Minor readability details

### DIFF
--- a/docs/source/architecture.rst
+++ b/docs/source/architecture.rst
@@ -91,7 +91,7 @@ use cases.
 
 Common examples are:
 
-* ``run task, run task in threads, run task with multiprocessing ```. The run task
+* ``run task, run task in threads, run task with multiprocessing``. The run task
   set of strategies are designed to be the most flexible and simple to use. They take
   a function provided by the user and execute it on every message, passing the output
   to the next step. The library includes synchronous and asynchronous versions depending

--- a/docs/source/getstarted.rst
+++ b/docs/source/getstarted.rst
@@ -19,14 +19,14 @@ a Kafka docker container. (It requires Docker to be installed).
 
 .. code-block:: Bash
 
-    docker run   --rm \
+    docker run --rm \
         -v zookeeper_volume:/var/lib/zookeeper \
         --env ZOOKEEPER_CLIENT_PORT=2181 \
         --name=zookeeper \
         -p 2181:2181 \
         confluentinc/cp-zookeeper:6.2.0
 
-    docker run   --rm \
+    docker run --rm \
         -v kafka_volume:/var/lib/kafka \
         --env KAFKA_ZOOKEEPER_CONNECT=localhost:2181 \
         --env KAFKA_LISTENERS=INTERNAL://0.0.0.0:9093,EXTERNAL://0.0.0.0:9092 \

--- a/docs/source/what_for.rst
+++ b/docs/source/what_for.rst
@@ -53,9 +53,7 @@ The most simple kafka consumer looks something like this:
 
    while True:
        message = consumer.poll()
-       send_to_destination(
-           process_message(message)
-     )
+       send_to_destination(process_message(message))
 
 This simple consumer would not satisfy the goals mentioned at the top of
 this page. The following subsections will explain why
@@ -83,7 +81,7 @@ reached its destination in the following way:
    # add this value to the config:
    "enable.auto.commit": "false"
    # -------
-   message = consumer.poll(0)
+   message = consumer.poll(timeout=0)
    send_to_destination(process_message(message))
    consumer.commit(message.offset())
 
@@ -102,7 +100,7 @@ batches
    # this code is purely descriptive.
    # We have to commit to each partition separately
    # but that code is not helpful for this example
-   message = consumer.poll(0)
+   message = consumer.poll(timeout=0)
    batch.append(process_message(message))
    if len(batch) == batch_size:
        consumer.commit(offsets=[m.offset() for m in batch])
@@ -125,7 +123,7 @@ operation. Here is how a simple Kafka Producer looks in code:
    }
    producer = Producer(conf)
    def send_to_destination(message):
-       # ❗This does not do what it says
+       # ❗ This does not do what it says
        # it writes to a buffer
        producer.produce("destination_topic", message)
        # this will actually block until the messages are produced
@@ -232,7 +230,7 @@ librdkafka’s Callback Hell
 
 librdkafka uses callbacks as a core mechanic for control flow. A few
 such examples have been mentioned in this document already. What is not
-clear however, is that **callbacks are only called when ``poll`` is
+clear however, is that **callbacks are only called when `poll` is
 called**
 
 This means that:

--- a/docs/source/what_for.rst
+++ b/docs/source/what_for.rst
@@ -230,7 +230,7 @@ librdkafka’s Callback Hell
 
 librdkafka uses callbacks as a core mechanic for control flow. A few
 such examples have been mentioned in this document already. What is not
-clear however, is that **callbacks are only called when `poll` is
+clear however, is that **callbacks are only called when ``poll`` is
 called**
 
 This means that:


### PR DESCRIPTION
Spacing, invalid code blocks, unified indents, added `timeout=` to make it obvious what that `0` actually is.