### PR TITLE
fix(multiprocessing): More performant backpressure [INC-378]

### DIFF
--- a/arroyo/processing/strategies/run_task_with_multiprocessing.py
+++ b/arroyo/processing/strategies/run_task_with_multiprocessing.py
@@ -445,6 +445,8 @@ class RunTaskWithMultiprocessing(
                     else None
                 )
             except NextStepTimeoutError:
+                if deadline is None or deadline > time.time():
+                    continue
                 break
             except multiprocessing.TimeoutError:
                 if self.__pool_waiting_time is None:

--- a/arroyo/processing/strategies/run_task_with_multiprocessing.py
+++ b/arroyo/processing/strategies/run_task_with_multiprocessing.py
@@ -431,6 +431,36 @@ class RunTaskWithMultiprocessing(
                     pass
 
     def __check_for_results(self, timeout: Optional[float] = None) -> None:
+        deadline = time.time() + timeout if timeout is not None else None
+
+        while self.__processes:
+            try:
+                self.__check_for_results_impl(
+                    timeout=max(deadline - time.time(), 0)
+                    if deadline is not None
+                    else None
+                )
+            except multiprocessing.TimeoutError:
+                if self.__pool_waiting_time is None:
+                    self.__pool_waiting_time = time.time()
+                else:
+                    current_time = time.time()
+                    if current_time - self.__pool_waiting_time > LOG_THRESHOLD_TIME:
+                        logger.warning(
+                            "Waited on the process pool longer than %d seconds. Waiting for %d results. Pool: %r",
+                            LOG_THRESHOLD_TIME,
+                            len(self.__processes),
+                            self.__pool,
+                        )
+                        self.__pool_waiting_time = current_time
+                break
+            else:
+                self.__pool_waiting_time = None
+
+                if deadline is not None and time.time() > deadline:
+                    break
+
+    def __check_for_results_impl(self, timeout: Optional[float] = None) -> None:
         input_batch, async_result = self.__processes[0]
 
         # If this call is being made in a context where it is intended to be
@@ -443,10 +473,9 @@ class RunTaskWithMultiprocessing(
 
         result = async_result.get(timeout=timeout)
 
-        next_step_has_applied_backpressure = False
-
         for idx, message in result.valid_messages_transformed:
             if isinstance(message, InvalidMessage):
+                # For the next invocation of __check_for_results, skip over this message
                 result.valid_messages_transformed.reset_iterator(idx + 1)
                 self.__invalid_messages.append(message)
                 raise message
@@ -456,24 +485,29 @@ class RunTaskWithMultiprocessing(
                 self.__next_step.submit(message)
 
             except MessageRejected:
-                result.next_index_to_process = idx
-                next_step_has_applied_backpressure = True
-                break
+                # For the next invocation of __check_for_results, start at this message
+                result.valid_messages_transformed.reset_iterator(idx)
 
-        if result.next_index_to_process != len(input_batch):
-            if next_step_has_applied_backpressure:
                 self.__metrics.increment(
                     "arroyo.strategies.run_task_with_multiprocessing.batch.backpressure"
                 )
-            else:
-                self.__metrics.increment(
-                    "arroyo.strategies.run_task_with_multiprocessing.batch.output.overflow"
+
+                # This is a warning because backpressure on the multiprocessing
+                # strategy _might_ cause degraded CPU saturation.
+                logger.warning(
+                    "Received backpressure from next_step, splitting output batch (%0.2f%% complete)",
+                    idx / len(input_batch) * 100,
                 )
+                raise multiprocessing.TimeoutError("Waiting on upstream strategy")
+
+        if result.next_index_to_process != len(input_batch):
+            self.__metrics.increment(
+                "arroyo.strategies.run_task_with_multiprocessing.batch.output.overflow"
+            )
 
             logger.warning(
-                "Received incomplete batch (%0.2f%% complete), resubmitting (reason: %s)",
+                "Received incomplete batch (%0.2f%% complete)",
                 result.next_index_to_process / len(input_batch) * 100,
-                "backpressure" if next_step_has_applied_backpressure else "overflow",
             )
 
             # TODO: This reserializes all the ``SerializedMessage`` data prior
@@ -505,25 +539,7 @@ class RunTaskWithMultiprocessing(
         self.__forward_invalid_offsets()
         self.__next_step.poll()
 
-        while self.__processes:
-            try:
-                self.__check_for_results(timeout=0)
-            except multiprocessing.TimeoutError:
-                if self.__pool_waiting_time is None:
-                    self.__pool_waiting_time = time.time()
-                else:
-                    current_time = time.time()
-                    if current_time - self.__pool_waiting_time > LOG_THRESHOLD_TIME:
-                        logger.warning(
-                            "Waited on the process pool longer than %d seconds. Waiting for %d results. Pool: %r",
-                            LOG_THRESHOLD_TIME,
-                            len(self.__processes),
-                            self.__pool,
-                        )
-                        self.__pool_waiting_time = current_time
-                break
-            else:
-                self.__pool_waiting_time = None
+        self.__check_for_results(timeout=0)
 
         if self.__batch_builder is not None and self.__batch_builder.ready():
             self.__submit_batch()
@@ -601,23 +617,14 @@ class RunTaskWithMultiprocessing(
 
         logger.debug("Waiting for %s batches...", len(self.__processes))
 
-        while self.__processes:
-            try:
-                self.__check_for_results(
-                    timeout=max(deadline - time.time(), 0)
-                    if deadline is not None
-                    else None
-                )
-            except multiprocessing.TimeoutError:
-                pass
+        self.__check_for_results(
+            timeout=timeout,
+        )
 
         self.__pool.close()
 
         logger.debug("Waiting for %s...", self.__pool)
-        # ``Pool.join`` doesn't accept a timeout (?!) but this really shouldn't
-        # block for any significant amount of time unless something really went
-        # wrong (i.e. we lost track of a task)
-        self.__pool.join()
+        self.__pool.terminate()
 
         self.__shared_memory_manager.shutdown()
 

--- a/arroyo/processing/strategies/run_task_with_multiprocessing.py
+++ b/arroyo/processing/strategies/run_task_with_multiprocessing.py
@@ -45,6 +45,10 @@ class ChildProcessTerminated(RuntimeError):
     pass
 
 
+class NextStepTimeoutError(RuntimeError):
+    pass
+
+
 # A serialized message is composed of a pickled ``Message`` instance (bytes)
 # and a sequence of ``(offset, length)`` that referenced locations in a shared
 # memory block for out of band buffer transfer.
@@ -440,6 +444,8 @@ class RunTaskWithMultiprocessing(
                     if deadline is not None
                     else None
                 )
+            except NextStepTimeoutError:
+                break
             except multiprocessing.TimeoutError:
                 if self.__pool_waiting_time is None:
                     self.__pool_waiting_time = time.time()
@@ -470,10 +476,9 @@ class RunTaskWithMultiprocessing(
 
         result = async_result.get(timeout=timeout)
 
-        next_step_has_applied_backpressure = False
-
         for idx, message in result.valid_messages_transformed:
             if isinstance(message, InvalidMessage):
+                # For the next invocation of __check_for_results, skip over this message
                 result.valid_messages_transformed.reset_iterator(idx + 1)
                 self.__invalid_messages.append(message)
                 raise message
@@ -483,24 +488,29 @@ class RunTaskWithMultiprocessing(
                 self.__next_step.submit(message)
 
             except MessageRejected:
-                result.next_index_to_process = idx
-                next_step_has_applied_backpressure = True
-                break
+                # For the next invocation of __check_for_results, start at this message
+                result.valid_messages_transformed.reset_iterator(idx)
 
-        if result.next_index_to_process != len(input_batch):
-            if next_step_has_applied_backpressure:
                 self.__metrics.increment(
                     "arroyo.strategies.run_task_with_multiprocessing.batch.backpressure"
                 )
-            else:
-                self.__metrics.increment(
-                    "arroyo.strategies.run_task_with_multiprocessing.batch.output.overflow"
+
+                # This is a warning because backpressure on the multiprocessing
+                # strategy _might_ cause degraded CPU saturation.
+                logger.warning(
+                    "Received backpressure from next_step, splitting output batch (%0.2f%% complete)",
+                    idx / len(input_batch) * 100,
                 )
+                raise NextStepTimeoutError()
+
+        if result.next_index_to_process != len(input_batch):
+            self.__metrics.increment(
+                "arroyo.strategies.run_task_with_multiprocessing.batch.output.overflow"
+            )
 
             logger.warning(
-                "Received incomplete batch (%0.2f%% complete), resubmitting (reason: %s)",
+                "Received incomplete batch (%0.2f%% complete), resubmitting",
                 result.next_index_to_process / len(input_batch) * 100,
-                "backpressure" if next_step_has_applied_backpressure else "overflow",
             )
 
             # TODO: This reserializes all the ``SerializedMessage`` data prior

--- a/arroyo/processing/strategies/run_task_with_multiprocessing.py
+++ b/arroyo/processing/strategies/run_task_with_multiprocessing.py
@@ -457,9 +457,6 @@ class RunTaskWithMultiprocessing(
             else:
                 self.__pool_waiting_time = None
 
-                if deadline is not None and time.time() > deadline:
-                    break
-
     def __check_for_results_impl(self, timeout: Optional[float] = None) -> None:
         input_batch, async_result = self.__processes[0]
 

--- a/arroyo/processing/strategies/run_task_with_multiprocessing.py
+++ b/arroyo/processing/strategies/run_task_with_multiprocessing.py
@@ -494,13 +494,6 @@ class RunTaskWithMultiprocessing(
                 self.__metrics.increment(
                     "arroyo.strategies.run_task_with_multiprocessing.batch.backpressure"
                 )
-
-                # This is a warning because backpressure on the multiprocessing
-                # strategy _might_ cause degraded CPU saturation.
-                logger.warning(
-                    "Received backpressure from next_step, splitting output batch (%0.2f%% complete)",
-                    idx / len(input_batch) * 100,
-                )
                 raise NextStepTimeoutError()
 
         if result.next_index_to_process != len(input_batch):

--- a/arroyo/types.py
+++ b/arroyo/types.py
@@ -64,13 +64,13 @@ class Message(Generic[TMessagePayload]):
         # ``__slots__`` for performance reasons. The class variable names
         # would conflict with the instance slot names, causing an error.
 
-        if type(self.value) in (float, int):
+        if type(self.payload) in (float, int):
             # For the case where value is a float or int, the repr is small and
             # therefore safe. This is very useful in tests.
             #
             # To prevent any nasty surprises with custom integer subtypes that
             # may have modified reprs we do not use isinstance.
-            return f"{type(self).__name__}({self.value}, {self.committable!r})"
+            return f"{type(self).__name__}({self.payload}, {self.committable!r})"
 
         # For any other type we cannot be sure the repr is performant.
         return f"{type(self).__name__}({self.committable!r})"

--- a/tests/processing/strategies/test_run_task_with_multiprocessing.py
+++ b/tests/processing/strategies/test_run_task_with_multiprocessing.py
@@ -285,30 +285,34 @@ def test_message_rejected_multiple() -> None:
     # since it's continually rejected
     assert next_step.submit.call_args_list == [
         call(Message(Value(2, {}))),
-        call(Message(Value(4, {}))),
-        call(Message(Value(6, {}))),
-        call(Message(Value(8, {}))),
-        call(Message(Value(10, {}))),
+        call(Message(Value(2, {}))),
+        call(Message(Value(2, {}))),
+        call(Message(Value(2, {}))),
+        call(Message(Value(2, {}))),
     ]
 
     # clear the side effect, let the message through now
     next_step.submit.reset_mock(side_effect=True)
 
-    for _ in range(5):
+    start_time = time.time()
+    while next_step.submit.call_count < 2:
         time.sleep(0.1)
         strategy.poll()
 
+        if time.time() - start_time > 5:
+            raise AssertionError("took too long to poll")
+
     # The messages should have been submitted successfully now
     assert next_step.submit.call_args_list == [
-        call(Message(Value(12, {}))),
-        call(Message(Value(-88, {}))),
+        call(Message(Value(2, {}))),
+        call(Message(Value(-98, {}))),
     ]
 
     strategy.close()
     strategy.join()
     assert next_step.submit.call_args_list == [
-        call(Message(Value(12, {}))),
-        call(Message(Value(-88, {}))),
+        call(Message(Value(2, {}))),
+        call(Message(Value(-98, {}))),
     ]
 
     assert TestingMetricsBackend.calls == [

--- a/tests/processing/strategies/test_run_task_with_multiprocessing.py
+++ b/tests/processing/strategies/test_run_task_with_multiprocessing.py
@@ -353,6 +353,7 @@ def run_sleep(value: Message[float]) -> float:
 
 def test_regression_join_timeout() -> None:
     next_step = Mock()
+    next_step.submit.side_effect = MessageRejected()
 
     strategy = RunTaskWithMultiprocessing(
         run_sleep,

--- a/tests/processing/strategies/test_run_task_with_multiprocessing.py
+++ b/tests/processing/strategies/test_run_task_with_multiprocessing.py
@@ -285,34 +285,30 @@ def test_message_rejected_multiple() -> None:
     # since it's continually rejected
     assert next_step.submit.call_args_list == [
         call(Message(Value(2, {}))),
-        call(Message(Value(2, {}))),
-        call(Message(Value(2, {}))),
-        call(Message(Value(2, {}))),
-        call(Message(Value(2, {}))),
+        call(Message(Value(4, {}))),
+        call(Message(Value(6, {}))),
+        call(Message(Value(8, {}))),
+        call(Message(Value(10, {}))),
     ]
 
     # clear the side effect, let the message through now
     next_step.submit.reset_mock(side_effect=True)
 
-    start_time = time.time()
-    while next_step.submit.call_count < 2:
+    for _ in range(5):
         time.sleep(0.1)
         strategy.poll()
 
-        if time.time() - start_time > 5:
-            raise AssertionError("took too long to poll")
-
     # The messages should have been submitted successfully now
     assert next_step.submit.call_args_list == [
-        call(Message(Value(2, {}))),
-        call(Message(Value(-98, {}))),
+        call(Message(Value(12, {}))),
+        call(Message(Value(-88, {}))),
     ]
 
     strategy.close()
     strategy.join()
     assert next_step.submit.call_args_list == [
-        call(Message(Value(2, {}))),
-        call(Message(Value(-98, {}))),
+        call(Message(Value(12, {}))),
+        call(Message(Value(-88, {}))),
     ]
 
     assert TestingMetricsBackend.calls == [

--- a/tests/processing/strategies/test_run_task_with_multiprocessing.py
+++ b/tests/processing/strategies/test_run_task_with_multiprocessing.py
@@ -408,6 +408,6 @@ def test_regression_join_timeout_many_messages() -> None:
 
     time_taken = time.time() - start
 
-    assert time_taken < 4
+    assert 2 < time_taken < 4
 
     assert next_step.submit.call_count > 0


### PR DESCRIPTION
Do not resubmit a batch when next_step raises MessageRejected. We can easily implement that now because we had to do something similar for DLQing

Batches are still re-serialized when output buffer overflows, so that can still have catastrophic perf impact.

Depends on a refactoring made in #237 


## Why as part of incident response?

There is no strong evidence that this is the culprit of the problems we have in INC-378, such as lack of CPU saturation. However, we know two things:

* We are constantly dissatisfied with throughput of our consumers
* Due to recently added metrics, we know that snuba generic-metrics keeps encountering backpressure from http step towards multiprocessing step

Because of (2), IMO this performance bottleneck must be a major contributor to (1)

If there is continuous MessageRejected, it could be that we process as much as every second batch a second time (and then maybe a third time). `n + (n - 1) + ... + 1` is still `O(n^2)`