### PR TITLE
fix(produce): Apply backpressure instead of crashing

### DIFF
--- a/arroyo/processing/strategies/produce.py
+++ b/arroyo/processing/strategies/produce.py
@@ -87,7 +87,11 @@ class Produce(ProcessingStrategy[Union[FilteredPayload, TStrategyPayload]]):
         future: Optional[Future[BrokerValue[TStrategyPayload]]] = None
 
         if not isinstance(message.payload, FilteredPayload):
-            future = self.__producer.produce(self.__topic, message.payload)
+            try:
+                future = self.__producer.produce(self.__topic, message.payload)
+            except BufferError as exc:
+                logger.exception(exc)
+                raise MessageRejected from exc
 
         self.__queue.append((message, future))
 


### PR DESCRIPTION
If we get local queue full, let's raise MessageRejected to slow down the consumer.