### PR TITLE
perf: inline now calling `coarsetime::Instant`

### DIFF
--- a/rust-arroyo/src/utils/timing.rs
+++ b/rust-arroyo/src/utils/timing.rs
@@ -7,6 +7,7 @@ pub struct Deadline {
     duration: Duration,
 }
 
+#[inline(always)]
 fn now() -> coarsetime::Instant {
     coarsetime::Instant::now_without_cache_update()
 }


### PR DESCRIPTION
This particular change reduces the overall execution time of `snuba-queries/1/rate-limited-real.json` from 9.3% to 5.8%, because it wasn't inlined.

I basically run the following command to create some traffic for local benchmarking:

```
❯ yes "$(cat ../sentry-kafka-schemas/examples/snuba-queries/1/rate-limited-real.json | jq -c .)" | head -10000 | kcat -P -b 127.0.0.1:9092 -t snuba-queries
```

### Before 

<img width="1241" alt="Screenshot 2024-01-24 at 4 20 07 PM" src="https://github.com/getsentry/arroyo/assets/1935246/b1aa0b4d-4b91-4d70-b7ac-9140bef135ce">

### After

<img width="942" alt="Screenshot 2024-01-24 at 4 20 20 PM" src="https://github.com/getsentry/arroyo/assets/1935246/16365c03-7b75-4bef-bcf1-5498c6f2350e">