### PR TITLE
fix(run_task_threads): Add metric to capture backpressure

### DIFF
--- a/arroyo/utils/metric_defs.py
+++ b/arroyo/utils/metric_defs.py
@@ -68,4 +68,7 @@ MetricName = Literal[
     "arroyo.processing.strategies.healthcheck.touch",
     # Number of messages dropped in the FilterStep strategy
     "arroyo.strategies.filter.dropped_messages",
+    # Counter, incremented when run task in threads raises a backpressure.
+    # Indicates that there is saturation in the thread pool.
+    "arroyo.strategies.run_task_in_threads.backpressure",
 ]


### PR DESCRIPTION
In order to debug backpressure being raised from run task in threads, add a new metric which captures the information. This would help triage whether the kafka doomsday alert is going off because of backpressure or not.