### PR TITLE
perf: Don't unnecessarily recreate strategy in revocation callback

### DIFF
--- a/arroyo/processing/processor.py
+++ b/arroyo/processing/processor.py
@@ -225,24 +225,6 @@ class StreamProcessor(Generic[TStrategyPayload]):
             if partitions:
                 _close_strategy()
 
-                # Recreate the strategy if the consumer still has other partitions
-                # assigned and is not closed or errored
-                try:
-                    current_partitions = self.__consumer.tell()
-                    if len(current_partitions.keys() - set(partitions)):
-                        active_partitions = {
-                            partition: offset
-                            for partition, offset in current_partitions.items()
-                            if partition not in partitions
-                        }
-                        logger.info(
-                            "Recreating strategy since there are still active partitions: %r",
-                            active_partitions,
-                        )
-                        _create_strategy(active_partitions)
-                except RuntimeError:
-                    pass
-
             # Partition revocation can happen anytime during the consumer lifecycle and happen
             # multiple times. What we want to know is that the consumer is not stuck somewhere.
             # The presence of this message as the last message of a consumer

--- a/tests/processing/test_processor.py
+++ b/tests/processing/test_processor.py
@@ -294,7 +294,7 @@ def test_stream_processor_create_with_partitions() -> None:
     revocation_callback([Partition(topic, 0)])
 
     create_args, _ = factory.create_with_partitions.call_args
-    assert factory.create_with_partitions.call_count == 3
+    assert factory.create_with_partitions.call_count == 2
     assert create_args[1] == offsets_p1
 
     # Second partition revoked - no partitions left
@@ -303,7 +303,7 @@ def test_stream_processor_create_with_partitions() -> None:
 
     # No partitions left means we don't re-create the strategy
     # so `create_with_partitions` call count shouldn't increase
-    assert factory.create_with_partitions.call_count == 3
+    assert factory.create_with_partitions.call_count == 2
 
 
 class CommitOffsets(ProcessingStrategy[int]):


### PR DESCRIPTION
It's very important for the revocation callback to finish quickly as it blocks assignments on the entire consumer group and causes slower than necessary rebalancing. Let's not unnecessarily create the strategy here, it will be done in on_assign.