### PR TITLE
feat: Reusable multiprocessing pool

### DIFF
--- a/arroyo/processing/strategies/run_task_with_multiprocessing.py
+++ b/arroyo/processing/strategies/run_task_with_multiprocessing.py
@@ -810,7 +810,6 @@ class RunTaskWithMultiprocessing(
         self.__closed = True
 
         logger.info("Terminating %r...", self.__pool)
-        # self.__pool.terminate()
 
         logger.info("Shutting down %r...", self.__shared_memory_manager)
         self.__shared_memory_manager.shutdown()
@@ -836,7 +835,6 @@ class RunTaskWithMultiprocessing(
                 raise
 
         logger.debug("Waiting for %s...", self.__pool)
-        # self.__pool.terminate()
 
         self.__shared_memory_manager.shutdown()
 

--- a/arroyo/processing/strategies/run_task_with_multiprocessing.py
+++ b/arroyo/processing/strategies/run_task_with_multiprocessing.py
@@ -284,6 +284,8 @@ class MultiprocessingPool:
     Multiprocessing pool for the RunTaskWithMultiprocessing strategy.
     It can be re-used each time the strategy is created on assignments.
 
+    NOTE: The close() method must be called when shutting down the consumer.
+
     :param num_processes: The number of processes to spawn.
 
     :param initializer: A function to run at the beginning of each subprocess.
@@ -314,6 +316,9 @@ class MultiprocessingPool:
         return self.__pool.apply_async(*args, **kwargs)
 
     def close(self) -> None:
+        """
+        Must be called manually when shutting down the consumer.
+        """
         self.__pool.terminate()
 
 

--- a/arroyo/processing/strategies/run_task_with_multiprocessing.py
+++ b/arroyo/processing/strategies/run_task_with_multiprocessing.py
@@ -307,10 +307,15 @@ class MultiprocessingPool:
             context=multiprocessing.get_context("spawn"),
         )
         self.__num_processes = num_processes
+        self.__initializer = initializer
 
     @property
     def num_processes(self) -> int:
         return self.__num_processes
+
+    @property
+    def initializer(self) -> Optional[Callable[[], None]]:
+        return self.__initializer
 
     def apply_async(self, *args: Any, **kwargs: Any) -> Any:
         return self.__pool.apply_async(*args, **kwargs)

--- a/arroyo/processing/strategies/run_task_with_multiprocessing.py
+++ b/arroyo/processing/strategies/run_task_with_multiprocessing.py
@@ -313,7 +313,7 @@ class MultiprocessingPool:
     def apply_async(self, *args: Any, **kwargs: Any) -> Any:
         return self.__pool.apply_async(*args, **kwargs)
 
-    def terminate(self) -> None:
+    def close(self) -> None:
         self.__pool.terminate()
 
 
@@ -805,13 +805,13 @@ class RunTaskWithMultiprocessing(
         self.__closed = True
 
         logger.info("Terminating %r...", self.__pool)
-        self.__pool.terminate()
+        # self.__pool.terminate()
 
         logger.info("Shutting down %r...", self.__shared_memory_manager)
         self.__shared_memory_manager.shutdown()
 
         logger.info("Terminating %r...", self.__next_step)
-        self.__next_step.terminate()
+        # self.__next_step.terminate()
 
     def join(self, timeout: Optional[float] = None) -> None:
         start_join = time.time()

--- a/arroyo/processing/strategies/run_task_with_multiprocessing.py
+++ b/arroyo/processing/strategies/run_task_with_multiprocessing.py
@@ -811,7 +811,7 @@ class RunTaskWithMultiprocessing(
         self.__shared_memory_manager.shutdown()
 
         logger.info("Terminating %r...", self.__next_step)
-        # self.__next_step.terminate()
+        self.__next_step.terminate()
 
     def join(self, timeout: Optional[float] = None) -> None:
         start_join = time.time()

--- a/tests/processing/strategies/test_all.py
+++ b/tests/processing/strategies/test_all.py
@@ -324,13 +324,10 @@ def test_join(strategy_factory: Type[StrategyFactory]) -> None:
 
 
 @pytest.mark.parametrize("strategy_factory", FACTORIES)
-def test_poll_next_step(
-    request: pytest.FixtureRequest, strategy_factory: Type[StrategyFactory]
-) -> None:
+def test_poll_next_step(strategy_factory: Type[StrategyFactory]) -> None:
     next_step = Mock()
     factory = strategy_factory()
     step = factory.strategy(next_step)
-    request.addfinalizer(step.terminate)
 
     # Ensure that polling a strategy forwards the poll unconditionally even if
     # there are no messages to process, or no progress at all. Otherwise there
@@ -338,6 +335,7 @@ def test_poll_next_step(
     # benchmarking/QE) have been processed but the last batch of offsets never
     # gets committed.
     step.poll()
+    step.terminate()
     factory.shutdown()
 
     assert next_step.poll.call_args_list == [call()]

--- a/tests/processing/strategies/test_all.py
+++ b/tests/processing/strategies/test_all.py
@@ -80,7 +80,7 @@ class RunTaskWithMultiprocessingFactory(StrategyFactory):
             next_step=next_step,
             max_batch_size=10,
             max_batch_time=60,
-            pool=MultiprocessingPool(num_processes=4),
+            pool=self.__pool,
             input_block_size=16384,
             output_block_size=16384,
         )
@@ -126,7 +126,9 @@ class ReduceFactory(StrategyFactory):
         if raises_invalid_message:
             pytest.skip("does not support invalid message")
 
-        def accumulator(result: bool, value: BaseValue[bool]) -> bool:
+        def accumulator(
+            result: Union[FilteredPayload, bool], value: BaseValue[bool]
+        ) -> bool:
             assert isinstance(result, bool)
             assert isinstance(value.payload, bool)
             return value.payload
@@ -336,6 +338,5 @@ def test_poll_next_step(
     # benchmarking/QE) have been processed but the last batch of offsets never
     # gets committed.
     step.poll()
-    factory.shutdown()
 
     assert next_step.poll.call_args_list == [call()]

--- a/tests/processing/strategies/test_all.py
+++ b/tests/processing/strategies/test_all.py
@@ -26,6 +26,7 @@ from arroyo.processing.strategies.reduce import Reduce
 from arroyo.processing.strategies.run_task import RunTask
 from arroyo.processing.strategies.run_task_in_threads import RunTaskInThreads
 from arroyo.processing.strategies.run_task_with_multiprocessing import (
+    MultiprocessingPool,
     RunTaskWithMultiprocessing,
 )
 from arroyo.types import (
@@ -72,9 +73,9 @@ def run_task_with_multiprocessing_factory(
     return RunTaskWithMultiprocessing(
         partial(run_task_function, raises_invalid_message),
         next_step=next_step,
-        num_processes=4,
         max_batch_size=10,
         max_batch_time=60,
+        pool=MultiprocessingPool(num_processes=4),
         input_block_size=16384,
         output_block_size=16384,
     )

--- a/tests/processing/strategies/test_all.py
+++ b/tests/processing/strategies/test_all.py
@@ -338,5 +338,6 @@ def test_poll_next_step(
     # benchmarking/QE) have been processed but the last batch of offsets never
     # gets committed.
     step.poll()
+    factory.shutdown()
 
     assert next_step.poll.call_args_list == [call()]

--- a/tests/processing/strategies/test_run_task_with_multiprocessing.py
+++ b/tests/processing/strategies/test_run_task_with_multiprocessing.py
@@ -215,8 +215,6 @@ def test_parallel_transform_step() -> None:
 
         transform_step.close()
 
-        pool.close()
-
     metrics.calls.clear()
 
     with assert_changes(
@@ -275,6 +273,7 @@ def test_parallel_transform_step() -> None:
         ],
     ):
         transform_step.join()
+        pool.close()
 
     assert next_step.submit.call_count == len(messages)
 
@@ -308,8 +307,7 @@ def test_parallel_run_task_terminate_workers() -> None:
         starting_processes,
     ), assert_changes(lambda: int(next_step.terminate.call_count), 0, 1):
         transform_step.terminate()
-
-    pool.close()
+        pool.close()
 
 
 _COUNT_CALLS = 0
@@ -654,6 +652,7 @@ def test_output_block_resizing_without_limits() -> None:
 
     strategy.close()
     strategy.join(timeout=3)
+    pool.close()
 
     assert (
         next_step.submit.call_args_list
@@ -671,8 +670,6 @@ def test_output_block_resizing_without_limits() -> None:
         )
         in TestingMetricsBackend.calls
     )
-
-    pool.close()
 
 
 def message_processor_raising_invalid_message(x: Message[KafkaPayload]) -> KafkaPayload:


### PR DESCRIPTION
The `RunTaskWithMultiprocessing` strategy now takes a `MultiprocessingPool` as an argument. The user can safely reuse the multiprocessing pool between rebalances. Recreating the pool each time is still also possible and would match today's behavior.