### PR TITLE
Revert "Add coverage report to CI (#286)"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,8 +79,4 @@ jobs:
           python -m pip install --upgrade pip
           make install
       - name: Run tests
-        run: pytest -vv --cov
-      - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@v3
-        env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+        run: pytest -vv

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,4 +1,3 @@
 pytest==7.1.2
 pytest-benchmark==4.0.0
-pytest-cov==4.1.0
 mypy==0.961


### PR DESCRIPTION
This reverts commit 0d7a0ec5afae584b8bdc3571d4ae656f4864a870.

Codecov is reporting the wrong thing. This is blocking the release process.