### PR TITLE
fix(multiprocessing): Make close() call the next steps close()

### DIFF
--- a/arroyo/processing/strategies/produce.py
+++ b/arroyo/processing/strategies/produce.py
@@ -124,5 +124,6 @@ class Produce(ProcessingStrategy[Union[FilteredPayload, TStrategyPayload]]):
             self.__next_step.poll()
             self.__next_step.submit(message)
 
+        self.__producer.close()
         self.__next_step.close()
         self.__next_step.join(remaining)

--- a/arroyo/processing/strategies/run_task_with_multiprocessing.py
+++ b/arroyo/processing/strategies/run_task_with_multiprocessing.py
@@ -669,6 +669,8 @@ class RunTaskWithMultiprocessing(
         if self.__batch_builder is not None and len(self.__batch_builder) > 0:
             self.__submit_batch()
 
+        self.__next_step.close()
+
     def terminate(self) -> None:
         self.__closed = True
 

--- a/arroyo/processing/strategies/run_task_with_multiprocessing.py
+++ b/arroyo/processing/strategies/run_task_with_multiprocessing.py
@@ -669,8 +669,6 @@ class RunTaskWithMultiprocessing(
         if self.__batch_builder is not None and len(self.__batch_builder) > 0:
             self.__submit_batch()
 
-        self.__next_step.close()
-
     def terminate(self) -> None:
         self.__closed = True
 


### PR DESCRIPTION
We are missing the call to next step's close() call in multiprocessing. In cases where the next step is Produce the consumer just hangs because the shutdown flag is not set.