### PR TITLE
ref: Combine DlqLimitState methods

### DIFF
--- a/tests/test_dlq.py
+++ b/tests/test_dlq.py
@@ -129,10 +129,7 @@ def test_dlq_limit_state() -> None:
 
     # 1 valid message followed by 4 invalid
     for i in range(4, 9):
-        value = BrokerValue(i, partition, i, datetime.now())
-        state.update_invalid_value(value)
-        assert state.should_accept(value)
+        assert state.record_invalid_message(BrokerValue(i, partition, i, datetime.now()))
 
     # Next message should not be accepted
-    state.update_invalid_value(BrokerValue(9, partition, 9, datetime.now()))
-    assert state.should_accept(value) == False
+    assert not state.record_invalid_message(BrokerValue(9, partition, 9, datetime.now()))


### PR DESCRIPTION
This aligns `DlqLimitState` with the Rust implementation in https://github.com/getsentry/snuba/pull/5156. To wit:

* `update_invalid_value` and `should_accept` are combined into `record_invalid_message`, since they're never called independently.
* We insert some default data if we've never received an invalid message on a partition.