### PR TITLE
ref: Global metrics registry

### DIFF
--- a/arroyo/utils/metric_defs.py
+++ b/arroyo/utils/metric_defs.py
@@ -1,0 +1,51 @@
+from typing import Literal
+
+MetricName = Literal[
+    # Number of messages in a multiprocessing batch
+    "batch.size.msg",
+    # Number of bytes in a multiprocessing batch
+    "batch.size.bytes",
+    # Number of times the consumer is spinning
+    "arroyo.consumer.run.count",
+    # How long it took the Reduce step to fill up a batch
+    "arroyo.strategies.reduce.batch_time",
+    # Counter, incremented when a strategy after multiprocessing applies
+    # backpressure to multiprocessing. May be a reason why CPU cannot be
+    # saturated.
+    "arroyo.strategies.run_task_with_multiprocessing.batch.backpressure",
+    # Counter, incremented when multiprocessing cannot fill the input batch
+    # because not enough memory was allocated. This results in batches smaller
+    # than configured. Increase `input_block_size` to fix.
+    "arroyo.strategies.run_task_with_multiprocessing.batch.input.overflow",
+    # Counter, incremented when multiprocessing cannot pull results in batches
+    # equal to the input batch size, because not enough memory was allocated.
+    # This can be devastating for throughput. Increase `output_block_size` to
+    # fix.
+    "arroyo.strategies.run_task_with_multiprocessing.batch.output.overflow",
+    # How many batches are being processed in parallel by multiprocessing.
+    "batches_in_progress",
+    # Counter. A subprocess by multiprocessing unexpectedly died.
+    "sigchld.detected",
+    # Gauge. Shows how many processes the multiprocessing strategy is
+    # configured with.
+    "transform.processes",
+    # Time (unitless) spent polling librdkafka for new messages.
+    "arroyo.consumer.poll.time",
+    # Time (unitless) spent in strategies (blocking in strategy.submit or
+    # strategy.poll)
+    "arroyo.consumer.processing.time",
+    # Time (unitless) spent pausing the consumer due to backpressure (MessageRejected)
+    "arroyo.consumer.paused.time",
+    # Time (unitless) spent in handling `InvalidMessage` exceptions and sending
+    # messages to the the DLQ.
+    "arroyo.consumer.dlq.time",
+    # Time (unitless) spent in waiting for the strategy to exit, such as during
+    # shutdown or rebalancing.
+    "arroyo.consumer.join.time",
+    # Time (unitless) spent in librdkafka callbacks. This metric's timings
+    # overlap other timings, and might spike at the same time.
+    "arroyo.consumer.callback.time",
+    # Time (unitless) spent in shutting down the consumer. This metric's
+    # timings overlap other timings, and might spike at the same time.
+    "arroyo.consumer.shutdown.time",
+]

--- a/arroyo/utils/metrics.py
+++ b/arroyo/utils/metrics.py
@@ -1,5 +1,9 @@
+from __future__ import annotations
+
 from abc import abstractmethod
 from typing import Any, Mapping, Optional, Protocol, Union, runtime_checkable
+
+from arroyo.utils.metric_defs import MetricName
 
 Tags = Mapping[str, str]
 
@@ -12,7 +16,10 @@ class Metrics(Protocol):
 
     @abstractmethod
     def increment(
-        self, name: str, value: Union[int, float] = 1, tags: Optional[Tags] = None
+        self,
+        name: MetricName,
+        value: Union[int, float] = 1,
+        tags: Optional[Tags] = None,
     ) -> None:
         """
         Increments a counter metric by a given value.
@@ -21,7 +28,7 @@ class Metrics(Protocol):
 
     @abstractmethod
     def gauge(
-        self, name: str, value: Union[int, float], tags: Optional[Tags] = None
+        self, name: MetricName, value: Union[int, float], tags: Optional[Tags] = None
     ) -> None:
         """
         Sets a gauge metric to the given value.
@@ -30,7 +37,7 @@ class Metrics(Protocol):
 
     @abstractmethod
     def timing(
-        self, name: str, value: Union[int, float], tags: Optional[Tags] = None
+        self, name: MetricName, value: Union[int, float], tags: Optional[Tags] = None
     ) -> None:
         """
         Records a timing metric.
@@ -44,17 +51,20 @@ class DummyMetricsBackend(Metrics):
     """
 
     def increment(
-        self, name: str, value: Union[int, float] = 1, tags: Optional[Tags] = None
+        self,
+        name: MetricName,
+        value: Union[int, float] = 1,
+        tags: Optional[Tags] = None,
     ) -> None:
         pass
 
     def gauge(
-        self, name: str, value: Union[int, float], tags: Optional[Tags] = None
+        self, name: MetricName, value: Union[int, float], tags: Optional[Tags] = None
     ) -> None:
         pass
 
     def timing(
-        self, name: str, value: Union[int, float], tags: Optional[Tags] = None
+        self, name: MetricName, value: Union[int, float], tags: Optional[Tags] = None
     ) -> None:
         pass
 
@@ -63,7 +73,7 @@ class Gauge:
     def __init__(
         self,
         metrics: Metrics,
-        name: str,
+        name: MetricName,
         tags: Optional[Tags] = None,
     ) -> None:
         self.__metrics = metrics
@@ -119,3 +129,6 @@ def get_metrics() -> Metrics:
     if _metrics_backend is None:
         return _dummy_metrics_backend
     return _metrics_backend
+
+
+__all__ = ["configure_metrics", "Metrics", "MetricName"]

--- a/docs-requirements.txt
+++ b/docs-requirements.txt
@@ -1,5 +1,4 @@
 sphinx>=5.3
 sphinxcontrib-mermaid==0.8.1
 shibuya
-sphinx-autodoc-typehints[type-comment]>=1.19.3
 typing-extensions

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -19,7 +19,6 @@ extensions = [
     "sphinx.ext.intersphinx",
     "sphinxcontrib.mermaid",
     "sphinx.ext.autodoc",
-    "sphinx_autodoc_typehints",
 ]
 
 always_document_param_types = True
@@ -48,3 +47,7 @@ html_css_files = [
 # html_logo = "_static/arroyo.png"
 
 autodoc_inherit_docstrings = False
+
+autodoc_type_aliases = {
+    "MetricName": "MetricName",
+}

--- a/docs/source/metrics.rst
+++ b/docs/source/metrics.rst
@@ -14,48 +14,39 @@ This can be done like so:
 
 .. code:: python
 
-    class Metrics:
+   from arroyo.utils.metrics import Metrics, MetricName
+
+    class MyMetrics(Metrics):
         def increment(
-            self, name: str, value: Union[int, float] = 1, tags: Optional[Tags] = None
+            self, name: MetricName, value: Union[int, float] = 1, tags: Optional[Tags] = None
         ) -> None:
             # Increment a counter by the given value.
             record_incr(name, value, tags)
 
         def gauge(
-            self, name: str, value: Union[int, float], tags: Optional[Tags] = None
+            self, name: MetricName, value: Union[int, float], tags: Optional[Tags] = None
         ) -> None:
             # Sets a gauge metric to the given value.
             record_gauge(name, value, tags)
 
         def timing(
-            self, name: str, value: Union[int, float], tags: Optional[Tags] = None
+            self, name: MetricName, value: Union[int, float], tags: Optional[Tags] = None
         ) -> None:
             # Emit a timing metric with the given value.
             record_timing(name, value, tags)
 
-    metrics_backend = Metrics()
+    metrics_backend = MyMetrics()
 
     configure_metrics(metrics_backend)
 
-Some of the metrics emitted by Arroyo include:
 
-.. list-table:: Metrics
-   :widths: 25 25 50
-   :header-rows: 1
+Available Metrics
+====================
 
-   * - Metric name
-     - Type
-     - Description
-   * - arroyo.consumer.poll.time
-     - Timing
-     - Time spent polling for messages. A higher number means the consumer has headroom as it is waiting for messages to arrive.
-   * - arroyo.consumer.processing.time
-     - Timing
-     - Time spent processing messages. A higher number means the consumer spends more time processing messages.
-   * - arroyo.consumer.paused.time
-     - Timing
-     - Time spent in backpressure. Usually means there could be some processing bottleneck.
+.. literalinclude:: ../../arroyo/utils/metric_defs.py
 
+API
+=======
 
 .. automodule:: arroyo.utils.metrics
    :members:

--- a/docs/source/strategies/index.rst
+++ b/docs/source/strategies/index.rst
@@ -16,7 +16,12 @@ Nevertheless, all arroyo strategies are written against the following interface:
    :undoc-members:
    :show-inheritance:
 
+Messages
+------------
 
+.. automodule:: arroyo.types
+   :members:
+   :undoc-members:
 
 .. toctree::
     :hidden:

--- a/tests/metrics.py
+++ b/tests/metrics.py
@@ -1,22 +1,22 @@
 from typing import MutableSequence, NamedTuple, Optional, Union
 
-from arroyo.utils.metrics import Metrics, Tags
+from arroyo.utils.metrics import MetricName, Metrics, Tags
 
 
 class Increment(NamedTuple):
-    name: str
+    name: MetricName
     value: Union[int, float]
     tags: Optional[Tags]
 
 
 class Gauge(NamedTuple):
-    name: str
+    name: MetricName
     value: Union[int, float]
     tags: Optional[Tags]
 
 
 class Timing(NamedTuple):
-    name: str
+    name: MetricName
     value: Union[int, float]
     tags: Optional[Tags]
 
@@ -32,17 +32,20 @@ class _TestingMetricsBackend(Metrics):
         self.calls: MutableSequence[Union[Increment, Gauge, Timing]] = []
 
     def increment(
-        self, name: str, value: Union[int, float] = 1, tags: Optional[Tags] = None
+        self,
+        name: MetricName,
+        value: Union[int, float] = 1,
+        tags: Optional[Tags] = None,
     ) -> None:
         self.calls.append(Increment(name, value, tags))
 
     def gauge(
-        self, name: str, value: Union[int, float], tags: Optional[Tags] = None
+        self, name: MetricName, value: Union[int, float], tags: Optional[Tags] = None
     ) -> None:
         self.calls.append(Gauge(name, value, tags))
 
     def timing(
-        self, name: str, value: Union[int, float], tags: Optional[Tags] = None
+        self, name: MetricName, value: Union[int, float], tags: Optional[Tags] = None
     ) -> None:
         self.calls.append(Timing(name, value, tags))
 

--- a/tests/utils/test_metrics.py
+++ b/tests/utils/test_metrics.py
@@ -1,6 +1,6 @@
 import pytest
 
-from arroyo.utils.metrics import Gauge, configure_metrics, get_metrics
+from arroyo.utils.metrics import Gauge, MetricName, configure_metrics, get_metrics
 from tests.metrics import Gauge as GaugeCall
 from tests.metrics import TestingMetricsBackend
 
@@ -8,7 +8,7 @@ from tests.metrics import TestingMetricsBackend
 def test_gauge_simple() -> None:
     backend = TestingMetricsBackend
 
-    name = "name"
+    name: MetricName = "name"  # type: ignore
     tags = {"tag": "value"}
     gauge = Gauge(backend, name, tags)
 


### PR DESCRIPTION
Register all metrics in the entire codebase in a Literal, and put
the literal in docs.

This is a bit less overhead than a global enum and requires fewer
changes in strategies that already pass metrics as strings.
