### PR TITLE
Make producer thread a deamon

### DIFF
--- a/arroyo/backends/kafka/consumer.py
+++ b/arroyo/backends/kafka/consumer.py
@@ -639,7 +639,7 @@ class KafkaProducer(Producer[KafkaPayload]):
         # The worker must execute in a separate thread to ensure that callbacks
         # are fired -- otherwise trying to produce "synchronously" via
         # ``produce(...).result()`` could result in a deadlock.
-        self.__result = execute(self.__worker)
+        self.__result = execute(self.__worker, daemon=True)
 
     def __worker(self) -> None:
         """


### PR DESCRIPTION
Sometimes a program may have to shut down before the strategies are created. This producer thread starts running as soon as the producer is instantiated even before it is added to a strategy.  To simplify cleanup, make it a daemon thread so that it exists when the parent process exists and doesn't block exiting.