### PR TITLE
add consumer_member_id tag to partitions assign / revoked metrics

### DIFF
--- a/arroyo/processing/processor.py
+++ b/arroyo/processing/processor.py
@@ -235,7 +235,7 @@ class StreamProcessor(Generic[TStrategyPayload]):
             logger.info("New partitions assigned: %r", partitions)
             logger.info("Member id: %r", self.__consumer.member_id)
             self.__metrics_buffer.metrics.increment(
-                "arroyo.consumer.partitions_assigned.count", len(partitions)
+                "arroyo.consumer.partitions_assigned.count", len(partitions), tags={"consumer_member_id": self.__consumer.member_id}
             )
 
             self.__buffered_messages.reset()
@@ -254,7 +254,7 @@ class StreamProcessor(Generic[TStrategyPayload]):
             logger.info("Partitions to revoke: %r", partitions)
 
             self.__metrics_buffer.metrics.increment(
-                "arroyo.consumer.partitions_revoked.count", len(partitions)
+                "arroyo.consumer.partitions_revoked.count", len(partitions), tags={"consumer_member_id": self.__consumer.member_id}
             )
 
             if partitions:


### PR DESCRIPTION
Attempted fix for #357

[DACI](https://www.notion.so/DACI-Improved-kafka-consumer-metrics-a3828b53d0554ddcb2ed67f4d0c89f83)

Starting with the metrics most important for understanding consumer balancing across a group, but it may make sense to include this tag on other consumer-related metrics as well. Can be done in a follow up.

**Questions**

* [ ] Do we have consumer member ID available when we generate all metrics? 
* [ ] Can we enable this "globally" in that case?
* [ ] If there are times when member ID is not available, could that just be recorded with a `null` or `none` tag? 