### PR TITLE
fix(filter): Handle MessageRejected correctly (INC-584)

### DIFF
--- a/arroyo/processing/strategies/filter.py
+++ b/arroyo/processing/strategies/filter.py
@@ -89,12 +89,6 @@ class FilterStep(ProcessingStrategy[Union[FilteredPayload, TStrategyPayload]]):
             if self.__commit_policy_state is not None:
                 self.__uncommitted_offsets.update(message.committable)
 
-        if policy is not None and policy.should_commit(now, self.__uncommitted_offsets):
-            # We cannot let MessageRejected propagate here. The caller will
-            # think it is for `message` (which has already been successfully
-            # submitted), and will double-send it.
-            self.__flush_uncommitted_offsets(now, can_backpressure=False)
-
     def __flush_uncommitted_offsets(self, now: float, can_backpressure: bool) -> None:
         if not self.__uncommitted_offsets:
             return

--- a/arroyo/types.py
+++ b/arroyo/types.py
@@ -35,6 +35,9 @@ class FilteredPayload:
     def __eq__(self, other: Any) -> bool:
         return isinstance(other, FilteredPayload)
 
+    def __repr__(self) -> str:
+        return "<FilteredPayload>"
+
 
 FILTERED_PAYLOAD = FilteredPayload()
 
@@ -64,7 +67,7 @@ class Message(Generic[TMessagePayload]):
         # ``__slots__`` for performance reasons. The class variable names
         # would conflict with the instance slot names, causing an error.
 
-        if type(self.payload) in (float, int):
+        if type(self.payload) in (float, int, bool, FilteredPayload):
             # For the case where value is a float or int, the repr is small and
             # therefore safe. This is very useful in tests.
             #


### PR DESCRIPTION
When joining a FilterStep, it can happen that the upstream strategy
raises MessageRejected. We need to deal with that somehow, and in this
PR I'm just suppressing that exception.

Also fix a severe bug where MessageRejected was propagated through
submit(), but the MessageRejected was for the wrong message, causing
double-submission of messages.
