### PR TITLE
fix(reduce): Add missing call to next_step.terminate()

### DIFF
--- a/arroyo/processing/strategies/filter.py
+++ b/arroyo/processing/strategies/filter.py
@@ -12,7 +12,6 @@ from arroyo.types import (
     TStrategyPayload,
     Value,
 )
-
 from arroyo.utils.metrics import get_metrics
 
 logger = logging.getLogger(__name__)
@@ -118,4 +117,4 @@ class FilterStep(ProcessingStrategy[Union[FilteredPayload, TStrategyPayload]]):
     def join(self, timeout: Optional[float] = None) -> None:
         self.__flush_uncommitted_offsets(time.time())
         self.__next_step.close()
-        self.__next_step.join(timeout)
+        self.__next_step.join(timeout=timeout)

--- a/arroyo/processing/strategies/guard.py
+++ b/arroyo/processing/strategies/guard.py
@@ -37,7 +37,7 @@ class _StrategyGuardAfter(BasicStrategy[TStrategyPayload]):
         self.__next_step.poll()
 
     def join(self, timeout: Optional[float] = None) -> None:
-        self.__next_step.join(timeout)
+        self.__next_step.join(timeout=timeout)
 
     def close(self) -> None:
         self.__next_step.close()

--- a/arroyo/processing/strategies/reduce.py
+++ b/arroyo/processing/strategies/reduce.py
@@ -154,6 +154,7 @@ class Reduce(
     def terminate(self) -> None:
         self.__closed = True
         self.__batch_builder = None
+        self.__next_step.terminate()
 
     def join(self, timeout: Optional[float] = None) -> None:
         """

--- a/arroyo/processing/strategies/run_task.py
+++ b/arroyo/processing/strategies/run_task.py
@@ -55,7 +55,7 @@ class RunTask(
         self.__next_step.poll()
 
     def join(self, timeout: Optional[float] = None) -> None:
-        self.__next_step.join(timeout)
+        self.__next_step.join(timeout=timeout)
 
     def close(self) -> None:
         self.__next_step.close()

--- a/arroyo/processing/strategies/run_task_in_threads.py
+++ b/arroyo/processing/strategies/run_task_in_threads.py
@@ -144,7 +144,7 @@ class RunTaskInThreads(
 
         self.__next_step.close()
         self.__executor.shutdown()
-        self.__next_step.join(timeout)
+        self.__next_step.join(timeout=timeout)
 
     def close(self) -> None:
         self.__closed = True

--- a/tests/processing/strategies/test_all.py
+++ b/tests/processing/strategies/test_all.py
@@ -266,3 +266,26 @@ def test_dlq(
         )
         for partition, offset, type_ in message_pattern
     ]
+
+
+@pytest.mark.parametrize("strategy_factory", FACTORIES)
+def test_terminate(strategy_factory: StrategyFactory) -> None:
+    next_step = Mock()
+
+    step = strategy_factory(next_step)
+    step.terminate()
+
+    assert next_step.terminate.call_args_list == [call()]
+
+
+@pytest.mark.parametrize("strategy_factory", FACTORIES)
+def test_join(strategy_factory: StrategyFactory) -> None:
+    next_step = Mock()
+
+    step = strategy_factory(next_step)
+    step.close()
+    step.join()
+
+    assert next_step.close.call_args_list == [call()]
+
+    assert next_step.join.call_args_list == [call(timeout=None)]


### PR DESCRIPTION
When a reduce strategy is terminated, the next strategy should also be
terminated.

We think that in INC-443, this caused the RunTaskInThreads in Snuba to
not be terminated at all, leaving us with background threads that
inhibited the shutdown of the process.

steps in snuba are:

* filterstep (optional)
* runtaskwithmultiprocessing (message processor)
* reduce (clickhouse write batch)
* runtaskinthreads (clickhouse write)

Also add more generic tests around close+join, and align arguments in
all strategies to be by-keyword so that the assertion passes.
