### PR TITLE
docs: Update dlq doc

### DIFF
--- a/docs/source/architecture.rst
+++ b/docs/source/architecture.rst
@@ -117,10 +117,4 @@ Common examples are:
   This is a typical way to write messages on a storages in batches to reduce the
   round trips.
 
-* ``Dead letter queue``. It is up to the developer to decide what to do with invalid
-  messages. One common option is to produce them onto a dead-letter topic. Arroyo provides
-  a strategy for that. The application developer writes the consumer logic, and the
-  dead-letter queue strategy wraps this logic and intercepts *InvalidMessage* exceptions
-  sending the content to a dedicated topic.
-
 All strategies included with Arroyo are in `the strategies module <https://github.com/getsentry/arroyo/tree/main/arroyo/processing/strategies>`_.

--- a/docs/source/dlqs.rst
+++ b/docs/source/dlqs.rst
@@ -18,5 +18,4 @@ The dead letter queue configuration is passed to the `StreamProcessor` and, if p
 
 
 .. automodule:: arroyo.dlq
-   :members:
-   :undoc-members:
+   :members: InvalidMessage, DlqLimit, DlqPolicy, DlqProducer, KafkaDlqProducer, NoopDlqProducer


### PR DESCRIPTION
Dlq as a strategy doesn't exist anymore, remove the legacy doc. Hide some classes from the doc