### PR TITLE
fix: Ensure carried over message is in buffer

### DIFF
--- a/arroyo/processing/processor.py
+++ b/arroyo/processing/processor.py
@@ -377,8 +377,7 @@ class StreamProcessor(Generic[TStrategyPayload]):
                     message = (
                         Message(self.__message) if self.__message is not None else None
                     )
-                    if not message_carried_over:
-                        self.__buffered_messages.append(self.__message)
+                    self.__buffered_messages.append(self.__message)
                     self.__processing_strategy.submit(message)
 
                     self.__metrics_buffer.incr_timing(

--- a/arroyo/processing/processor.py
+++ b/arroyo/processing/processor.py
@@ -354,6 +354,8 @@ class StreamProcessor(Generic[TStrategyPayload]):
             try:
                 start_poll = time.time()
                 self.__message = self.__consumer.poll(timeout=1.0)
+                if self.__message:
+                    self.__buffered_messages.append(self.__message)
                 self.__metrics_buffer.incr_timing(
                     "arroyo.consumer.poll.time", time.time() - start_poll
                 )
@@ -377,7 +379,6 @@ class StreamProcessor(Generic[TStrategyPayload]):
                     message = (
                         Message(self.__message) if self.__message is not None else None
                     )
-                    self.__buffered_messages.append(self.__message)
                     self.__processing_strategy.submit(message)
 
                     self.__metrics_buffer.incr_timing(


### PR DESCRIPTION
Since `_run_once` can early return (https://github.com/getsentry/arroyo/blob/6286c7921978065edeb5ce72d829031f952d2e5e/arroyo/processing/processor.py#L369) it was possible that a message was never placed in `self.buffered_messages`. If we try to retreive it later, it can crash the consumer.

This is suspected to be the cause of the `Invalid message not found in buffer` messages we saw in prod.