### PR TITLE
fix: Enable stats collection

### DIFF
--- a/rust-arroyo/src/backends/kafka/config.rs
+++ b/rust-arroyo/src/backends/kafka/config.rs
@@ -3,6 +3,8 @@ use std::collections::HashMap;
 
 use super::InitialOffset;
 
+const STATS_COLLECTION_FREQ_MS: String = "1000";
+
 #[derive(Debug, Clone)]
 pub struct OffsetResetConfig {
     pub auto_offset_reset: InitialOffset,
@@ -52,6 +54,11 @@ impl KafkaConfig {
         config.config_map.insert(
             "max.poll.interval.ms".to_string(),
             max_poll_interval_ms.to_string(),
+        );
+
+        config.config_map.insert(
+            "statistics.interval.ms".to_string(),
+            STATS_COLLECTION_FREQ_MS,
         );
 
         // HACK: If the max poll interval is less than 45 seconds, set the session timeout


### PR DESCRIPTION
As for the Python version of Arroyo, we enable the collection of stats every second.