### PR TITLE
fix: Temporarily bring back support for legacy commit log format

### DIFF
--- a/tests/backends/test_commit.py
+++ b/tests/backends/test_commit.py
@@ -1,5 +1,6 @@
 import time
 
+from arroyo.backends.kafka import KafkaPayload
 from arroyo.backends.kafka.commit import CommitCodec
 from arroyo.commit import Commit
 from arroyo.types import Partition, Topic
@@ -24,3 +25,12 @@ def test_encode_decode() -> None:
     encoded = commit_codec.encode(commit)
 
     assert commit_codec.decode(encoded) == commit
+
+
+def test_decode_legacy() -> None:
+    legacy = KafkaPayload(
+        b"topic:0:leader-a", b"5", [("orig_message_ts", b"2023-09-26T21:58:14.191325Z")]
+    )
+    decoded = CommitCodec().decode(legacy)
+    assert decoded.offset == 5
+    assert decoded.group == "leader-a"


### PR DESCRIPTION
We experienced issues when deploying https://github.com/getsentry/arroyo/pull/295 to production. It was discovered that very old commit log entries are still present. This is likely because the commit log topic has cleanup.policy=compact set, which causes messages to never expire if they have a unique key.

The process of fixing this is underway: https://github.com/getsentry/snuba/pull/4941 and https://github.com/getsentry/ops/pull/8361

However we have to keep support for the legacy commit log format around for a while until this work is complete.