### PR TITLE
Add socket.timeout.ms to supported kafka configurations

### DIFF
--- a/arroyo/backends/kafka/configuration.py
+++ b/arroyo/backends/kafka/configuration.py
@@ -27,6 +27,7 @@ SUPPORTED_KAFKA_CONFIGURATION = (
     "sasl.username",
     "sasl.password",
     "security.protocol",
+    "socket.timeout.ms",
     "ssl.ca.location",
     "ssl.ca.certificate.stores",
     "ssl.certificate.location",


### PR DESCRIPTION
Looks like this is in Sentry but not here. Seems safe to add here?

https://github.com/getsentry/sentry/blob/af54b69df3ed3b8beb5e945854d2e4f4c852a14d/src/sentry/utils/kafka_config.py#L17