### PR TITLE
perf: Avoid unnecessarily clearing the rdkafka buffer on backpressure

### DIFF
--- a/arroyo/processing/processor.py
+++ b/arroyo/processing/processor.py
@@ -142,9 +142,9 @@ class StreamProcessor(Generic[TStrategyPayload]):
 
         self.__message: Optional[BrokerValue[TStrategyPayload]] = None
 
+        # The timestamp when backpressure state started
         self.__backpressure_timestamp: Optional[float] = None
-        # If the consumer is in the paused state, this is when the last call to
-        # ``pause`` occurred.
+        # Consumer is paused after it is in backpressure state for > 1 second
         self.__is_paused = False
 
         self.__commit_policy_state = commit_policy.get_state_machine()

--- a/arroyo/processing/processor.py
+++ b/arroyo/processing/processor.py
@@ -338,7 +338,7 @@ class StreamProcessor(Generic[TStrategyPayload]):
 
         message_carried_over = self.__message is not None
 
-        if message_carried_over:
+        if self.__is_paused:
             # If a message was carried over from the previous run, there are two reasons:
             #
             # * MessageRejected. the consumer should be paused and not
@@ -346,11 +346,11 @@ class StreamProcessor(Generic[TStrategyPayload]):
             # * InvalidMessage. the message should be resubmitted.
             #   _handle_invalid_message is responsible for clearing out
             #   self.__message if it was the invalid one.
-            if self.__is_paused and self.__consumer.poll(timeout=0) is not None:
+            if self.__consumer.poll(timeout=0) is not None:
                 raise InvalidStateError(
                     "received message when consumer was expected to be paused"
                 )
-        else:
+        if not message_carried_over:
             # Otherwise, we need to try fetch a new message from the consumer,
             # even if there is no active assignment and/or processing strategy.
             try:

--- a/tests/processing/test_processor.py
+++ b/tests/processing/test_processor.py
@@ -86,6 +86,8 @@ def test_stream_processor_lifecycle() -> None:
     with assert_changes(lambda: int(consumer.pause.call_count), 0, 1):
         processor._run_once()
         assert strategy.submit.call_args_list[-1] == mock.call(message)
+        time.sleep(1)
+        processor._run_once()  # Should pause now
 
     # If ``Consumer.poll`` returns a message when we expect it to be paused,
     # we should raise an exception.

--- a/tests/processing/test_processor.py
+++ b/tests/processing/test_processor.py
@@ -134,9 +134,13 @@ def test_stream_processor_lifecycle() -> None:
         (Timing, "arroyo.consumer.poll.time"),
         (Timing, "arroyo.consumer.callback.time"),
         (Timing, "arroyo.consumer.processing.time"),
+        (Increment, "arroyo.consumer.run.count"),
+        (Timing, "arroyo.consumer.processing.time"),
         (Timing, "arroyo.consumer.paused.time"),
         (Timing, "arroyo.consumer.join.time"),
         (Timing, "arroyo.consumer.shutdown.time"),
+        (Timing, "arroyo.consumer.callback.time"),
+        (Timing, "arroyo.consumer.poll.time"),
         (Increment, "arroyo.consumer.run.count"),
     ]
 


### PR DESCRIPTION
This is the same fix we did in the Rust version of Arroyo https://github.com/getsentry/snuba/pull/4774

We saw a lot of performance improvements after this change so I'm porting it to Python too.