### PR TITLE
feat: Enable automatic latency recording for consumers

### DIFF
--- a/arroyo/processing/strategies/produce.py
+++ b/arroyo/processing/strategies/produce.py
@@ -69,7 +69,11 @@ class Produce(ProcessingStrategy[Union[FilteredPayload, TStrategyPayload]]):
                     break
 
                 message = Message(
-                    Value(future.result().payload, original_message.committable)
+                    Value(
+                        future.result().payload,
+                        original_message.committable,
+                        original_message.timestamp,
+                    )
                 )
 
             self.__queue.popleft()
@@ -122,7 +126,11 @@ class Produce(ProcessingStrategy[Union[FilteredPayload, TStrategyPayload]]):
                     break
 
                 message = Message(
-                    Value(future.result().payload, original_message.committable)
+                    Value(
+                        future.result().payload,
+                        original_message.committable,
+                        original_message.timestamp,
+                    )
                 )
 
             self.__next_step.poll()

--- a/arroyo/processing/strategies/unfold.py
+++ b/arroyo/processing/strategies/unfold.py
@@ -55,9 +55,11 @@ class Unfold(
         for idx, value in enumerate(iterable):
             # Last message is special because offsets can be committed along with it
             if idx == num_messages - 1:
-                next_message = Message(Value(value, message.committable))
+                next_message = Message(
+                    Value(value, message.committable, message.timestamp)
+                )
             else:
-                next_message = Message(Value(value, {}))
+                next_message = Message(Value(value, {}, message.timestamp))
 
             if store_remaining_messages == False:
                 try:

--- a/arroyo/utils/metric_defs.py
+++ b/arroyo/utils/metric_defs.py
@@ -62,6 +62,8 @@ MetricName = Literal[
     # Time (unitless) spent in shutting down the consumer. This metric's
     # timings overlap other timings, and might spike at the same time.
     "arroyo.consumer.shutdown.time",
+    # Consumer latency in seconds. Recorded by the commit offsets strategy.
+    "arroyo.consumer.latency",
     # Queue size of background queue that librdkafka uses to prefetch messages.
     "arroyo.consumer.librdkafka.total_queue_size",
     # Counter metric to measure how often the healthcheck file has been touched.

--- a/examples/transform_and_produce/batched.py
+++ b/examples/transform_and_produce/batched.py
@@ -41,6 +41,7 @@ def index_data(
                     value=json.dumps(indexed_messages[i]).encode(),
                 ),
                 committable=batch.payload[i].committable,
+                timestamp=batch.timestamp,
             )
         )
     return ret
@@ -71,7 +72,6 @@ class BatchedIndexerStrategyFactory(ProcessingStrategyFactory[KafkaPayload]):
         commit: Commit,
         partitions: Mapping[Partition, int],
     ) -> ProcessingStrategy[KafkaPayload]:
-
         unbatch: UnbatchStep[KafkaPayload] = UnbatchStep(
             next_step=Produce(self.__producer, self.__topic, CommitOffsets(commit))
         )

--- a/tests/processing/strategies/test_all.py
+++ b/tests/processing/strategies/test_all.py
@@ -139,9 +139,9 @@ def test_filters(strategy_factory: StrategyFactory) -> None:
         return message.payload
 
     messages: Sequence[DummyMessage] = [
-        Message(Value(True, {Partition(Topic("topic"), 0): 1})),
+        Message(Value(True, {Partition(Topic("topic"), 0): 1}, NOW)),
         Message(Value(FILTERED_PAYLOAD, {Partition(Topic("topic"), 0): 2})),
-        Message(Value(True, {Partition(Topic("topic"), 0): 3})),
+        Message(Value(True, {Partition(Topic("topic"), 0): 3}, NOW)),
     ]
 
     for message in messages:

--- a/tests/processing/strategies/test_commit.py
+++ b/tests/processing/strategies/test_commit.py
@@ -1,14 +1,18 @@
-from unittest.mock import Mock
+from datetime import datetime
+from unittest.mock import ANY, Mock
 
 from arroyo.processing.strategies.commit import CommitOffsets
 from arroyo.types import Message, Partition, Topic, Value
+from tests.metrics import Increment, TestingMetricsBackend
 
 
 def test_commit() -> None:
     commit_func = Mock()
     strategy = CommitOffsets(commit_func)
 
-    strategy.submit(Message(Value(b"", {Partition(Topic("topic"), 1): 5})))
+    strategy.submit(
+        Message(Value(b"", {Partition(Topic("topic"), 1): 5}, datetime.now()))
+    )
 
     assert commit_func.call_count == 1
 
@@ -23,3 +27,16 @@ def test_commit_poll() -> None:
 
     assert commit_func.call_count == 1
 
+
+def test_record_metric() -> None:
+    commit_func = Mock()
+    strategy = CommitOffsets(commit_func)
+    now = datetime.now()
+
+    strategy.submit(Message(Value(b"", {Partition(Topic("topic"), 1): 5}, now)))
+    strategy.poll()
+
+    metrics = TestingMetricsBackend
+    assert metrics.calls == [
+        Increment(name="arroyo.consumer.latency", value=ANY, tags=None)
+    ]

--- a/tests/processing/strategies/test_guard.py
+++ b/tests/processing/strategies/test_guard.py
@@ -19,7 +19,8 @@ from arroyo.types import (
 
 def test_guard() -> None:
     partition = Partition(Topic("topic"), 1)
-    message = Message(BrokerValue(b"", partition, 5, datetime.now()))
+    now = datetime.now()
+    message = Message(BrokerValue(b"", partition, 5, now))
 
     # Reject all messages that aren't the filtered one
     def inner_strategy_submit(msg: Message[bytes]) -> None:

--- a/tests/processing/strategies/test_produce.py
+++ b/tests/processing/strategies/test_produce.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 from unittest import mock
 
 import pytest
@@ -26,8 +27,9 @@ def test_produce() -> None:
 
     value = b'{"something": "something"}'
     data = KafkaPayload(None, value, [])
+    now = datetime.now()
 
-    message = Message(Value(data, {Partition(orig_topic, 0): 1}))
+    message = Message(Value(data, {Partition(orig_topic, 0): 1}, now))
 
     strategy.submit(message)
 

--- a/tests/processing/strategies/test_reduce.py
+++ b/tests/processing/strategies/test_reduce.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 from typing import Callable, Set
 from unittest.mock import Mock, call
 
@@ -6,6 +7,8 @@ from arroyo.types import BaseValue, Message, Partition, Topic, Value
 
 
 def test_reduce() -> None:
+    now = datetime.now()
+
     def accumulator(result: Set[int], value: BaseValue[int]) -> Set[int]:
         result.add(value.payload)
         return result
@@ -26,6 +29,7 @@ def test_reduce() -> None:
                     {
                         partition: i + 1,
                     },
+                    now,
                 )
             )
         )
@@ -33,7 +37,7 @@ def test_reduce() -> None:
 
     next_step.submit.assert_has_calls(
         [
-            call(Message(Value({0, 1, 2}, {partition: 3}))),
-            call(Message(Value({3, 4, 5}, {partition: 6}))),
+            call(Message(Value({0, 1, 2}, {partition: 3}, now))),
+            call(Message(Value({3, 4, 5}, {partition: 6}, now))),
         ]
     )

--- a/tests/processing/strategies/test_unfold.py
+++ b/tests/processing/strategies/test_unfold.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 from typing import Sequence
 from unittest.mock import Mock, call
 
@@ -12,16 +13,17 @@ def generator(num: int) -> Sequence[int]:
 
 def test_unfold() -> None:
     partition = Partition(Topic("topic"), 0)
+    now = datetime.now()
 
-    message = Message(Value(2, {partition: 1}))
+    message = Message(Value(2, {partition: 1}, now))
     next_step = Mock()
 
     strategy = Unfold(generator, next_step)
     strategy.submit(message)
 
     assert next_step.submit.call_args_list == [
-        call(Message(Value(0, committable={}))),
-        call(Message(Value(1, committable={partition: 1}))),
+        call(Message(Value(0, committable={}, timestamp=now))),
+        call(Message(Value(1, committable={partition: 1}, timestamp=now))),
     ]
 
     strategy.close()
@@ -30,20 +32,20 @@ def test_unfold() -> None:
 
 def test_message_rejected() -> None:
     partition = Partition(Topic("topic"), 0)
-
+    now = datetime.now()
     next_step = Mock()
     next_step.submit.side_effect = MessageRejected()
 
     strategy = Unfold(generator, next_step)
 
-    message = Message(Value(2, {partition: 1}))
+    message = Message(Value(2, {partition: 1}, now))
     strategy.submit(message)
 
     assert next_step.submit.call_count == 1
 
     # Message doesn't actually go through since it was rejected
     assert next_step.submit.call_args_list == [
-        call(Message(Value(0, committable={}))),
+        call(Message(Value(0, committable={}, timestamp=now))),
     ]
 
     # clear the side effect, both messages should be submitted now
@@ -52,8 +54,8 @@ def test_message_rejected() -> None:
     strategy.poll()
 
     assert next_step.submit.call_args_list == [
-        call(Message(Value(0, committable={}))),
-        call(Message(Value(1, committable={partition: 1}))),
+        call(Message(Value(0, committable={}, timestamp=now))),
+        call(Message(Value(1, committable={partition: 1}, timestamp=now))),
     ]
 
     strategy.close()

--- a/tests/processing/test_processor.py
+++ b/tests/processing/test_processor.py
@@ -184,7 +184,10 @@ def test_stream_processor_invalid_message_from_poll() -> None:
     consumer.poll.side_effect = [BrokerValue(0, partition, offset, now)]
 
     strategy = mock.Mock()
-    strategy.poll.side_effect = [InvalidMessage(partition, 0, needs_commit=False), None]
+    strategy.poll.side_effect = [
+        InvalidMessage(partition, 0, needs_commit=False),
+        None,
+    ]
 
     factory = mock.Mock()
     factory.create_with_partitions.return_value = strategy
@@ -562,7 +565,8 @@ def test_healthcheck(tmpdir: py.path.local) -> None:
     topic = Topic("topic")
     partition = Partition(topic, 0)
     consumer = mock.Mock()
-    consumer.poll.return_value = BrokerValue(0, partition, 1, datetime.now())
+    now = datetime.now()
+    consumer.poll.return_value = BrokerValue(0, partition, 1, now)
     strategy = mock.Mock()
     strategy.submit.side_effect = InvalidMessage(partition, 1)
     factory = mock.Mock()

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -19,7 +19,7 @@ def test_message() -> None:
     assert pickle.loads(pickle.dumps(broker_message)) == broker_message
 
     # Generic payload
-    message = Message(Value(b"", {partition: 1}))
+    message = Message(Value(b"", {partition: 1}, datetime.now()))
     assert pickle.loads(pickle.dumps(message)) == message
 
     # Replace payload


### PR DESCRIPTION
The goal of this change is to record a common latency metric for all consumers that use Arroyo.

The new metric is called `arroyo.consumer.latency` -- it represents the time in seconds from when the message was initially produced (broker timestamp) to when the consumer successfully committed the offset for a message.

Note that if a consumer is doing either manual batching (not using Arroyo's built in Reduce/Batch) or manual committing of offsets (not using Arroyo's CommitOffsets strategy), then the metric will not be recorded automatically.

Closes https://github.com/getsentry/arroyo/issues/307