### PR TITLE
fix: Rename Rust arroyo metric since it has a different unit [SNS-2605]

### DIFF
--- a/rust-arroyo/src/processing/strategies/reduce.rs
+++ b/rust-arroyo/src/processing/strategies/reduce.rs
@@ -177,8 +177,7 @@ impl<T, TResult: Clone> Reduce<T, TResult> {
             return Ok(());
         }
 
-        // FIXME: this used to be in seconds
-        timer!("arroyo.strategies.reduce.batch_time", batch_time);
+        timer!("arroyo.strategies.reduce.batch_time.ms", batch_time);
 
         let batch_state = mem::replace(
             &mut self.batch_state,


### PR DESCRIPTION
We can also later decide to change the Python metric, but then we would
have to fix dashboards outside of Snuba.
