### PR TITLE
rust: add more rust logging

### DIFF
--- a/arroyo/backends/abstract.py
+++ b/arroyo/backends/abstract.py
@@ -165,6 +165,15 @@ class Consumer(Generic[TStrategyPayload], ABC):
     def closed(self) -> bool:
         raise NotImplementedError
 
+    @property
+    @abstractmethod
+    def member_id(self) -> str:
+        """
+        Return the member ID of the consumer as supplied by the broker.
+        This is useful for debugging purposes.
+        """
+        raise NotImplementedError
+
 
 class Producer(Generic[TStrategyPayload], ABC):
     @abstractmethod

--- a/arroyo/backends/kafka/consumer.py
+++ b/arroyo/backends/kafka/consumer.py
@@ -628,6 +628,11 @@ class KafkaConsumer(Consumer[KafkaPayload]):
     def closed(self) -> bool:
         return self.__state is KafkaConsumerState.CLOSED
 
+    @property
+    def member_id(self) -> str:
+        member_id: str = self.__consumer.memberid()
+        return member_id
+
 
 class KafkaProducer(Producer[KafkaPayload]):
     def __init__(self, configuration: Mapping[str, Any]) -> None:

--- a/arroyo/backends/local/backend.py
+++ b/arroyo/backends/local/backend.py
@@ -359,6 +359,10 @@ class LocalConsumer(Consumer[TStrategyPayload]):
     def closed(self) -> bool:
         return self.__closed
 
+    @property
+    def member_id(self) -> str:
+        return "local-consumer"
+
 
 class LocalProducer(Producer[TStrategyPayload]):
     def __init__(self, broker: LocalBroker[TStrategyPayload]) -> None:

--- a/arroyo/processing/processor.py
+++ b/arroyo/processing/processor.py
@@ -233,6 +233,7 @@ class StreamProcessor(Generic[TStrategyPayload]):
         @_rdkafka_callback(metrics=self.__metrics_buffer)
         def on_partitions_assigned(partitions: Mapping[Partition, int]) -> None:
             logger.info("New partitions assigned: %r", partitions)
+            logger.info("Member id: %r", self.__consumer.member_id)
             self.__metrics_buffer.metrics.increment(
                 "arroyo.consumer.partitions_assigned.count", len(partitions)
             )
@@ -422,7 +423,8 @@ class StreamProcessor(Generic[TStrategyPayload]):
                         self.__backpressure_timestamp = time.time()
 
                     elif not self.__is_paused and (
-                        time.time() - self.__backpressure_timestamp > BACKPRESSURE_THRESHOLD
+                        time.time() - self.__backpressure_timestamp
+                        > BACKPRESSURE_THRESHOLD
                     ):
                         self.__metrics_buffer.incr_counter("arroyo.consumer.pause", 1)
                         logger.debug(

--- a/rust-arroyo/src/backends/kafka/mod.rs
+++ b/rust-arroyo/src/backends/kafka/mod.rs
@@ -246,12 +246,7 @@ impl<C: AssignmentCallbacks> ConsumerContext for CustomContext<C> {
                 // it would be better to log it only when it changes. We log for debugging purposes.
                 unsafe {
                     let member_id = rd_kafka_memberid(base_consumer.client().native_ptr());
-                    let member_id_slice = std::ffi::CStr::from_ptr(member_id);
-                    let buf = std::ffi::CStr::from_ptr(member_id).to_bytes();
-                    let buf_str = String::from_utf8(buf.to_vec()).ok();
-
                     tracing::info!("Kafka consumer member id: {:?}", std::ffi::CStr::from_ptr(member_id).to_str().unwrap());
-                    println!("CustomContext: Kafka consumer member id str: {:?} -- {:?}", member_id_slice.to_str().unwrap(), buf_str);
                 };
 
 

--- a/rust-arroyo/src/backends/kafka/mod.rs
+++ b/rust-arroyo/src/backends/kafka/mod.rs
@@ -31,7 +31,6 @@ mod errors;
 pub mod producer;
 pub mod types;
 
-
 #[derive(Eq, Hash, PartialEq)]
 enum KafkaConsumerState {
     Consuming,
@@ -246,9 +245,11 @@ impl<C: AssignmentCallbacks> ConsumerContext for CustomContext<C> {
                 // it would be better to log it only when it changes. We log for debugging purposes.
                 unsafe {
                     let member_id = rd_kafka_memberid(base_consumer.client().native_ptr());
-                    tracing::info!("Kafka consumer member id: {:?}", std::ffi::CStr::from_ptr(member_id).to_str().unwrap());
+                    tracing::info!(
+                        "Kafka consumer member id: {:?}",
+                        std::ffi::CStr::from_ptr(member_id).to_str().unwrap()
+                    );
                 };
-
 
                 for partition in committed_offsets.elements() {
                     let raw_offset = partition.offset().to_raw().unwrap();
@@ -515,7 +516,6 @@ mod tests {
     impl AssignmentCallbacks for EmptyCallbacks {
         fn on_assign(&self, partitions: HashMap<Partition, u64>) {
             println!("assignment event: {:?}", partitions);
-
         }
         fn on_revoke<C>(&self, _: C, partitions: Vec<Partition>) {
             println!("revocation event: {:?}", partitions);


### PR DESCRIPTION
Adds more logging to rust to more closely match python. Specifically, we add logging to show when the processor is terminating or closing/rejoining strategies.

We also introduce logging to show the member id as supplied by the broker. This is useful for debugging issue related to rebalancing in kafka since the broker logs only show member id.