### PR TITLE
fix(multiprocessing): Increase default block sizes

### DIFF
--- a/arroyo/processing/strategies/run_task_with_multiprocessing.py
+++ b/arroyo/processing/strategies/run_task_with_multiprocessing.py
@@ -37,8 +37,8 @@ __all__ = ["RunTaskWithMultiprocessing"]
 TResult = TypeVar("TResult")
 TBatchValue = TypeVar("TBatchValue")
 
-DEFAULT_INPUT_BLOCK_SIZE = 16 * 1024 * 1024
-DEFAULT_OUTPUT_BLOCK_SIZE = 16 * 1024 * 1024
+DEFAULT_INPUT_BLOCK_SIZE = 25 * 1024 * 1024
+DEFAULT_OUTPUT_BLOCK_SIZE = 25 * 1024 * 1024
 
 LOG_THRESHOLD_TIME = 20  # In seconds
 

--- a/tests/processing/strategies/test_run_task_with_multiprocessing.py
+++ b/tests/processing/strategies/test_run_task_with_multiprocessing.py
@@ -11,6 +11,7 @@ from arroyo.backends.kafka import KafkaPayload
 from arroyo.dlq import InvalidMessage
 from arroyo.processing.strategies import MessageRejected
 from arroyo.processing.strategies.run_task_with_multiprocessing import (
+    DEFAULT_INPUT_BLOCK_SIZE,
     MessageBatch,
     MultiprocessingPool,
     RunTaskWithMultiprocessing,
@@ -552,7 +553,7 @@ def test_input_block_resizing_max_size() -> None:
         pool=pool,
         input_block_size=None,
         output_block_size=INPUT_SIZE // 2,
-        max_input_block_size=16000,
+        max_input_block_size=DEFAULT_INPUT_BLOCK_SIZE,
     )
 
     with pytest.raises(MessageRejected):
@@ -621,7 +622,7 @@ def test_output_block_resizing_max_size() -> None:
         pool=pool,
         input_block_size=INPUT_SIZE,
         output_block_size=None,
-        max_output_block_size=16000,
+        max_output_block_size=DEFAULT_INPUT_BLOCK_SIZE,
     )
 
     for _ in range(NUM_MESSAGES):


### PR DESCRIPTION
There are some Sentry topics for which we allow a single message to be as large as 25 MB. In cases like these, using the autoresizing of block sizes could fail if the default block sizes are smaller than the maximum size of a single message. This change modifies the default block sizes to be atleast as high as the maximum size of a single message.