### PR TITLE
fix(dlq): RunTaskWithMultiprocessing supports forwarding downstream invalid message

### DIFF
--- a/arroyo/processing/strategies/run_task_with_multiprocessing.py
+++ b/arroyo/processing/strategies/run_task_with_multiprocessing.py
@@ -788,7 +788,7 @@ class RunTaskWithMultiprocessing(
                 )
                 break
             except InvalidMessage:
-                pass
+                raise
 
         logger.debug("Waiting for %s...", self.__pool)
         self.__pool.terminate()

--- a/arroyo/processing/strategies/run_task_with_multiprocessing.py
+++ b/arroyo/processing/strategies/run_task_with_multiprocessing.py
@@ -774,14 +774,21 @@ class RunTaskWithMultiprocessing(
         self.__next_step.terminate()
 
     def join(self, timeout: Optional[float] = None) -> None:
+        start_join = time.time()
         deadline = time.time() + timeout if timeout is not None else None
         self.__forward_invalid_offsets()
 
         logger.debug("Waiting for %s batches...", len(self.__processes))
 
-        self.__check_for_results(
-            timeout=timeout,
-        )
+        while True:
+            elapsed = time.time() - start_join
+            try:
+                self.__check_for_results(
+                    timeout=timeout - elapsed if timeout is not None else None,
+                )
+                break
+            except InvalidMessage:
+                pass
 
         logger.debug("Waiting for %s...", self.__pool)
         self.__pool.terminate()

--- a/arroyo/processing/strategies/run_task_with_multiprocessing.py
+++ b/arroyo/processing/strategies/run_task_with_multiprocessing.py
@@ -613,6 +613,13 @@ class RunTaskWithMultiprocessing(
 
             try:
                 self.__next_step.poll()
+            except InvalidMessage as e:
+                # For the next invocation of __check_for_results, start at this message
+                result.valid_messages_transformed.reset_iterator(idx)
+                self.__invalid_messages.append(e)
+                raise e
+
+            try:
                 self.__next_step.submit(message)
 
             except MessageRejected:
@@ -625,7 +632,8 @@ class RunTaskWithMultiprocessing(
                 raise NextStepTimeoutError()
             except InvalidMessage as e:
                 # For the next invocation of __check_for_results, skip over this message
-                result.valid_messages_transformed.reset_iterator(idx)
+                # since we do not want to re-submit it.
+                result.valid_messages_transformed.reset_iterator(idx + 1)
                 self.__invalid_messages.append(e)
                 raise e
 

--- a/arroyo/processing/strategies/run_task_with_multiprocessing.py
+++ b/arroyo/processing/strategies/run_task_with_multiprocessing.py
@@ -625,7 +625,7 @@ class RunTaskWithMultiprocessing(
                 raise NextStepTimeoutError()
             except InvalidMessage as e:
                 # For the next invocation of __check_for_results, skip over this message
-                result.valid_messages_transformed.reset_iterator(idx + 1)
+                result.valid_messages_transformed.reset_iterator(idx)
                 self.__invalid_messages.append(e)
                 raise e
 


### PR DESCRIPTION
Invalid messages raised from strategies downstream of RunTaskWithMultiprocessing are not correctly handled currently. Currently messages from that batch will be re-submitted to the next step multiple times. This change ensures they are correctly re-raised and avoids the duplicate messages downstream.