### PR TITLE
fix: Commit offsets even when topic is empty

### DIFF
--- a/arroyo/processing/strategies/commit.py
+++ b/arroyo/processing/strategies/commit.py
@@ -17,7 +17,7 @@ class CommitOffsets(ProcessingStrategy[Any]):
         self.__commit = commit
 
     def poll(self) -> None:
-        pass
+        self.__commit({})
 
     def submit(self, message: Message[Any]) -> None:
         self.__commit(message.committable)

--- a/tests/processing/strategies/test_commit.py
+++ b/tests/processing/strategies/test_commit.py
@@ -11,3 +11,15 @@ def test_commit() -> None:
     strategy.submit(Message(Value(b"", {Partition(Topic("topic"), 1): 5})))
 
     assert commit_func.call_count == 1
+
+
+def test_commit_poll() -> None:
+    # This is currently necessary to ensure that offsets are committed (still
+    # debounced) even when the topic is empty.
+    commit_func = Mock()
+    strategy = CommitOffsets(commit_func)
+
+    strategy.poll()
+
+    assert commit_func.call_count == 1
+

--- a/tests/processing/strategies/test_produce.py
+++ b/tests/processing/strategies/test_produce.py
@@ -70,12 +70,12 @@ def test_produce_and_commit() -> None:
     assert broker_storage.consume(Partition(result_topic, 0), 1) is None
     assert commit.call_count == 0
     strategy.poll()
-    assert commit.call_count == 1
+    assert commit.call_count == 2
 
     strategy.submit(message)
     strategy.poll()
-    assert commit.call_count == 2
+    assert commit.call_count == 4
 
     # Commit count immediately increases once we call join()
     strategy.join()
-    assert commit.call_count == 3
+    assert commit.call_count == 5


### PR DESCRIPTION
Currently it's not possible for arroyo to ever hit consumer lag=zero if
nobody is constantly producing to the topic.
