### PR TITLE
feat(metrics): Allow reconfiguring the metrics backend

### DIFF
--- a/arroyo/utils/metrics.py
+++ b/arroyo/utils/metrics.py
@@ -1,14 +1,11 @@
 from __future__ import annotations
 
-import logging
 from abc import abstractmethod
 from typing import Any, Mapping, Optional, Protocol, Union, runtime_checkable
 
 from arroyo.utils.metric_defs import MetricName
 
 Tags = Mapping[str, str]
-
-logger = logging.getLogger(__name__)
 
 
 @runtime_checkable
@@ -114,14 +111,14 @@ _metrics_backend: Optional[Metrics] = None
 _dummy_metrics_backend = DummyMetricsBackend()
 
 
-def configure_metrics(metrics: Metrics) -> None:
+def configure_metrics(metrics: Metrics, force: bool = False) -> None:
     """
     Metrics should generally only be configured once.
     """
     global _metrics_backend
 
-    if _metrics_backend is not None:
-        logger.warning("Metrics backend is already configured")
+    if not force:
+        assert _metrics_backend is None, "Metrics is already set"
 
     # Perform a runtime check of metrics instance upon initialization of
     # this class to avoid errors down the line when it is used.

--- a/arroyo/utils/metrics.py
+++ b/arroyo/utils/metrics.py
@@ -1,11 +1,14 @@
 from __future__ import annotations
 
+import logging
 from abc import abstractmethod
 from typing import Any, Mapping, Optional, Protocol, Union, runtime_checkable
 
 from arroyo.utils.metric_defs import MetricName
 
 Tags = Mapping[str, str]
+
+logger = logging.getLogger(__name__)
 
 
 @runtime_checkable
@@ -113,11 +116,12 @@ _dummy_metrics_backend = DummyMetricsBackend()
 
 def configure_metrics(metrics: Metrics) -> None:
     """
-    Metrics can only be configured once
+    Metrics should generally only be configured once.
     """
     global _metrics_backend
 
-    assert _metrics_backend is None, "Metrics is already set"
+    if _metrics_backend is not None:
+        logger.warning("Metrics backend is already configured")
 
     # Perform a runtime check of metrics instance upon initialization of
     # this class to avoid errors down the line when it is used.

--- a/arroyo/utils/metrics.py
+++ b/arroyo/utils/metrics.py
@@ -113,7 +113,8 @@ _dummy_metrics_backend = DummyMetricsBackend()
 
 def configure_metrics(metrics: Metrics, force: bool = False) -> None:
     """
-    Metrics should generally only be configured once.
+    Metrics can generally only be configured once, unless force is passed
+    on subsequent initializations.
     """
     global _metrics_backend
 

--- a/tests/utils/test_metrics.py
+++ b/tests/utils/test_metrics.py
@@ -1,3 +1,5 @@
+import pytest
+
 from arroyo.utils.metrics import Gauge, MetricName, configure_metrics, get_metrics
 from tests.metrics import Gauge as GaugeCall
 from tests.metrics import TestingMetricsBackend, _TestingMetricsBackend
@@ -23,8 +25,9 @@ def test_gauge_simple() -> None:
 def test_configure_metrics() -> None:
     assert get_metrics() == TestingMetricsBackend
 
-    # Can be reset to something else
-    other = _TestingMetricsBackend()
+    with pytest.raises(AssertionError):
+        configure_metrics(_TestingMetricsBackend())
 
-    configure_metrics(other)
+    # Can be reset to something else with force
+    configure_metrics(_TestingMetricsBackend(), force=True)
     assert get_metrics() != TestingMetricsBackend

--- a/tests/utils/test_metrics.py
+++ b/tests/utils/test_metrics.py
@@ -1,8 +1,6 @@
-import pytest
-
 from arroyo.utils.metrics import Gauge, MetricName, configure_metrics, get_metrics
 from tests.metrics import Gauge as GaugeCall
-from tests.metrics import TestingMetricsBackend
+from tests.metrics import TestingMetricsBackend, _TestingMetricsBackend
 
 
 def test_gauge_simple() -> None:
@@ -25,5 +23,8 @@ def test_gauge_simple() -> None:
 def test_configure_metrics() -> None:
     assert get_metrics() == TestingMetricsBackend
 
-    with pytest.raises(AssertionError):
-        configure_metrics(TestingMetricsBackend)
+    # Can be reset to something else
+    other = _TestingMetricsBackend()
+
+    configure_metrics(other)
+    assert get_metrics() != TestingMetricsBackend


### PR DESCRIPTION
There are some rare situations where we might want to reconfigure the metrics backend to something else after a while. This came up in the DLQ consumer code, which can be instructed to consume from multiple queues and apply different policies. In this scenario, we want to tag the metrics very differently each time.