### PR TITLE
Add flexible Reduce strategy type

### DIFF
--- a/arroyo/processing/strategies/buffer.py
+++ b/arroyo/processing/strategies/buffer.py
@@ -42,7 +42,7 @@ class BufferProtocol(Protocol[TPayload, TResult]):
         ...
 
     @property
-    def ready_to_commit(self) -> bool:
+    def is_ready(self) -> bool:
         """Return "True" if the buffer is ready to be committed.
 
         Determined by message count, buffer size, the time of day, the phase of the moon,
@@ -109,7 +109,7 @@ class Buffer(
             return None
 
         # If you're not forcing me and I'm not ready to commit then I'm not doing anything.
-        if not force and not self.__buffer.ready_to_commit:
+        if not force and not self.__buffer.is_ready:
             return None
 
         # Push the buffer to the next step.

--- a/arroyo/processing/strategies/buffer.py
+++ b/arroyo/processing/strategies/buffer.py
@@ -54,7 +54,7 @@ class BufferProtocol(Protocol[TPayload, TResult]):
         """Accept a TPayload mutating the internal state of the batch builder."""
         ...
 
-    def new(self) -> "BufferProtocol":
+    def new(self) -> "BufferProtocol[TPayload, TResult]":
         """Return a new instance of the "BufferProtocol" class.
 
         This is defined as an instance method (as opposed to a factory method) because we do
@@ -117,7 +117,7 @@ class Buffer(
 
         buffer_msg = Message(
             Value(
-                payload=cast(TResult, self.__buffer.buffer),
+                payload=self.__buffer.buffer,
                 committable=self.__offsets,
                 timestamp=self.__last_timestamp,
             )

--- a/arroyo/processing/strategies/buffer.py
+++ b/arroyo/processing/strategies/buffer.py
@@ -120,7 +120,7 @@ class Buffer(
                 timestamp=self.__last_timestamp,
             )
         )
-        self.__next_step.submit(cast(Message[TResult], buffer_msg))
+        self.__next_step.submit(buffer_msg)
         self.__metrics.timing(
             "arroyo.strategies.reduce.batch_time",
             time.time() - self.__init_time,

--- a/arroyo/processing/strategies/buffer.py
+++ b/arroyo/processing/strategies/buffer.py
@@ -50,7 +50,7 @@ class BufferProtocol(Protocol[TPayload, TResult]):
         """
         ...
 
-    def append(self, message: TPayload) -> None:
+    def append(self, message: BaseValue[TPayload]) -> None:
         """Accept a TPayload mutating the internal state of the batch builder."""
         ...
 
@@ -156,7 +156,7 @@ class Buffer(
 
         self.__offsets.update(message.value.committable)
         self.__last_timestamp = message.value.timestamp
-        self.__buffer.append(cast(BaseValue[TPayload], message.value).payload)
+        self.__buffer.append(cast(BaseValue[TPayload], message.value))
 
     def poll(self) -> None:
         assert not self.__closed

--- a/arroyo/processing/strategies/buffer.py
+++ b/arroyo/processing/strategies/buffer.py
@@ -190,4 +190,4 @@ class Buffer(
         )
 
 
-__all__ = ["Reduce"]
+__all__ = ["Buffer"]

--- a/arroyo/processing/strategies/healthcheck.py
+++ b/arroyo/processing/strategies/healthcheck.py
@@ -7,6 +7,7 @@ from arroyo.utils.metrics import get_metrics
 
 HEALTHCHECK_MAX_FREQUENCY_SEC = 1.0  # In seconds
 
+
 class Healthcheck(ProcessingStrategy[TStrategyPayload]):
     """
     A strategy that takes a filepath, and touches that file everytime
@@ -15,7 +16,10 @@ class Healthcheck(ProcessingStrategy[TStrategyPayload]):
 
     File touches are debounced to happen once per second at most.
     """
-    def __init__(self, healthcheck_file: str, next_step: ProcessingStrategy[TStrategyPayload]):
+
+    def __init__(
+        self, healthcheck_file: str, next_step: ProcessingStrategy[TStrategyPayload]
+    ):
         self.__healthcheck_file = healthcheck_file
         self.__healthcheck_file_touched_at: Optional[float] = None
         self.__next_step = next_step

--- a/arroyo/processing/strategies/reduce.py
+++ b/arroyo/processing/strategies/reduce.py
@@ -1,11 +1,9 @@
 import time
-from datetime import datetime
-from typing import Callable, Generic, MutableMapping, Optional, TypeVar, Union, cast
+from typing import Callable, Generic, Optional, TypeVar, Union
 
 from arroyo.processing.strategies.buffer import Buffer
-from arroyo.processing.strategies import MessageRejected, ProcessingStrategy
-from arroyo.types import BaseValue, FilteredPayload, Message, Partition, Value
-from arroyo.utils.metrics import get_metrics
+from arroyo.processing.strategies import ProcessingStrategy
+from arroyo.types import BaseValue, FilteredPayload, Message
 
 TPayload = TypeVar("TPayload")
 TResult = TypeVar("TResult")

--- a/arroyo/processing/strategies/reduce.py
+++ b/arroyo/processing/strategies/reduce.py
@@ -2,6 +2,7 @@ import time
 from datetime import datetime
 from typing import Callable, Generic, MutableMapping, Optional, TypeVar, Union, cast
 
+from arroyo.processing.strategies.buffer import Buffer
 from arroyo.processing.strategies import MessageRejected, ProcessingStrategy
 from arroyo.types import BaseValue, FilteredPayload, Message, Partition, Value
 from arroyo.utils.metrics import get_metrics

--- a/arroyo/processing/strategies/reduce.py
+++ b/arroyo/processing/strategies/reduce.py
@@ -14,60 +14,50 @@ TResult = TypeVar("TResult")
 Accumulator = Callable[[TResult, BaseValue[TPayload]], TResult]
 
 
-class BatchBuilder(Generic[TPayload, TResult]):
-    """
-    Accumulates values into a batch.
-    """
+class ReduceBuffer(Generic[TPayload, TResult]):
+    """Reduce strategy buffer class."""
 
     def __init__(
         self,
         accumulator: Accumulator[TResult, TPayload],
-        initial_value: TResult,
+        initial_value: Callable[[], TResult],
         max_batch_size: int,
         max_batch_time: float,
-    ) -> None:
-        self.__max_batch_time = max_batch_time
-        self.__max_batch_size = max_batch_size
-        self.__accumulator = accumulator
-        self.__accumulated_value = initial_value
+    ):
+        self.accumulator = accumulator
+        self.initial_value = initial_value
+        self.max_batch_size = max_batch_size
+        self.max_batch_time = max_batch_time
 
-        # For latency recording.
-        # The timestamp of the last message in the batch is one applied to the batch
-        self.__last_timestamp: Optional[datetime] = None
-        self.__count = 0
-        self.__offsets: MutableMapping[Partition, int] = {}
-        self.init_time = time.time()
+        self._buffer = initial_value()
+        self._buffer_size = 0
+        self._buffer_until = time.time() + max_batch_time
 
-    def append(self, value: BaseValue[Union[FilteredPayload, TPayload]]) -> None:
-        self.__offsets.update(value.committable)
-        self.__last_timestamp = value.timestamp
-        if not isinstance(value.payload, FilteredPayload):
-            self.__accumulated_value = self.__accumulator(
-                self.__accumulated_value, cast(BaseValue[TPayload], value)
-            )
+    @property
+    def buffer(self) -> TResult:
+        return self._buffer
 
-            self.__count += 1
+    @property
+    def is_empty(self) -> bool:
+        return self._buffer_size == 0
 
-    def build_if_ready(self) -> Optional[Value[TResult]]:
-        if (
-            self.__count >= self.__max_batch_size
-            or time.time() > self.init_time + self.__max_batch_time
-        ):
-            assert isinstance(self.__last_timestamp, datetime)
-            return Value(
-                payload=self.__accumulated_value,
-                committable=self.__offsets,
-                timestamp=self.__last_timestamp,
-            )
-        else:
-            return None
+    @property
+    def is_ready(self) -> bool:
+        return (
+            self._buffer_size >= self.max_batch_size
+            or time.time() >= self._buffer_until
+        )
 
-    def build(self) -> Value[TResult]:
-        assert isinstance(self.__last_timestamp, datetime)
-        return Value(
-            payload=self.__accumulated_value,
-            committable=self.__offsets,
-            timestamp=self.__last_timestamp,
+    def append(self, message: BaseValue[TPayload]) -> None:
+        self._buffer = self.accumulator(self._buffer, message)
+        self._buffer_size += 1
+
+    def new(self) -> "ReduceBuffer[TPayload, TResult]":
+        return ReduceBuffer(
+            accumulator=self.accumulator,
+            initial_value=self.initial_value,
+            max_batch_size=self.max_batch_size,
+            max_batch_time=self.max_batch_time,
         )
 
 
@@ -96,105 +86,30 @@ class Reduce(
         initial_value: Callable[[], TResult],
         next_step: ProcessingStrategy[TResult],
     ) -> None:
-        self.__max_batch_size = max_batch_size
-        self.__max_batch_time = max_batch_time
-        self.__accumulator = accumulator
-        self.__initial_value = initial_value
-        self.__next_step = next_step
-        self.__batch_builder: Optional[BatchBuilder[TPayload, TResult]] = None
-        self.__metrics = get_metrics()
-        self.__closed = False
-
-    def __flush(self, force: bool) -> None:
-        assert self.__batch_builder is not None
-        batch = (
-            self.__batch_builder.build_if_ready()
-            if not force
-            else self.__batch_builder.build()
+        self.__buffer_step = Buffer(
+            buffer=ReduceBuffer(
+                max_batch_size=max_batch_size,
+                max_batch_time=max_batch_time,
+                accumulator=accumulator,
+                initial_value=initial_value,
+            ),
+            next_step=next_step,
         )
-        if batch is None:
-            return
-
-        batch_msg = Message(batch)
-
-        self.__next_step.submit(batch_msg)
-
-        self.__metrics.timing(
-            "arroyo.strategies.reduce.batch_time",
-            time.time() - self.__batch_builder.init_time,
-        )
-
-        self.__batch_builder = None
 
     def submit(self, message: Message[Union[FilteredPayload, TPayload]]) -> None:
-        """
-        Accumulates messages in the current batch.
-        A new batch is created at the first message received.
-
-        This method tries to flush before adding the message
-        to the current batch. This is so that, if we receive
-        `MessageRejected` exception from the following step,
-        we can propagate the exception without processing the
-        new message. This allows the previous step to try again
-        without introducing duplications.
-        """
-        assert not self.__closed
-
-        if isinstance(message.payload, FilteredPayload):
-            self.__next_step.submit(cast(Message[TResult], message))
-            return
-
-        if self.__batch_builder is not None:
-            self.__flush(force=False)
-
-        if self.__batch_builder is None:
-            self.__batch_builder = BatchBuilder(
-                self.__accumulator,
-                self.__initial_value(),
-                max_batch_size=self.__max_batch_size,
-                max_batch_time=self.__max_batch_time,
-            )
-
-        self.__batch_builder.append(cast(BaseValue[TPayload], message.value))
+        self.__buffer_step.submit(message)
 
     def poll(self) -> None:
-        assert not self.__closed
-
-        if self.__batch_builder is not None:
-            try:
-                self.__flush(force=False)
-            except MessageRejected:
-                pass
-
-        self.__next_step.poll()
+        self.__buffer_step.poll()
 
     def close(self) -> None:
-        self.__closed = True
+        self.__buffer_step.close()
 
     def terminate(self) -> None:
-        self.__closed = True
-        self.__batch_builder = None
-        self.__next_step.terminate()
+        self.__buffer_step.terminate()
 
     def join(self, timeout: Optional[float] = None) -> None:
-        """
-        Terminates the strategy by joining the following step.
-        This method tries to flush the current batch no matter
-        whether the batch is ready or not.
-        """
-        deadline = time.time() + timeout if timeout is not None else None
-        if self.__batch_builder is not None:
-            while deadline is None or time.time() < deadline:
-                try:
-                    self.__flush(force=True)
-                    break
-                except MessageRejected:
-                    pass
-
-        self.__next_step.close()
-        self.__next_step.join(
-            timeout=max(deadline - time.time(), 0) if deadline is not None else None
-        )
+        self.__buffer_step.join(timeout)
 
 
 __all__ = ["Reduce"]

--- a/arroyo/processing/strategies/reduce_new.py
+++ b/arroyo/processing/strategies/reduce_new.py
@@ -1,0 +1,193 @@
+import time
+from datetime import datetime
+from typing import (
+    Callable,
+    Generic,
+    MutableMapping,
+    Optional,
+    TypeVar,
+    Union,
+    cast,
+    Protocol,
+)
+
+from arroyo.processing.strategies import MessageRejected, ProcessingStrategy
+from arroyo.types import BaseValue, FilteredPayload, Message, Partition, Value
+from arroyo.utils.metrics import get_metrics
+
+TPayload = TypeVar("TPayload")
+TResult = TypeVar("TResult")
+
+
+Accumulator = Callable[[TResult, BaseValue[TPayload]], TResult]
+
+
+# Does the protocol need to be generic over the payload and result?
+class Buffer(Protocol[TPayload, TResult]):
+    """Reduce strategy buffer protocol.
+
+    Buffer is agnostic to the caller. It accepts messages and describes its state to caller's
+    using its internal state. This is by design to reduce coupling between the Buffer and its
+    implementer.
+    """
+
+    @property
+    def buffer(self) -> TResult:
+        """Return a TResult buffer which will (likely) be committed by the next-step."""
+        ...
+
+    @property
+    def is_empty(self) -> bool:
+        """Return "True" if the buffer is empty.
+
+        Because a buffer could have a complex implementation, the caller has no idea if the
+        buffer is empty unless the buffer exposes it.
+        """
+        ...
+
+    @property
+    def ready_to_commit(self) -> bool:
+        """Return "True" if the buffer is ready to be committed.
+
+        Determined by message count, buffer size, the time of day, the phase of the moon,
+        whatever you want.
+        """
+        ...
+
+    def append(self, message: TPayload) -> None:
+        """Accept a TPayload mutating the internal state of the batch builder."""
+        ...
+
+    def new(self) -> "Buffer":
+        """Return a new instance of the "Buffer" protocol class.
+
+        This is defined as an instance method (as opposed to a factory method) because we do
+        not want the Reduce strategy to know _anything_ about the buffer's implementation. The
+        buffer is passed to the stategy as an instance. The strategy does not need to concern
+        itself with the arguments required to construct the instance.
+
+        This method could be replaced with a "reset" method but a reset may not be so simple and
+        may lead to unexpected bugs. However, constructing a new instance should be a relatively
+        simple proposition by comparison. This also introduces the possibility of a buffer which
+        dynamically manages its commit interval (intentionally or not). Responsibile
+        implementation is required.
+        """
+        ...
+
+
+class Reduce(
+    ProcessingStrategy[Union[FilteredPayload, TPayload]], Generic[TPayload, TResult]
+):
+    """Accumulates messages until the buffer declares its ready to commit. The accumulator
+    function is run on each message in the order it is received.
+
+    Once the "batch" is full, the accumulated value is submitted to the next step.
+
+    This strategy propagates `MessageRejected` exceptions from the
+    downstream steps if they are thrown.
+    """
+
+    def __init__(self, buffer: Buffer, next_step: ProcessingStrategy[TResult]) -> None:
+        self.__buffer = buffer
+        self.__next_step = next_step
+        self.__metrics = get_metrics()
+        self.__closed = False
+
+        # Previously these values were tracked in the "BatchBuilder" class. That's fine if
+        # BatchBuilder is internal to the Arroyo library however if the "BatchBuilder" is defined
+        # by the implementer, you are then asking the implementer to manage responsibly manage
+        # offsets (which can be tricky). Therefore, we manage it within the strategy and allow
+        # the buffer to be ignorant of its caller.
+        self.__last_timestamp: Optional[datetime] = None
+        self.__offsets: MutableMapping[Partition, int] = {}
+        self.__init_time = time.time()
+
+    def __flush(self, force: bool) -> None:
+        # You might want to ask the buffer if its empty or not rather than assuming. It may
+        # very well be holding multiple buffers which fill at non-uniform rates.
+        if self.__buffer.is_empty:
+            return None
+
+        # If you're not forcing me and I'm not ready to commit then I'm not doing anything.
+        if not force and not self.__buffer.ready_to_commit:
+            return None
+
+        # Push the buffer to the next step.
+        buffer_msg = Message(
+            Value(
+                payload=self.__buffer.buffer,
+                committable=self.__offsets,
+                timestamp=self.__last_timestamp,
+            )
+        )
+        self.__next_step.submit(buffer_msg)
+        self.__metrics.timing(
+            "arroyo.strategies.reduce.batch_time",
+            time.time() - self.__init_time,
+        )
+
+        # Reset to the empty state.
+        self.__buffer = self.__buffer.new()
+        self.__last_timestamp = None
+        self.__offsets = {}
+        self.__init_time = time.time()
+
+    def submit(self, message: Message[Union[FilteredPayload, TPayload]]) -> None:
+        """
+        Accumulates messages in the current batch.
+        A new batch is created at the first message received.
+
+        This method tries to flush before adding the message
+        to the current batch. This is so that, if we receive
+        `MessageRejected` exception from the following step,
+        we can propagate the exception without processing the
+        new message. This allows the previous step to try again
+        without introducing duplications.
+        """
+        assert not self.__closed
+
+        if isinstance(message.payload, FilteredPayload):
+            self.__next_step.submit(cast(Message[TResult], message))
+            return
+
+        self.__flush(force=False)
+        self.__buffer.append(cast(BaseValue[TPayload], message.value))
+
+    def poll(self) -> None:
+        assert not self.__closed
+
+        try:
+            self.__flush(force=False)
+        except MessageRejected:
+            pass
+
+        self.__next_step.poll()
+
+    def close(self) -> None:
+        self.__closed = True
+
+    def terminate(self) -> None:
+        self.__closed = True
+        self.__next_step.terminate()
+
+    def join(self, timeout: Optional[float] = None) -> None:
+        """
+        Terminates the strategy by joining the following step.
+        This method tries to flush the current batch no matter
+        whether the batch is ready or not.
+        """
+        deadline = time.time() + timeout if timeout is not None else None
+        while deadline is None or time.time() < deadline:
+            try:
+                self.__flush(force=True)
+                break
+            except MessageRejected:
+                pass
+
+        self.__next_step.close()
+        self.__next_step.join(
+            timeout=max(deadline - time.time(), 0) if deadline is not None else None
+        )
+
+
+__all__ = ["Reduce"]

--- a/tests/processing/strategies/test_batching.py
+++ b/tests/processing/strategies/test_batching.py
@@ -8,7 +8,7 @@ import pytest
 from arroyo.processing.strategies.abstract import MessageRejected
 from arroyo.processing.strategies.batching import BatchStep, UnbatchStep, ValuesBatch
 from arroyo.processing.strategies.run_task import RunTask
-from arroyo.types import BaseValue, BrokerValue, Message, Partition, Topic, Value
+from arroyo.types import BrokerValue, Message, Partition, Topic, Value
 
 NOW = datetime(2022, 1, 1, 0, 0, 1)
 

--- a/tests/processing/strategies/test_buffer.py
+++ b/tests/processing/strategies/test_buffer.py
@@ -1,16 +1,17 @@
 from datetime import datetime
 from unittest.mock import Mock, call
+from typing import List
 
 from arroyo.processing.strategies.buffer import Buffer
 from arroyo.types import Message, Partition, Topic, Value
 
 
 class BufferTest:
-    def __init__(self):
-        self._buffer = []
+    def __init__(self) -> None:
+        self._buffer: List[int] = []
 
     @property
-    def buffer(self) -> list[int]:
+    def buffer(self) -> List[int]:
         return self._buffer
 
     @property
@@ -24,7 +25,7 @@ class BufferTest:
     def append(self, message: int) -> None:
         self._buffer.append(message)
 
-    def new(self):
+    def new(self) -> "BufferTest":
         return BufferTest()
 
 

--- a/tests/processing/strategies/test_buffer.py
+++ b/tests/processing/strategies/test_buffer.py
@@ -19,7 +19,7 @@ class BufferTest:
         return len(self._buffer) == 0
 
     @property
-    def ready_to_commit(self) -> bool:
+    def is_ready(self) -> bool:
         return len(self._buffer) >= 3
 
     def append(self, message: int) -> None:

--- a/tests/processing/strategies/test_buffer.py
+++ b/tests/processing/strategies/test_buffer.py
@@ -3,7 +3,7 @@ from unittest.mock import Mock, call
 from typing import List
 
 from arroyo.processing.strategies.buffer import Buffer
-from arroyo.types import Message, Partition, Topic, Value
+from arroyo.types import BaseValue, Message, Partition, Topic, Value
 
 
 class BufferTest:
@@ -22,8 +22,8 @@ class BufferTest:
     def is_ready(self) -> bool:
         return len(self._buffer) >= 3
 
-    def append(self, message: int) -> None:
-        self._buffer.append(message)
+    def append(self, message: BaseValue[int]) -> None:
+        self._buffer.append(message.payload)
 
     def new(self) -> "BufferTest":
         return BufferTest()

--- a/tests/processing/strategies/test_buffer.py
+++ b/tests/processing/strategies/test_buffer.py
@@ -1,0 +1,56 @@
+from datetime import datetime
+from unittest.mock import Mock, call
+
+from arroyo.processing.strategies.buffer import Buffer
+from arroyo.types import Message, Partition, Topic, Value
+
+
+class BufferTest:
+    def __init__(self):
+        self._buffer = []
+
+    @property
+    def buffer(self) -> list[int]:
+        return self._buffer
+
+    @property
+    def is_empty(self) -> bool:
+        return len(self._buffer) == 0
+
+    @property
+    def ready_to_commit(self) -> bool:
+        return len(self._buffer) >= 3
+
+    def append(self, message: int) -> None:
+        self._buffer.append(message)
+
+    def new(self):
+        return BufferTest()
+
+
+def test_buffer() -> None:
+    now = datetime.now()
+    next_step = Mock()
+    strategy = Buffer(BufferTest(), next_step)
+    partition = Partition(Topic("topic"), 0)
+
+    for i in range(6):
+        strategy.submit(
+            Message(
+                Value(
+                    i,
+                    {
+                        partition: i + 1,
+                    },
+                    now,
+                )
+            )
+        )
+        strategy.poll()
+
+    next_step.submit.assert_has_calls(
+        [
+            call(Message(Value([0, 1, 2], {partition: 3}, now))),
+            call(Message(Value([3, 4, 5], {partition: 6}, now))),
+        ]
+    )


### PR DESCRIPTION
The pull is documented in the code.  Its more contextual to read the reasoning there.  Mostly the buffer protocol and the flush method.  The buffer impl is totally independent of Arroyo/Kafka all the rest.  You can write a buffer with no knowledge of where it will be used.

- Adds the concept of a Buffer protocol.
- Moves all Kafka specific behavior out of the buffer protocol and into the strategy class.
- Allows for flexible buffering without constraint.