### PR TITLE
feat: make default auto.offset.reset earliest

### DIFF
--- a/arroyo/backends/kafka/configuration.py
+++ b/arroyo/backends/kafka/configuration.py
@@ -61,7 +61,7 @@ def build_kafka_consumer_configuration(
 ) -> KafkaBrokerConfig:
 
     if auto_offset_reset is None:
-        auto_offset_reset = "error"
+        auto_offset_reset = "earliest"
 
     if queued_max_messages_kbytes is None:
         queued_max_messages_kbytes = DEFAULT_QUEUED_MAX_MESSAGE_KBYTES

--- a/rust-arroyo/src/backends/kafka/mod.rs
+++ b/rust-arroyo/src/backends/kafka/mod.rs
@@ -43,9 +43,9 @@ enum KafkaConsumerState {
 
 #[derive(Debug, Clone, Copy, Default)]
 pub enum InitialOffset {
+    #[default]
     Earliest,
     Latest,
-    #[default]
     Error,
 }
 


### PR DESCRIPTION
error is undesirable most of the time and is not a good default. it can cause downtime when doing things like scaling partitions as the new partitions will error thus crashlooping the consumer. this happened in inc-702