### PR TITLE
feat: Avoid spinning on MessageRejected

### DIFF
--- a/arroyo/processing/processor.py
+++ b/arroyo/processing/processor.py
@@ -399,6 +399,7 @@ class StreamProcessor(Generic[TStrategyPayload]):
                         self.__paused_timestamp = time.time()
                     else:
                         current_time = time.time()
+                        time.sleep(0.01)
                         if self.__paused_timestamp:
                             self.__metrics_buffer.incr_timing(
                                 "arroyo.consumer.paused.time",

--- a/docs/source/backpressure.rst
+++ b/docs/source/backpressure.rst
@@ -38,12 +38,6 @@ It is not recommended to apply backpressure by just ``sleep()``-ing in
 pauses the consumer, it will block the main thread for too long and and prevent
 things like consumer rebalancing from occuring.
 
-There is a known issue where the main thread spins at 100% CPU while the
-consumer is paused by raising :py:class:`~abstract.MessageRejected`, because
-:py:class:`~abstract.ProcessingStrategy.submit` is retried too quickly. This
-hasn't been a significant problem in practice so far because most strategies
-only need to apply backpressure for small periods of time and are waiting for
-either a subprocess or some external I/O to finish. However, it does mean that
-during this time, the `GIL
-<https://wiki.python.org/moin/GlobalInterpreterLock>`_ gets very noisy and
-background thread performance may suffer from that.
+A 0.01 second sleep is applied each time :py:class:`~abstract.MessageRejected` is
+raised to prevent the main thread spinning at 100% CPU. However background thread
+performance may be impacted during this time.


### PR DESCRIPTION
This was done in https://github.com/getsentry/sentry/blob/43de083a4b874ab23de5db2c8f7f2958a3cb70ab/src/sentry/processing/backpressure/arroyo.py#L40, should probably be an Arroyo default