### PR TITLE
metrics: Add metrics about dropped messages in FilterStep

### DIFF
--- a/arroyo/processing/strategies/filter.py
+++ b/arroyo/processing/strategies/filter.py
@@ -82,15 +82,10 @@ class FilterStep(ProcessingStrategy[Union[FilteredPayload, TStrategyPayload]]):
             for partition in message.committable:
                 self.__uncommitted_offsets.pop(partition, None)
             self.__next_step.submit(message)
-        elif self.__commit_policy_state is not None:
-            # first scenario, where a CommitPolicy is passed in
-            # and messages are dropped
-            self.__uncommitted_offsets.update(message.committable)
-            self.__metrics.increment("arroyo.strategies.filter_step.dropped_messages")
-        elif self.__commit_policy_state is None:
-            # second scenario, where a CommitPolicy is not passed in
-            # and messages are dropped
-            self.__metrics.increment("arroyo.strategies.filter_step.dropped_messages")
+        else:
+            self.__metrics.increment("arroyo.strategies.filter.dropped_messages")
+            if self.__commit_policy_state is not None:
+                self.__uncommitted_offsets.update(message.committable)
 
         policy = self.__commit_policy_state
 

--- a/arroyo/utils/metric_defs.py
+++ b/arroyo/utils/metric_defs.py
@@ -53,5 +53,5 @@ MetricName = Literal[
     # Counter metric to measure how often the healthcheck file has been touched.
     "arroyo.processing.strategies.healthcheck.touch",
     # Number of messages dropped in the FilterStep strategy
-    "arroyo.strategies.filter_step.dropped_messages",
+    "arroyo.strategies.filter.dropped_messages",
 ]

--- a/arroyo/utils/metric_defs.py
+++ b/arroyo/utils/metric_defs.py
@@ -52,4 +52,6 @@ MetricName = Literal[
     "arroyo.consumer.librdkafka.total_queue_size",
     # Counter metric to measure how often the healthcheck file has been touched.
     "arroyo.processing.strategies.healthcheck.touch",
+    # Number of messages dropped in the FilterStep strategy
+    "arroyo.strategies.filter_step.dropped_messages",
 ]


### PR DESCRIPTION
For https://github.com/getsentry/arroyo/issues/257 

It seemed to me that we should emit this metric in both scenarios, whether a CommitPolicy was passed in or not. Might have missed something though.

Also, if there are other metrics that would be helpful to add in `FilterStep` strategy, I can include them in this PR.