### PR TITLE
feat: Automatically resize blocks if they get too small

### DIFF
--- a/arroyo/utils/metric_defs.py
+++ b/arroyo/utils/metric_defs.py
@@ -5,6 +5,10 @@ MetricName = Literal[
     "arroyo.strategies.run_task_with_multiprocessing.batch.size.msg",
     # Number of bytes in a multiprocessing batch
     "arroyo.strategies.run_task_with_multiprocessing.batch.size.bytes",
+    # Number of messages in a multiprocessing batch after the message transformation
+    "arroyo.strategies.run_task_with_multiprocessing.output_batch.size.msg",
+    # Number of bytes in a multiprocessing batch after the message transformation
+    "arroyo.strategies.run_task_with_multiprocessing.output_batch.size.bytes",
     # Number of times the consumer is spinning
     "arroyo.consumer.run.count",
     # How long it took the Reduce step to fill up a batch
@@ -22,6 +26,14 @@ MetricName = Literal[
     # This can be devastating for throughput. Increase `output_block_size` to
     # fix.
     "arroyo.strategies.run_task_with_multiprocessing.batch.output.overflow",
+    # Arroyo has decided to re-allocate a block in order to combat input buffer
+    # overflow. This can be enabled or disabled using `resize_input_blocks`
+    # setting.
+    "arroyo.strategies.run_task_with_multiprocessing.batch.input.resize",
+    # Arroyo has decided to re-allocate a block in order to combat output buffer
+    # overflow. This can be enabled or disabled using `resize_output_blocks`
+    # setting.
+    "arroyo.strategies.run_task_with_multiprocessing.batch.output.resize",
     # How many batches are being processed in parallel by multiprocessing.
     "arroyo.strategies.run_task_with_multiprocessing.batches_in_progress",
     # Counter. A subprocess by multiprocessing unexpectedly died.

--- a/tests/processing/strategies/test_run_task_with_multiprocessing.py
+++ b/tests/processing/strategies/test_run_task_with_multiprocessing.py
@@ -222,14 +222,44 @@ def test_parallel_transform_step() -> None:
         lambda: metrics.calls,
         [],
         [
+            TimingCall(
+                name="arroyo.strategies.run_task_with_multiprocessing.output_batch.size.msg",
+                value=2,
+                tags=None,
+            ),
+            TimingCall(
+                name="arroyo.strategies.run_task_with_multiprocessing.output_batch.size.bytes",
+                value=16000,
+                tags=None,
+            ),
             IncrementCall(
                 name="arroyo.strategies.run_task_with_multiprocessing.batch.output.overflow",
                 value=1,
                 tags=None,
             ),
+            TimingCall(
+                name="arroyo.strategies.run_task_with_multiprocessing.output_batch.size.msg",
+                value=1,
+                tags=None,
+            ),
+            TimingCall(
+                name="arroyo.strategies.run_task_with_multiprocessing.output_batch.size.bytes",
+                value=16000,
+                tags=None,
+            ),
             GaugeCall(
                 "arroyo.strategies.run_task_with_multiprocessing.batches_in_progress",
                 1.0,
+                tags=None,
+            ),
+            TimingCall(
+                name="arroyo.strategies.run_task_with_multiprocessing.output_batch.size.msg",
+                value=1,
+                tags=None,
+            ),
+            TimingCall(
+                name="arroyo.strategies.run_task_with_multiprocessing.output_batch.size.bytes",
+                value=4000,
                 tags=None,
             ),
             GaugeCall(
@@ -381,9 +411,15 @@ def test_message_rejected_multiple() -> None:
             value=0,
             tags=None,
         ),
-        IncrementCall(
-            name="arroyo.strategies.run_task_with_multiprocessing.batch.backpressure",
-            value=1,
+    ] + [
+        TimingCall(
+            name="arroyo.strategies.run_task_with_multiprocessing.output_batch.size.msg",
+            value=2,
+            tags=None,
+        ),
+        TimingCall(
+            name="arroyo.strategies.run_task_with_multiprocessing.output_batch.size.bytes",
+            value=0,
             tags=None,
         ),
         IncrementCall(
@@ -391,19 +427,15 @@ def test_message_rejected_multiple() -> None:
             value=1,
             tags=None,
         ),
-        IncrementCall(
-            name="arroyo.strategies.run_task_with_multiprocessing.batch.backpressure",
-            value=1,
+    ] * 5 + [
+        TimingCall(
+            name="arroyo.strategies.run_task_with_multiprocessing.output_batch.size.msg",
+            value=2,
             tags=None,
         ),
-        IncrementCall(
-            name="arroyo.strategies.run_task_with_multiprocessing.batch.backpressure",
-            value=1,
-            tags=None,
-        ),
-        IncrementCall(
-            name="arroyo.strategies.run_task_with_multiprocessing.batch.backpressure",
-            value=1,
+        TimingCall(
+            name="arroyo.strategies.run_task_with_multiprocessing.output_batch.size.bytes",
+            value=0,
             tags=None,
         ),
         GaugeCall(
@@ -475,3 +507,135 @@ def test_regression_join_timeout_many_messages() -> None:
     assert 2 < time_taken < 4
 
     assert next_step.submit.call_count > 0
+
+
+def run_multiply_times_two(x: Message[KafkaPayload]) -> KafkaPayload:
+    return KafkaPayload(None, x.payload.value * 2, [])
+
+
+def test_input_block_resizing_max_size() -> None:
+    INPUT_SIZE = 36000
+    next_step = Mock()
+
+    strategy = RunTaskWithMultiprocessing(
+        run_multiply_times_two,
+        next_step,
+        num_processes=2,
+        max_batch_size=INPUT_SIZE // 10,
+        max_batch_time=60,
+        input_block_size=1,
+        output_block_size=1,
+        resize_input_blocks=True,
+        max_input_block_size=16000,
+        resize_output_blocks=False,
+    )
+
+    with pytest.raises(MessageRejected):
+        for _ in range(INPUT_SIZE // 10):
+            strategy.submit(Message(Value(KafkaPayload(None, b"x" * 10, []), {})))
+
+    strategy.close()
+    strategy.join(timeout=3)
+
+    assert not any(
+        x.name == "arroyo.strategies.run_task_with_multiprocessing.batch.input.resize"
+        for x in TestingMetricsBackend.calls
+    )
+
+
+def test_input_block_resizing_without_limits() -> None:
+    INPUT_SIZE = 36000
+    next_step = Mock()
+
+    strategy = RunTaskWithMultiprocessing(
+        run_multiply_times_two,
+        next_step,
+        num_processes=2,
+        max_batch_size=INPUT_SIZE // 10,
+        max_batch_time=60,
+        input_block_size=1,
+        output_block_size=1,
+        resize_input_blocks=True,
+        resize_output_blocks=False,
+    )
+
+    with pytest.raises(MessageRejected):
+        for _ in range(INPUT_SIZE // 10):
+            strategy.submit(Message(Value(KafkaPayload(None, b"x" * 10, []), {})))
+
+    strategy.close()
+    strategy.join(timeout=3)
+
+    assert (
+        IncrementCall(
+            name="arroyo.strategies.run_task_with_multiprocessing.batch.input.resize",
+            value=1,
+            tags=None,
+        )
+        in TestingMetricsBackend.calls
+    )
+
+
+def test_output_block_resizing_max_size() -> None:
+    INPUT_SIZE = 72000
+    next_step = Mock()
+
+    strategy = RunTaskWithMultiprocessing(
+        run_multiply_times_two,
+        next_step,
+        num_processes=2,
+        max_batch_size=INPUT_SIZE // 10,
+        max_batch_time=60,
+        input_block_size=INPUT_SIZE,
+        output_block_size=1,
+        resize_input_blocks=False,
+        resize_output_blocks=True,
+        max_output_block_size=16000,
+    )
+
+    for _ in range(INPUT_SIZE // 10):
+        strategy.submit(Message(Value(KafkaPayload(None, b"x" * 10, []), {})))
+
+    strategy.close()
+    strategy.join(timeout=3)
+
+    assert not any(
+        x.name == "arroyo.strategies.run_task_with_multiprocessing.batch.output.resize"
+        for x in TestingMetricsBackend.calls
+    )
+
+
+def test_output_block_resizing_without_limits() -> None:
+    INPUT_SIZE = 144000
+    next_step = Mock()
+
+    strategy = RunTaskWithMultiprocessing(
+        run_multiply_times_two,
+        next_step,
+        num_processes=2,
+        max_batch_size=INPUT_SIZE // 10,
+        max_batch_time=60,
+        input_block_size=INPUT_SIZE,
+        output_block_size=1,
+        resize_input_blocks=False,
+        resize_output_blocks=True,
+    )
+
+    for _ in range(INPUT_SIZE // 10):
+        strategy.submit(Message(Value(KafkaPayload(None, b"x" * 10, []), {})))
+
+    strategy.close()
+    strategy.join(timeout=3)
+
+    assert next_step.submit.call_args_list == [
+        call(Message(Value(KafkaPayload(None, b"x" * 20, []), {}))),
+    ] * (INPUT_SIZE // 10)
+
+    assert (
+        IncrementCall(
+            name="arroyo.strategies.run_task_with_multiprocessing.batch.output.resize",
+            value=1,
+            tags=None,
+        )
+        in TestingMetricsBackend.calls
+    )


### PR DESCRIPTION
This is a naive implementation that resizes input/output blocks if they
become too small.

Blocks are reallocated once the overflowing batch is successfully
drained.

This will make startup of a consumer slower, but over time hopefully all
blocks eventually reach a state where they won't overflow anymore.
