### PR TITLE
Use structlog for logging

### DIFF
--- a/arroyo/backends/abstract.py
+++ b/arroyo/backends/abstract.py
@@ -1,13 +1,15 @@
 from __future__ import annotations
 
-import logging
+import structlog
 from abc import ABC, abstractmethod, abstractproperty
 from concurrent.futures import Future
 from typing import Callable, Generic, Mapping, Optional, Sequence, Union
+from arroyo.environment import setup_logging
 
 from arroyo.types import BrokerValue, Partition, Topic, TStrategyPayload
 
-logger = logging.getLogger(__name__)
+setup_logging()
+logger = structlog.get_logger().bind(module=__name__)
 
 
 class Consumer(Generic[TStrategyPayload], ABC):

--- a/arroyo/backends/kafka/configuration.py
+++ b/arroyo/backends/kafka/configuration.py
@@ -1,10 +1,12 @@
 import copy
-import logging
+import structlog
 from typing import Any, Dict, Mapping, Optional, Sequence
+from arroyo.environment import setup_logging
 
 from arroyo.utils.logging import pylog_to_syslog_level
 
-logger = logging.getLogger(__name__)
+setup_logging()
+logger = structlog.get_logger().bind(module=__name__)
 
 KafkaBrokerConfig = Dict[str, Any]
 

--- a/arroyo/backends/kafka/consumer.py
+++ b/arroyo/backends/kafka/consumer.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-import logging
+import structlog
 from concurrent.futures import Future
 from datetime import datetime
 from enum import Enum
@@ -37,6 +37,7 @@ from confluent_kafka import Producer as ConfluentProducer
 from confluent_kafka import TopicPartition as ConfluentTopicPartition
 
 from arroyo.backends.abstract import Consumer, Producer
+from arroyo.environment import setup_logging
 from arroyo.errors import (
     ConsumerError,
     EndOfPartition,
@@ -47,7 +48,8 @@ from arroyo.types import BrokerValue, Partition, Topic
 from arroyo.utils.concurrent import execute
 from arroyo.utils.retries import NoRetryPolicy, RetryPolicy
 
-logger = logging.getLogger(__name__)
+setup_logging()
+logger = structlog.get_logger().bind(module=__name__)
 
 
 KafkaConsumerState = Enum(

--- a/arroyo/dlq.py
+++ b/arroyo/dlq.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-import logging
+import structlog
 from abc import ABC, abstractmethod
 from collections import defaultdict, deque
 from concurrent.futures import Future
@@ -18,6 +18,7 @@ from typing import (
 
 from arroyo.backends.abstract import Producer
 from arroyo.backends.kafka import KafkaPayload
+from arroyo.environment import setup_logging
 from arroyo.types import (
     FILTERED_PAYLOAD,
     BrokerValue,
@@ -29,7 +30,8 @@ from arroyo.types import (
     Value,
 )
 
-logger = logging.getLogger(__name__)
+setup_logging()
+logger = structlog.get_logger().bind(module=__name__)
 
 
 class InvalidMessage(Exception):
@@ -341,7 +343,7 @@ class InvalidMessageState:
         for m in self.__invalid_messages:
             next_offset = m.offset + 1
             if m.partition in committable and next_offset < committable[m.partition]:
-                logger.warn(
+                logger.warning(
                     "InvalidMessage was raised out of order. "
                     "Potentially dropping offset for committing.\n\n"
                     "Either Arroyo has a bug or you wrote a custom strategy "

--- a/arroyo/environment.py
+++ b/arroyo/environment.py
@@ -1,0 +1,32 @@
+import logging
+
+import structlog
+from structlog.types import EventDict
+
+
+def add_severity_attribute(
+    logger: logging.Logger, method_name: str, event_dict: EventDict
+) -> EventDict:
+    """
+    Set the severity attribute for Google Cloud logging ingestion
+    """
+    event_dict["severity"] = event_dict["level"].upper()
+    del event_dict["level"]
+    return event_dict
+
+
+def setup_logging() -> None:
+    structlog.configure(
+        cache_logger_on_first_use=True,
+        wrapper_class=structlog.make_filtering_bound_logger(logging.INFO),
+        processors=[
+            structlog.contextvars.merge_contextvars,
+            structlog.processors.add_log_level,
+            add_severity_attribute,
+            structlog.stdlib.PositionalArgumentsFormatter(),
+            structlog.processors.StackInfoRenderer(),
+            structlog.processors.format_exc_info,
+            structlog.processors.TimeStamper(fmt="iso", utc=True),
+            structlog.processors.JSONRenderer(),
+        ],
+    )

--- a/arroyo/environment.py
+++ b/arroyo/environment.py
@@ -17,8 +17,7 @@ def add_severity_attribute(
 
 def setup_logging() -> None:
     structlog.configure(
-        cache_logger_on_first_use=True,
-        wrapper_class=structlog.BoundLogger,
+        wrapper_class=structlog.stdlib.BoundLogger,
         processors=[
             structlog.contextvars.merge_contextvars,
             structlog.processors.add_log_level,

--- a/arroyo/environment.py
+++ b/arroyo/environment.py
@@ -18,6 +18,7 @@ def add_severity_attribute(
 def setup_logging() -> None:
     structlog.configure(
         wrapper_class=structlog.stdlib.BoundLogger,
+        logger_factory=structlog.stdlib.LoggerFactory(),
         processors=[
             structlog.contextvars.merge_contextvars,
             structlog.processors.add_log_level,

--- a/arroyo/environment.py
+++ b/arroyo/environment.py
@@ -18,7 +18,7 @@ def add_severity_attribute(
 def setup_logging() -> None:
     structlog.configure(
         cache_logger_on_first_use=True,
-        wrapper_class=structlog.make_filtering_bound_logger(logging.INFO),
+        wrapper_class=structlog.BoundLogger,
         processors=[
             structlog.contextvars.merge_contextvars,
             structlog.processors.add_log_level,

--- a/arroyo/processing/processor.py
+++ b/arroyo/processing/processor.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import functools
-import logging
+import structlog
 import time
 from collections import defaultdict
 from enum import Enum
@@ -21,6 +21,7 @@ from typing import (
 from arroyo.backends.abstract import Consumer
 from arroyo.commit import CommitPolicy
 from arroyo.dlq import BufferedMessages, DlqPolicy, DlqPolicyWrapper, InvalidMessage
+from arroyo.environment import setup_logging
 from arroyo.errors import RecoverableError
 from arroyo.processing.strategies.abstract import (
     MessageRejected,
@@ -31,7 +32,8 @@ from arroyo.types import BrokerValue, Message, Partition, Topic, TStrategyPayloa
 from arroyo.utils.logging import handle_internal_error
 from arroyo.utils.metrics import get_metrics
 
-logger = logging.getLogger(__name__)
+setup_logging()
+logger = structlog.get_logger().bind(module=__name__)
 
 METRICS_FREQUENCY_SEC = 1.0  # In seconds
 

--- a/arroyo/processing/strategies/filter.py
+++ b/arroyo/processing/strategies/filter.py
@@ -1,8 +1,9 @@
-import logging
+import structlog
 import time
 from typing import Callable, MutableMapping, Optional, Union, cast
 
 from arroyo.commit import CommitPolicy, CommitPolicyState
+from arroyo.environment import setup_logging
 from arroyo.processing.strategies.abstract import ProcessingStrategy
 from arroyo.types import (
     FILTERED_PAYLOAD,
@@ -13,7 +14,8 @@ from arroyo.types import (
     Value,
 )
 
-logger = logging.getLogger(__name__)
+setup_logging()
+logger = structlog.get_logger().bind(module=__name__)
 
 
 class FilterStep(ProcessingStrategy[Union[FilteredPayload, TStrategyPayload]]):

--- a/arroyo/processing/strategies/produce.py
+++ b/arroyo/processing/strategies/produce.py
@@ -1,10 +1,11 @@
-import logging
+import structlog
 import time
 from collections import deque
 from concurrent.futures import Future
 from typing import Deque, Optional, Tuple, Union
 
 from arroyo.backends.abstract import Producer
+from arroyo.environment import setup_logging
 from arroyo.processing.strategies.abstract import MessageRejected, ProcessingStrategy
 from arroyo.processing.strategies.commit import CommitOffsets
 from arroyo.types import (
@@ -17,7 +18,8 @@ from arroyo.types import (
     Value,
 )
 
-logger = logging.getLogger(__name__)
+setup_logging()
+logger = structlog.get_logger().bind(module=__name__)
 
 
 class Produce(ProcessingStrategy[Union[FilteredPayload, TStrategyPayload]]):

--- a/arroyo/processing/strategies/run_task_in_threads.py
+++ b/arroyo/processing/strategies/run_task_in_threads.py
@@ -1,14 +1,16 @@
-import logging
+import structlog
 import time
 from collections import deque
 from concurrent.futures import Future, ThreadPoolExecutor
 from typing import Callable, Deque, Generic, Optional, Tuple, TypeVar, Union, cast
 
 from arroyo.dlq import InvalidMessage, InvalidMessageState
+from arroyo.environment import setup_logging
 from arroyo.processing.strategies.abstract import MessageRejected, ProcessingStrategy
 from arroyo.types import FilteredPayload, Message, TStrategyPayload
 
-logger = logging.getLogger(__name__)
+setup_logging()
+logger = structlog.get_logger().bind(module=__name__)
 
 TResult = TypeVar("TResult")
 

--- a/arroyo/processing/strategies/run_task_with_multiprocessing.py
+++ b/arroyo/processing/strategies/run_task_with_multiprocessing.py
@@ -1,4 +1,4 @@
-import logging
+import structlog
 import multiprocessing
 import pickle
 import signal
@@ -26,11 +26,13 @@ from typing import (
 )
 
 from arroyo.dlq import InvalidMessage, InvalidMessageState
+from arroyo.environment import setup_logging
 from arroyo.processing.strategies.abstract import MessageRejected, ProcessingStrategy
 from arroyo.types import FilteredPayload, Message, TStrategyPayload
 from arroyo.utils.metrics import Gauge, get_metrics
 
-logger = logging.getLogger(__name__)
+setup_logging()
+logger = structlog.get_logger().bind(module=__name__)
 
 __all__ = ["RunTaskWithMultiprocessing"]
 

--- a/arroyo/utils/profiler.py
+++ b/arroyo/utils/profiler.py
@@ -1,8 +1,9 @@
-import logging
+import structlog
 import time
 from cProfile import Profile
 from pathlib import Path
 from typing import Mapping, Optional
+from arroyo.environment import setup_logging
 
 from arroyo.processing.strategies.abstract import (
     ProcessingStrategy,
@@ -10,7 +11,8 @@ from arroyo.processing.strategies.abstract import (
 )
 from arroyo.types import Commit, Message, Partition, TStrategyPayload
 
-logger = logging.getLogger(__name__)
+setup_logging()
+logger = structlog.get_logger().bind(module=__name__)
 
 
 class ProcessingStrategyProfilerWrapper(ProcessingStrategy[TStrategyPayload]):

--- a/examples/transform_and_produce/batched.py
+++ b/examples/transform_and_produce/batched.py
@@ -1,8 +1,9 @@
 import json
-import logging
+import structlog
 from typing import Any, Mapping, MutableSequence, Sequence
 
 from arroyo.backends.kafka.consumer import KafkaPayload, KafkaProducer
+from arroyo.environment import setup_logging
 from arroyo.processing.strategies import (
     BatchStep,
     CommitOffsets,
@@ -17,7 +18,8 @@ from arroyo.processing.strategies.abstract import (
 from arroyo.processing.strategies.batching import ValuesBatch
 from arroyo.types import BaseValue, Commit, Message, Partition, Topic, Value
 
-logger = logging.getLogger(__name__)
+setup_logging()
+logger = structlog.get_logger().bind(module=__name__)
 
 
 def resolve_index(msgs: Sequence[Mapping[str, Any]]) -> Sequence[Mapping[str, Any]]:

--- a/examples/transform_and_produce/simple.py
+++ b/examples/transform_and_produce/simple.py
@@ -1,9 +1,10 @@
 import hashlib
 import json
-import logging
+import structlog
 from typing import Mapping
 
 from arroyo.backends.kafka.consumer import KafkaPayload, KafkaProducer
+from arroyo.environment import setup_logging
 from arroyo.processing.strategies import CommitOffsets, Produce, TransformStep
 from arroyo.processing.strategies.abstract import (
     ProcessingStrategy,
@@ -11,7 +12,8 @@ from arroyo.processing.strategies.abstract import (
 )
 from arroyo.types import Commit, Message, Partition, Topic
 
-logger = logging.getLogger(__name__)
+setup_logging()
+logger = structlog.get_logger().bind(module=__name__)
 
 
 def hash_password(value: Message[KafkaPayload]) -> KafkaPayload:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 confluent-kafka>=1.9.0
+structlog==22.3.0


### PR DESCRIPTION
This PR transitions logging to use structlog as it has better compatibility with GCP. Currently, this uses a stdlib logging wrapper.