### PR TITLE
fix(run-task-in-threads): Fix shutdown

### DIFF
--- a/arroyo/processing/strategies/run_task_in_threads.py
+++ b/arroyo/processing/strategies/run_task_in_threads.py
@@ -1,7 +1,7 @@
 import logging
 import time
 from collections import deque
-from concurrent.futures import Future, ThreadPoolExecutor
+from concurrent.futures import Future, ThreadPoolExecutor, TimeoutError
 from typing import Callable, Deque, Generic, Optional, Tuple, TypeVar, Union, cast
 
 from arroyo.dlq import InvalidMessage, InvalidMessageState
@@ -127,6 +127,9 @@ class RunTaskInThreads(
                 # Will raise if the future errored
                 try:
                     result = future.result(remaining)
+                except TimeoutError:
+                    pass
+
                 except InvalidMessage as e:
                     self.__invalid_messages.append(e)
                     raise e


### PR DESCRIPTION
We weren't catching the timeout error which was causing the consumer to crash unnecessarily instead of shutting down cleanly