### PR TITLE
perf: replace `HashMap` with `FxHashMap`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ path = "rust-arroyo/src/lib.rs"
 [dependencies]
 chrono = "0.4.26"
 coarsetime = "0.1.33"
+fxhash = "0.2.1"
 once_cell = "1.18.0"
 rand = "0.8.5"
 rdkafka = { version = "0.36.1", features = ["cmake-build", "tracing"] }

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,0 +1,2 @@
+# Use fxhash::{FxHashMap, FxHashSet} whenever possible
+disallowed-types = ["std::collections::HashMap", "std::collections::HashSet"]

--- a/rust-arroyo/examples/base_consumer.rs
+++ b/rust-arroyo/examples/base_consumer.rs
@@ -1,5 +1,6 @@
 extern crate rust_arroyo;
 
+use fxhash::FxHashMap;
 use rust_arroyo::backends::kafka::config::KafkaConfig;
 use rust_arroyo::backends::kafka::InitialOffset;
 use rust_arroyo::backends::kafka::KafkaConsumer;
@@ -7,11 +8,10 @@ use rust_arroyo::backends::AssignmentCallbacks;
 use rust_arroyo::backends::CommitOffsets;
 use rust_arroyo::backends::Consumer;
 use rust_arroyo::types::{Partition, Topic};
-use std::collections::HashMap;
 
 struct EmptyCallbacks {}
 impl AssignmentCallbacks for EmptyCallbacks {
-    fn on_assign(&self, _: HashMap<Partition, u64>) {}
+    fn on_assign(&self, _: FxHashMap<Partition, u64>) {}
     fn on_revoke<C: CommitOffsets>(&self, _: C, _: Vec<Partition>) {}
 }
 

--- a/rust-arroyo/src/backends/kafka/config.rs
+++ b/rust-arroyo/src/backends/kafka/config.rs
@@ -1,5 +1,5 @@
+use fxhash::FxHashMap;
 use rdkafka::config::ClientConfig as RdKafkaConfig;
-use std::collections::HashMap;
 
 use super::InitialOffset;
 
@@ -11,7 +11,7 @@ pub struct OffsetResetConfig {
 
 #[derive(Debug, Clone)]
 pub struct KafkaConfig {
-    config_map: HashMap<String, String>,
+    config_map: FxHashMap<String, String>,
     // Only applies to consumers
     offset_reset_config: Option<OffsetResetConfig>,
 }
@@ -19,9 +19,9 @@ pub struct KafkaConfig {
 impl KafkaConfig {
     pub fn new_config(
         bootstrap_servers: Vec<String>,
-        override_params: Option<HashMap<String, String>>,
+        override_params: Option<FxHashMap<String, String>>,
     ) -> Self {
-        let mut config_map = HashMap::new();
+        let mut config_map = FxHashMap::default();
         config_map.insert("bootstrap.servers".to_string(), bootstrap_servers.join(","));
         let config = Self {
             config_map,
@@ -37,7 +37,7 @@ impl KafkaConfig {
         auto_offset_reset: InitialOffset,
         strict_offset_reset: bool,
         max_poll_interval_ms: usize,
-        override_params: Option<HashMap<String, String>>,
+        override_params: Option<FxHashMap<String, String>>,
     ) -> Self {
         let mut config = KafkaConfig::new_config(bootstrap_servers, None);
         config.offset_reset_config = Some(OffsetResetConfig {
@@ -68,7 +68,7 @@ impl KafkaConfig {
 
     pub fn new_producer_config(
         bootstrap_servers: Vec<String>,
-        override_params: Option<HashMap<String, String>>,
+        override_params: Option<FxHashMap<String, String>>,
     ) -> Self {
         let config = KafkaConfig::new_config(bootstrap_servers, None);
 
@@ -104,7 +104,7 @@ impl From<KafkaConfig> for RdKafkaConfig {
 
 fn apply_override_params(
     mut config: KafkaConfig,
-    override_params: Option<HashMap<String, String>>,
+    override_params: Option<FxHashMap<String, String>>,
 ) -> KafkaConfig {
     if let Some(params) = override_params {
         for (param, value) in params {
@@ -119,8 +119,8 @@ mod tests {
     use crate::backends::kafka::InitialOffset;
 
     use super::KafkaConfig;
+    use fxhash::FxHashMap;
     use rdkafka::config::ClientConfig as RdKafkaConfig;
-    use std::collections::HashMap;
 
     #[test]
     fn test_build_consumer_configuration() {
@@ -130,7 +130,7 @@ mod tests {
             InitialOffset::Error,
             false,
             30_000,
-            Some(HashMap::from([(
+            Some(FxHashMap::from_iter([(
                 "queued.max.messages.kbytes".to_string(),
                 "1000000".to_string(),
             )])),

--- a/rust-arroyo/src/backends/mod.rs
+++ b/rust-arroyo/src/backends/mod.rs
@@ -1,5 +1,5 @@
 use super::types::{BrokerMessage, Partition, TopicOrPartition};
-use std::collections::{HashMap, HashSet};
+use fxhash::{FxHashMap, FxHashSet};
 use std::time::Duration;
 use thiserror::Error;
 
@@ -48,13 +48,13 @@ pub trait CommitOffsets {
     ///
     /// Returns a map of all offsets that were committed. This combines [`Consumer::stage_offsets`] and
     /// [`Consumer::commit_offsets`].
-    fn commit(self, offsets: HashMap<Partition, u64>) -> Result<(), ConsumerError>;
+    fn commit(self, offsets: FxHashMap<Partition, u64>) -> Result<(), ConsumerError>;
 }
 
 /// This is basically an observer pattern to receive the callbacks from
 /// the consumer when partitions are assigned/revoked.
 pub trait AssignmentCallbacks: Send + Sync {
-    fn on_assign(&self, partitions: HashMap<Partition, u64>);
+    fn on_assign(&self, partitions: FxHashMap<Partition, u64>);
     fn on_revoke<C: CommitOffsets>(&self, commit_offsets: C, partitions: Vec<Partition>);
 }
 
@@ -119,19 +119,19 @@ pub trait Consumer<TPayload, C>: Send {
     ///
     /// If any of the provided partitions are not in the assignment set, an
     /// exception will be raised and no partitions will be paused.
-    fn pause(&mut self, partitions: HashSet<Partition>) -> Result<(), ConsumerError>;
+    fn pause(&mut self, partitions: FxHashSet<Partition>) -> Result<(), ConsumerError>;
 
     /// Resume consuming from the provided partitions.
     ///
     /// If any of the provided partitions are not in the assignment set, an
     /// exception will be raised and no partitions will be resumed.
-    fn resume(&mut self, partitions: HashSet<Partition>) -> Result<(), ConsumerError>;
+    fn resume(&mut self, partitions: FxHashSet<Partition>) -> Result<(), ConsumerError>;
 
     /// Return the currently paused partitions.
-    fn paused(&self) -> Result<HashSet<Partition>, ConsumerError>;
+    fn paused(&self) -> Result<FxHashSet<Partition>, ConsumerError>;
 
     /// Return the working offsets for all currently assigned positions.
-    fn tell(&self) -> Result<HashMap<Partition, u64>, ConsumerError>;
+    fn tell(&self) -> Result<FxHashMap<Partition, u64>, ConsumerError>;
 
     /// Update the working offsets for the provided partitions.
     ///
@@ -147,10 +147,11 @@ pub trait Consumer<TPayload, C>: Send {
     ///
     /// If any provided partitions are not in the assignment set, an
     /// exception will be raised and no offsets will be modified.
-    fn seek(&self, offsets: HashMap<Partition, u64>) -> Result<(), ConsumerError>;
+    fn seek(&self, offsets: FxHashMap<Partition, u64>) -> Result<(), ConsumerError>;
 
     /// Commit offsets.
-    fn commit_offsets(&mut self, positions: HashMap<Partition, u64>) -> Result<(), ConsumerError>;
+    fn commit_offsets(&mut self, positions: FxHashMap<Partition, u64>)
+        -> Result<(), ConsumerError>;
 }
 
 pub trait Producer<TPayload>: Send + Sync {

--- a/rust-arroyo/src/backends/storages/memory.rs
+++ b/rust-arroyo/src/backends/storages/memory.rs
@@ -1,8 +1,8 @@
 use super::{ConsumeError, MessageStorage, TopicDoesNotExist, TopicExists};
 use crate::types::{BrokerMessage, Partition, Topic};
 use chrono::{DateTime, Utc};
+use fxhash::FxHashMap;
 use std::cmp::Ordering;
-use std::collections::HashMap;
 use std::convert::TryFrom;
 
 /// Stores a list of messages for each partition of a topic.
@@ -51,13 +51,13 @@ impl<TPayload> TopicMessages<TPayload> {
 
 /// An implementation of [`MessageStorage`] that holds messages in memory.
 pub struct MemoryMessageStorage<TPayload> {
-    topics: HashMap<Topic, TopicMessages<TPayload>>,
+    topics: FxHashMap<Topic, TopicMessages<TPayload>>,
 }
 
 impl<TPayload> Default for MemoryMessageStorage<TPayload> {
     fn default() -> Self {
-        MemoryMessageStorage {
-            topics: HashMap::new(),
+        Self {
+            topics: FxHashMap::default(),
         }
     }
 }

--- a/rust-arroyo/src/processing/strategies/commit_offsets.rs
+++ b/rust-arroyo/src/processing/strategies/commit_offsets.rs
@@ -1,6 +1,5 @@
-use std::collections::HashMap;
-
 use chrono::{DateTime, Duration, Utc};
+use fxhash::FxHashMap;
 
 use crate::processing::strategies::{CommitRequest, ProcessingStrategy, SubmitError};
 use crate::timer;
@@ -9,7 +8,7 @@ use crate::types::{Message, Partition};
 use super::StrategyError;
 
 pub struct CommitOffsets {
-    partitions: HashMap<Partition, u64>,
+    partitions: FxHashMap<Partition, u64>,
     last_commit_time: DateTime<Utc>,
     last_record_time: DateTime<Utc>,
     commit_frequency: Duration,

--- a/rust-arroyo/src/processing/strategies/reduce.rs
+++ b/rust-arroyo/src/processing/strategies/reduce.rs
@@ -413,6 +413,7 @@ mod tests {
         assert!(submitted_messages_clone.lock().unwrap().is_empty());
     }
 
+    #[test]
     fn test_reduce_with_zero_batch_size_flush() {
         let submitted_messages = Arc::new(Mutex::new(Vec::new()));
         let submitted_messages_clone = submitted_messages.clone();


### PR DESCRIPTION
This is a breaking change since we need to update Snuba to use `FxHashMap` instead of `HashMap`. I believe the performance benefits makes this justifiable, but I'm not sure what the policy is for breaking changes.

I didn't run any benchmark but depending on the response I'll open a PR to update Snuba as well and share the benchmark results.