### PR TITLE
fix(multiprocessing): Reset pool if tasks are not completed

### DIFF
--- a/arroyo/processing/strategies/run_task_with_multiprocessing.py
+++ b/arroyo/processing/strategies/run_task_with_multiprocessing.py
@@ -309,10 +309,14 @@ class MultiprocessingPool:
         self.__num_processes = num_processes
         self.__initializer = initializer
         self.__pool: Optional[Pool] = None
+        self.__metrics = get_metrics()
         self.maybe_create_pool()
 
     def maybe_create_pool(self) -> None:
         if self.__pool is None:
+            self.__metrics.increment(
+                "arroyo.strategies.run_task_with_multiprocessing.pool.create"
+            )
             self.__pool = Pool(
                 self.__num_processes,
                 initializer=partial(parallel_worker_initializer, self.__initializer),

--- a/arroyo/processing/strategies/run_task_with_multiprocessing.py
+++ b/arroyo/processing/strategies/run_task_with_multiprocessing.py
@@ -340,8 +340,7 @@ class MultiprocessingPool:
         Also called from strategy.join() if there are pending futures in order
         ensure state is completely cleaned up.
         """
-        if self.__pool:
-            self.__pool.terminate()
+        self.__pool.terminate()
 
 
 class RunTaskWithMultiprocessing(

--- a/arroyo/processing/strategies/run_task_with_multiprocessing.py
+++ b/arroyo/processing/strategies/run_task_with_multiprocessing.py
@@ -284,11 +284,12 @@ class MultiprocessingPool:
     Multiprocessing pool for the RunTaskWithMultiprocessing strategy.
     It can be re-used each time the strategy is created on assignments.
 
-    The multiprocessing pool is lazily created whe the first message is submitted.
-    Reset() is called from strategy.join() if there are pending futures that
-    have not been completed yet.
-
     NOTE: The close() method must be called when shutting down the consumer.
+
+    The `close()` method is also called by `RunTaskWithMultiprocessing` when
+    there are uncompleted pending tasks to ensure no state is carried over.
+    The `maybe_create_pool` function is called on every assignment to ensure
+    the pool is re-created again, in case it was closed on the previous recovation.
 
     :param num_processes: The number of processes to spawn.
 

--- a/arroyo/utils/metric_defs.py
+++ b/arroyo/utils/metric_defs.py
@@ -43,6 +43,8 @@ MetricName = Literal[
     # Gauge. Shows how many processes the multiprocessing strategy is
     # configured with.
     "arroyo.strategies.run_task_with_multiprocessing.processes",
+    # Counter. Incremented when the multiprocessing pool is created (or re-created).
+    "arroyo.strategies.run_task_with_multiprocessing.pool.create",
     # Time (unitless) spent polling librdkafka for new messages.
     "arroyo.consumer.poll.time",
     # Time (unitless) spent in strategies (blocking in strategy.submit or

--- a/tests/processing/strategies/test_run_task_with_multiprocessing.py
+++ b/tests/processing/strategies/test_run_task_with_multiprocessing.py
@@ -399,6 +399,11 @@ def test_message_rejected_multiple() -> None:
     ]
 
     assert TestingMetricsBackend.calls == [
+        IncrementCall(
+            name="arroyo.strategies.run_task_with_multiprocessing.pool.create",
+            value=1,
+            tags=None,
+        ),
         GaugeCall(
             name="arroyo.strategies.run_task_with_multiprocessing.batches_in_progress",
             value=0.0,

--- a/tests/processing/strategies/test_run_task_with_multiprocessing.py
+++ b/tests/processing/strategies/test_run_task_with_multiprocessing.py
@@ -151,6 +151,11 @@ def test_parallel_transform_step() -> None:
         lambda: metrics.calls,
         [],
         [
+            IncrementCall(
+                name="arroyo.strategies.run_task_with_multiprocessing.pool.create",
+                value=1,
+                tags=None,
+            ),
             GaugeCall(
                 "arroyo.strategies.run_task_with_multiprocessing.batches_in_progress",
                 0.0,


### PR DESCRIPTION
If multiprocessing tasks are not completed within the timeout specified, we need to reset the pool to avoid state being carried over between assignments.