### PR TITLE
fix: Mermaid diagrams in dark mode

### DIFF
--- a/docs/source/_static/custom.css
+++ b/docs/source/_static/custom.css
@@ -1,0 +1,10 @@
+/* fix mermaid diagrams in dark mode of shibuya theme we use */
+
+html.dark .mermaid path {
+  stroke: #fff !important;
+}
+
+html.dark .mermaid .marker {
+  stroke: #fff !important;
+  fill: #fff !important;
+}

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -41,6 +41,10 @@ html_theme = "shibuya"
 
 html_static_path = ["_static"]
 
+html_css_files = [
+    "custom.css",
+]
+
 # html_logo = "_static/arroyo.png"
 
 autodoc_inherit_docstrings = False


### PR DESCRIPTION
Mermaid diagrams in arroyo don't look nice if the docs are viewed in
dark mode. Override some CSS so it looks palatable.

Mermaid themes can't be switched on the fly unfortunately.
