### PR TITLE
feat: A better API for abandoning messages on shutdown

### DIFF
--- a/arroyo/processing/strategies/batching.py
+++ b/arroyo/processing/strategies/batching.py
@@ -41,6 +41,7 @@ class BatchStep(ProcessingStrategy[Union[FilteredPayload, TStrategyPayload]]):
         max_batch_size: int,
         max_batch_time: float,
         next_step: ProcessingStrategy[ValuesBatch[TStrategyPayload]],
+        abandon_messages_on_shutdown: bool = False,
     ) -> None:
         def accumulator(
             result: ValuesBatch[TStrategyPayload], value: BaseValue[TStrategyPayload]
@@ -56,6 +57,7 @@ class BatchStep(ProcessingStrategy[Union[FilteredPayload, TStrategyPayload]]):
             accumulator,
             lambda: [],
             next_step,
+            abandon_messages_on_shutdown=abandon_messages_on_shutdown,
         )
 
     def submit(
@@ -109,13 +111,14 @@ class UnbatchStep(
     def __init__(
         self,
         next_step: ProcessingStrategy[Union[FilteredPayload, TStrategyPayload]],
+        abandon_messages_on_shutdown: bool = False,
     ) -> None:
         def generator(
             values: ValuesBatch[TStrategyPayload],
         ) -> MutableSequence[TStrategyPayload]:
             return [value.payload for value in values]
 
-        self.__unfold_step = Unfold(generator, next_step)
+        self.__unfold_step = Unfold(generator, next_step, abandon_messages_on_shutdown=abandon_messages_on_shutdown)
 
     def submit(
         self, message: Message[Union[FilteredPayload, ValuesBatch[TStrategyPayload]]]

--- a/arroyo/processing/strategies/reduce.py
+++ b/arroyo/processing/strategies/reduce.py
@@ -83,6 +83,7 @@ class Reduce(
         accumulator: Accumulator[TResult, TPayload],
         initial_value: Callable[[], TResult],
         next_step: ProcessingStrategy[TResult],
+        abandon_messages_on_shutdown: bool = False,
     ) -> None:
         self.__buffer_step = Buffer(
             buffer=ReduceBuffer(
@@ -92,6 +93,7 @@ class Reduce(
                 initial_value=initial_value,
             ),
             next_step=next_step,
+            abandon_messages_on_shutdown=abandon_messages_on_shutdown,
         )
 
     def submit(self, message: Message[Union[FilteredPayload, TPayload]]) -> None:

--- a/arroyo/processing/strategies/run_task_with_multiprocessing.py
+++ b/arroyo/processing/strategies/run_task_with_multiprocessing.py
@@ -507,11 +507,13 @@ class RunTaskWithMultiprocessing(
         output_block_size: Optional[int] = None,
         max_input_block_size: Optional[int] = None,
         max_output_block_size: Optional[int] = None,
+        abandon_messages_on_shutdown: bool = False,
     ) -> None:
         self.__transform_function = function
         self.__next_step = next_step
         self.__max_batch_size = max_batch_size
         self.__max_batch_time = max_batch_time
+        self.__abandon_messages_on_shutdown = abandon_messages_on_shutdown
 
         self.__resize_input_blocks = input_block_size is None
         self.__resize_output_blocks = output_block_size is None
@@ -861,6 +863,9 @@ class RunTaskWithMultiprocessing(
     def join(self, timeout: Optional[float] = None) -> None:
         start_join = time.time()
         deadline = time.time() + timeout if timeout is not None else None
+        if self.__abandon_messages_on_shutdown:
+            deadline = time.time()
+
         self.__forward_invalid_offsets()
 
         logger.debug("Waiting for %s batches...", len(self.__processes))

--- a/tests/processing/strategies/test_reduce.py
+++ b/tests/processing/strategies/test_reduce.py
@@ -4,9 +4,11 @@ from unittest.mock import Mock, call
 
 from arroyo.processing.strategies.reduce import Reduce
 from arroyo.types import BaseValue, Message, Partition, Topic, Value
+import pytest
 
 
-def test_reduce() -> None:
+@pytest.mark.parametrize("abandon_messages_on_shutdown", (True, False))
+def test_reduce(abandon_messages_on_shutdown: bool) -> None:
     now = datetime.now()
 
     def accumulator(result: Set[int], value: BaseValue[int]) -> Set[int]:
@@ -17,11 +19,11 @@ def test_reduce() -> None:
 
     next_step = Mock()
 
-    strategy = Reduce(3, 5.0, accumulator, initial_value, next_step)
+    strategy = Reduce(3, 5.0, accumulator, initial_value, next_step, abandon_messages_on_shutdown=abandon_messages_on_shutdown)
 
     partition = Partition(Topic("topic"), 0)
 
-    for i in range(6):
+    for i in range(7):
         strategy.submit(
             Message(
                 Value(
@@ -41,3 +43,11 @@ def test_reduce() -> None:
             call(Message(Value({3, 4, 5}, {partition: 6}, now))),
         ]
     )
+
+    strategy.close()
+    strategy.join()
+
+    if abandon_messages_on_shutdown:
+        assert next_step.submit.call_count == 2
+    else:
+        assert next_step.submit.call_count == 3


### PR DESCRIPTION
There were a number of incidents recently (e.g. inc-706) where consumers were not shutdown cleanly as they were unable to finish processing all pending messages before they get kicked out by the broker or kubernetes due to timeouts.

In order to facilitate quicker shutdown, this change aims to make it easier for consumers to drop work and shutdown faster instead of attempting to finish processing every message that has been queued.

A number of strategies that support asynchronous processing (run task in threads, run task with multiprocessing, reduce, unfold, batch, unbatch) now support an optional `abandon_messages_on_shutdown` argument in the constructor. If this is set to true, any work in this processing strategy will be immediately dropped on shutdown. The default is false for backward compatibility.