### PR TITLE
Add coverage report to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,3 +80,7 @@ jobs:
           make install
       - name: Run tests
         run: pytest -vv
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@v3
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,7 +79,7 @@ jobs:
           python -m pip install --upgrade pip
           make install
       - name: Run tests
-        run: pytest -vv
+        run: pytest -vv --cov
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v3
         env:

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,3 +1,4 @@
 pytest==7.1.2
 pytest-benchmark==4.0.0
+pytest-cov==4.1.0
 mypy==0.961


### PR DESCRIPTION
Add  codcov reports. This can help inform us of uncovered branches and help with investigating bugs.