### PR TITLE
feat: Add global shutdown handler for strategy factory

### DIFF
--- a/arroyo/processing/processor.py
+++ b/arroyo/processing/processor.py
@@ -298,6 +298,7 @@ class StreamProcessor(Generic[TStrategyPayload]):
 
             logger.info("Closing %r...", self.__consumer)
             self.__consumer.close()
+            self.__processor_factory.shutdown()
             logger.info("Processor terminated")
             raise
 
@@ -446,6 +447,7 @@ class StreamProcessor(Generic[TStrategyPayload]):
         logger.info("Stopping consumer")
         self.__metrics_buffer.flush()
         self.__consumer.close()
+        self.__processor_factory.shutdown()
         logger.info("Stopped")
 
         # if there was an active processing strategy, it should be shut down

--- a/arroyo/processing/strategies/abstract.py
+++ b/arroyo/processing/strategies/abstract.py
@@ -118,3 +118,11 @@ class ProcessingStrategyFactory(ABC, Generic[TStrategyPayload]):
         :param partitions: A mapping of a ``Partition`` to it's most recent offset.
         """
         raise NotImplementedError
+
+    def shutdown(self) -> None:
+        """
+        Custom code to execute when the ``StreamProcessor`` shuts down entirely.
+
+        Note that this code will also be executed on crashes of the strategy.
+        """
+        pass


### PR DESCRIPTION
In sentry's unified consumers, there is no place to register a global
shutdown handler. Add this to arroyo directly in order to standardize
it, though technically there's no use for such a shutdown outside of
unified consumers since in other scenarios, the user manages the
lifecycle of the application themselves.

related to https://github.com/getsentry/arroyo/pull/277
