### PR TITLE
fix: Fix run task in threads (again)

### DIFF
--- a/arroyo/processing/strategies/run_task_in_threads.py
+++ b/arroyo/processing/strategies/run_task_in_threads.py
@@ -128,8 +128,7 @@ class RunTaskInThreads(
                 try:
                     result = future.result(remaining)
                 except TimeoutError:
-                    pass
-
+                    continue
                 except InvalidMessage as e:
                     self.__invalid_messages.append(e)
                     raise e


### PR DESCRIPTION
There's no "result" available if we hit the timeout error