### PR TITLE
fix: Default input block size should be larger

### DIFF
--- a/arroyo/processing/strategies/run_task_with_multiprocessing.py
+++ b/arroyo/processing/strategies/run_task_with_multiprocessing.py
@@ -37,8 +37,8 @@ __all__ = ["RunTaskWithMultiprocessing"]
 TResult = TypeVar("TResult")
 TBatchValue = TypeVar("TBatchValue")
 
-DEFAULT_INPUT_BLOCK_SIZE = 16 * 1024
-DEFAULT_OUTPUT_BLOCK_SIZE = 16 * 1024
+DEFAULT_INPUT_BLOCK_SIZE = 16 * 1024 * 1024
+DEFAULT_OUTPUT_BLOCK_SIZE = 16 * 1024 * 1024
 
 LOG_THRESHOLD_TIME = 20  # In seconds
 

--- a/tests/processing/strategies/test_run_task_with_multiprocessing.py
+++ b/tests/processing/strategies/test_run_task_with_multiprocessing.py
@@ -515,23 +515,25 @@ def run_multiply_times_two(x: Message[KafkaPayload]) -> KafkaPayload:
 
 
 def test_input_block_resizing_max_size() -> None:
-    INPUT_SIZE = 36000
+    INPUT_SIZE = 36 * 1024 * 1024
+    MSG_SIZE = 10 * 1024
+    NUM_MESSAGES = INPUT_SIZE // MSG_SIZE
     next_step = Mock()
 
     strategy = RunTaskWithMultiprocessing(
         run_multiply_times_two,
         next_step,
         num_processes=2,
-        max_batch_size=INPUT_SIZE // 10,
+        max_batch_size=NUM_MESSAGES,
         max_batch_time=60,
         input_block_size=None,
-        output_block_size=16000,
+        output_block_size=INPUT_SIZE // 2,
         max_input_block_size=16000,
     )
 
     with pytest.raises(MessageRejected):
-        for _ in range(INPUT_SIZE // 10):
-            strategy.submit(Message(Value(KafkaPayload(None, b"x" * 10, []), {})))
+        for _ in range(NUM_MESSAGES):
+            strategy.submit(Message(Value(KafkaPayload(None, b"x" * MSG_SIZE, []), {})))
 
     strategy.close()
     strategy.join(timeout=3)

--- a/tests/processing/strategies/test_run_task_with_multiprocessing.py
+++ b/tests/processing/strategies/test_run_task_with_multiprocessing.py
@@ -576,22 +576,24 @@ def test_input_block_resizing_without_limits() -> None:
 
 
 def test_output_block_resizing_max_size() -> None:
-    INPUT_SIZE = 72000
+    INPUT_SIZE = 72 * 1024 * 1024
+    MSG_SIZE = 10 * 1024
+    NUM_MESSAGES = INPUT_SIZE // MSG_SIZE
     next_step = Mock()
 
     strategy = RunTaskWithMultiprocessing(
         run_multiply_times_two,
         next_step,
         num_processes=2,
-        max_batch_size=INPUT_SIZE // 10,
+        max_batch_size=NUM_MESSAGES,
         max_batch_time=60,
         input_block_size=INPUT_SIZE,
         output_block_size=None,
         max_output_block_size=16000,
     )
 
-    for _ in range(INPUT_SIZE // 10):
-        strategy.submit(Message(Value(KafkaPayload(None, b"x" * 10, []), {})))
+    for _ in range(NUM_MESSAGES):
+        strategy.submit(Message(Value(KafkaPayload(None, b"x" * MSG_SIZE, []), {})))
 
     strategy.close()
     strategy.join(timeout=3)

--- a/tests/processing/strategies/test_run_task_with_multiprocessing.py
+++ b/tests/processing/strategies/test_run_task_with_multiprocessing.py
@@ -543,22 +543,24 @@ def test_input_block_resizing_max_size() -> None:
 
 
 def test_input_block_resizing_without_limits() -> None:
-    INPUT_SIZE = 36000
+    INPUT_SIZE = 36 * 1024 * 1024
+    MSG_SIZE = 10 * 1024
+    NUM_MESSAGES = INPUT_SIZE // MSG_SIZE
     next_step = Mock()
 
     strategy = RunTaskWithMultiprocessing(
         run_multiply_times_two,
         next_step,
         num_processes=2,
-        max_batch_size=INPUT_SIZE // 10,
+        max_batch_size=NUM_MESSAGES,
         max_batch_time=60,
         input_block_size=None,
-        output_block_size=16000,
+        output_block_size=INPUT_SIZE // 2,
     )
 
     with pytest.raises(MessageRejected):
-        for _ in range(INPUT_SIZE // 10):
-            strategy.submit(Message(Value(KafkaPayload(None, b"x" * 10, []), {})))
+        for _ in range(NUM_MESSAGES):
+            strategy.submit(Message(Value(KafkaPayload(None, b"x" * MSG_SIZE, []), {})))
 
     strategy.close()
     strategy.join(timeout=3)


### PR DESCRIPTION
We were under the assumption that we can pick an arbitrarily low value
here since it will be automatically resized. However, in the case where
a single message is larger than the block size, the consumer can still
crash.

This is too hard to fix right now and not worth it, so hardcode it to
16M (which is more than the max Kafka message size), and hope it never
happens again.

The original purpose of dynamically resizing input blocks was to make
performance tuning simpler, and IMO we still have achieved that.
