### PR TITLE
fix(multiprocessing): Implement better error messages for block overflow

### DIFF
--- a/tests/processing/strategies/test_run_task_with_multiprocessing.py
+++ b/tests/processing/strategies/test_run_task_with_multiprocessing.py
@@ -38,7 +38,7 @@ def test_message_batch() -> None:
         Value(KafkaPayload(None, b"\x00" * 16000, []), {partition: 1}, datetime.now())
     )
 
-    batch: MessageBatch[Message[KafkaPayload]] = MessageBatch(block)
+    batch: MessageBatch[Message[KafkaPayload]] = MessageBatch(block, "test")
     with assert_changes(lambda: len(batch), 0, 1):
         batch.append(message)
 
@@ -76,7 +76,7 @@ def test_parallel_run_task_worker_apply() -> None:
     input_block = smm.SharedMemory(32768)
     assert input_block.size == 32768
 
-    input_batch = MessageBatch[Message[Any]](input_block)
+    input_batch = MessageBatch[Message[Any]](input_block, "test")
     for message in messages:
         input_batch.append(message)
 


### PR DESCRIPTION
See INC-594 -- in a later TT role-playing exercise, it became apparent
that this error message is suboptimal, in that it neither tells you
whether input or output is overflowing, and what parameter to tweak
