### PR TITLE
feat(router) Add a router strategy to route messages to multiple strategies.

### DIFF
--- a/arroyo/processing/strategies/router.py
+++ b/arroyo/processing/strategies/router.py
@@ -1,0 +1,100 @@
+from collections import deque
+from typing import Deque, Mapping, MutableMapping, Optional, Set
+
+from arroyo.types import Partition
+
+
+class PartitionWatermark:
+    def __init__(self, routes: Set[str]):
+        self.__committed: Mapping[str, Deque[int]] = {
+            route: deque() for route in routes
+        }
+        self.__uncommitted: Mapping[str, Deque[int]] = {
+            route: deque() for route in routes
+        }
+
+        self.__lowest_uncommitted: Optional[int] = None
+
+    def add_message(self, route: str, offset: int) -> None:
+        self.__uncommitted[route].append(offset)
+
+    def advance_watermark(self, route: str, offset: int) -> None:
+        assert self.__uncommitted[route], "There are no watermarks to advance"
+        while self.__uncommitted[route][0] <= offset:
+            uncommitted = self.__uncommitted[route].popleft()
+            self.__committed[route].append(uncommitted)
+
+        self.__lowest_uncommitted = None
+        for _, queue in self.__uncommitted.items():
+            if queue and (
+                self.__lowest_uncommitted is None
+                or self.__lowest_uncommitted > queue[0]
+            ):
+                self.__lowest_uncommitted = queue[0]
+
+    def get_watermark(self) -> Optional[int]:
+        high_watermark = None
+        for _, queue in self.__committed.items():
+            for committed in queue:
+                if (
+                    self.__lowest_uncommitted is None
+                    or committed < self.__lowest_uncommitted
+                ) and (high_watermark is None or committed > high_watermark):
+                    high_watermark = committed
+
+        return high_watermark
+
+    def purge(self, offset: int) -> None:
+        for _, queue in self.__committed.items():
+            last_dropped = None
+            for committed in queue:
+                if (
+                    self.__lowest_uncommitted is None
+                    or committed < self.__lowest_uncommitted
+                ):
+                    last_dropped = queue.popleft()
+                else:
+                    if last_dropped:
+                        queue.appendleft(last_dropped)
+                        continue
+
+
+class CommitWatermarkTracker:
+    """
+    Keeps track of the watermark of multiple partitions and decides
+    when and what to commit.
+    """
+
+    def __init__(self, routes: Set[str], partitions: Set[Partition]) -> None:
+        self.__watermarks: Mapping[Partition, PartitionWatermark] = {
+            partition: PartitionWatermark(routes) for partition in partitions
+        }
+
+        self.__committed_offsets: MutableMapping[Partition, int] = {}
+
+    def add_message(self, route: str, partition: Partition, offset: int) -> None:
+        self.__watermarks[partition].add_message(route, offset)
+
+    def add_commit(
+        self, route: str, offsets: Mapping[Partition, int]
+    ) -> Mapping[Partition, int]:
+        """
+        Figures out what needs tio be committed when a strategy calls the
+        commit callback
+        """
+        high_watermark: MutableMapping[Partition, int] = {}
+        for partition, offset in offsets.items():
+            watermark = self.__watermarks[partition]
+            watermark.advance_watermark(route, offset)
+            watermark_offset = watermark.get_watermark()
+            if watermark_offset is not None:
+                high_watermark[partition] = watermark_offset
+            watermark.purge(offset)
+
+        ret = {}
+        for partition, offset in high_watermark.items():
+            if self.__committed_offsets.get(partition, 0) < offset:
+                self.__committed_offsets[partition] = offset
+                ret[partition] = offset
+
+        return ret

--- a/arroyo/processing/strategies/router.py
+++ b/arroyo/processing/strategies/router.py
@@ -54,6 +54,7 @@ class PartitionWatermark:
         """
         Remove the last message we added
         """
+        assert self.__uncommitted[route], "There are no uncommitted offsets to remove"
         val = self.__uncommitted[route].pop()
         if val == self.__lowest_uncommitted:
             self.__lowest_uncommitted = None

--- a/arroyo/processing/strategies/router.py
+++ b/arroyo/processing/strategies/router.py
@@ -59,7 +59,7 @@ class PartitionWatermark:
         """
         self.__uncommitted[route].append(offset)
 
-    def remove_last(self, route: str) -> None:
+    def rewind(self, route: str) -> None:
         """
         Remove the last message we added
         """
@@ -145,8 +145,8 @@ class CommitWatermarkTracker:
             self.__watermarks[partition] = PartitionWatermark(self.__route_names)
         self.__watermarks[partition].add_message(route, offset)
 
-    def remove_last(self, route: str, partition: Partition) -> None:
-        self.__watermarks[partition].remove_last(route)
+    def rewind(self, route: str, partition: Partition) -> None:
+        self.__watermarks[partition].rewind(route)
 
     def add_commit(
         self, route: str, offsets: Mapping[Partition, int]
@@ -293,7 +293,7 @@ class RouterStrategy(ProcessingStrategy[Union[FilteredPayload, TStrategyPayload]
                 # When we receive a `MessageRejected` exception upon submit
                 # the message is not supposed to have been committed, so
                 # we need to remove it from the watermark.
-                self.__watermark_tracker.remove_last(route, partition)
+                self.__watermark_tracker.rewind(route, partition)
             raise
 
     def close(self) -> None:

--- a/arroyo/processing/strategies/router.py
+++ b/arroyo/processing/strategies/router.py
@@ -1,7 +1,12 @@
+import logging
 from collections import deque
-from typing import Deque, Mapping, MutableMapping, Optional, Set
+from functools import partial
+from typing import Deque, Mapping, MutableMapping, Optional, Protocol, Set, Union
 
-from arroyo.types import Partition
+from arroyo.processing.strategies.abstract import ProcessingStrategy
+from arroyo.types import Commit, FilteredPayload, Message, Partition, TStrategyPayload
+
+logger = logging.getLogger(__name__)
 
 
 class PartitionWatermark:
@@ -44,6 +49,20 @@ class PartitionWatermark:
         Adds one uncommitted offset to one route.
         """
         self.__uncommitted[route].append(offset)
+
+    def remove_last(self, route: str) -> None:
+        """
+        Remove the last message we added
+        """
+        val = self.__uncommitted[route].pop()
+        if val == self.__lowest_uncommitted:
+            self.__lowest_uncommitted = None
+            for _, queue in self.__uncommitted.items():
+                if queue and (
+                    self.__lowest_uncommitted is None
+                    or self.__lowest_uncommitted > queue[0]
+                ):
+                    self.__lowest_uncommitted = queue[0]
 
     def advance_watermark(self, route: str, offset: int) -> None:
         """
@@ -118,15 +137,18 @@ class CommitWatermarkTracker:
     when and what to commit.
     """
 
-    def __init__(self, routes: Set[str], partitions: Set[Partition]) -> None:
-        self.__watermarks: Mapping[Partition, PartitionWatermark] = {
-            partition: PartitionWatermark(routes) for partition in partitions
-        }
-
+    def __init__(self, routes: Set[str]) -> None:
+        self.__route_names = routes
+        self.__watermarks: MutableMapping[Partition, PartitionWatermark] = {}
         self.__committed_offsets: MutableMapping[Partition, int] = {}
 
     def add_message(self, route: str, partition: Partition, offset: int) -> None:
+        if partition not in self.__watermarks:
+            self.__watermarks[partition] = PartitionWatermark(self.__route_names)
         self.__watermarks[partition].add_message(route, offset)
+
+    def remove_last(self, route: str, partition: Partition) -> None:
+        self.__watermarks[partition].remove_last(route)
 
     def add_commit(
         self, route: str, offsets: Mapping[Partition, int]
@@ -137,6 +159,10 @@ class CommitWatermarkTracker:
         """
         high_watermark: MutableMapping[Partition, int] = {}
         for partition, offset in offsets.items():
+            assert (
+                partition in self.__watermarks
+            ), f"Partition {partition} is unknown. I have never received a message for it"
+
             watermark = self.__watermarks[partition]
             watermark.advance_watermark(route, offset)
             watermark_offset = watermark.get_watermark()
@@ -151,3 +177,97 @@ class CommitWatermarkTracker:
                 ret[partition] = offset
 
         return ret
+
+    @property
+    def uncommitted_offsets(self) -> int:
+        return sum(
+            watermark.uncommitted_offsets for watermark in self.__watermarks.values()
+        )
+
+
+class RouteBuilder(Protocol):
+    def __call__(self, commit: Commit) -> ProcessingStrategy[TStrategyPayload]:
+        pass
+
+
+class RouteSelector(Protocol):
+    def __call__(
+        self, message: Message[Union[FilteredPayload, TStrategyPayload]]
+    ) -> str:
+        pass
+
+
+class RouterStrategy(ProcessingStrategy[Union[FilteredPayload, TStrategyPayload]]):
+    def __init__(
+        self,
+        routes: Mapping[str, RouteBuilder],
+        selector: RouteSelector,
+        commit: Commit,
+    ) -> None:
+        self.__root_commit = commit
+        self.__watermark_tracker = CommitWatermarkTracker(set(routes.keys()))
+        self.__force_commit = False
+
+        def commit_func(
+            route: str, offsets: Mapping[Partition, int], force: bool = False
+        ) -> None:
+            offsets_to_commit = self.__watermark_tracker.add_commit(route, offsets)
+            if offsets_to_commit:
+                self.__root_commit(offsets_to_commit, force or self.__force_commit)
+                self.__force_commit = False
+            else:
+                if force:
+                    self.__force_commit
+
+        self.__selector = selector
+        self.__routes: Mapping[
+            str, ProcessingStrategy[Union[FilteredPayload, TStrategyPayload]]
+        ] = {
+            name: builder(partial(commit_func, name))
+            for name, builder in routes.items()
+        }
+
+        self.__closed = False
+
+    def poll(self) -> None:
+        for route in self.__routes.values():
+            route.poll()
+
+    def submit(
+        self, message: Message[Union[FilteredPayload, TStrategyPayload]]
+    ) -> None:
+        assert not self.__closed
+
+        route = self.__selector(message)
+        assert route in self.__routes, f"Invalid route {route}"
+        for partition, offset in message.committable.items():
+            self.__watermark_tracker.add_message(route, partition, offset)
+
+        try:
+            self.__routes[route].submit(message)
+        except Exception:
+            for partition, offset in message.committable.items():
+                self.__watermark_tracker.remove_last(route, partition)
+            raise
+
+    def close(self) -> None:
+        self.__closed = True
+
+        for route in self.__routes.values():
+            route.close()
+
+    def terminate(self) -> None:
+        self.__closed = True
+
+        for route in self.__routes.values():
+            logger.debug("Terminating %r...", route)
+            route.terminate()
+
+    def join(self, timeout: Optional[float] = None) -> None:
+        for route in self.__routes.values():
+            # TODO: Should maybe reduce the timeout at each route
+            route.join(timeout)
+
+        uncommitted = self.__watermark_tracker.uncommitted_offsets
+        if uncommitted:
+            logger.error(f"Terminating with {uncommitted} uncommitted offsets")

--- a/tests/processing/strategies/test_router.py
+++ b/tests/processing/strategies/test_router.py
@@ -42,6 +42,9 @@ def test_invalid_offset() -> None:
 
 
 def test_single_route() -> None:
+    """
+    Validates watermark is increased correctly with one route only.
+    """
     watermark = PartitionWatermark({"route1"})
 
     watermark.add_message("route1", 10)
@@ -74,6 +77,10 @@ def test_single_route() -> None:
 
 
 def test_switching_routes() -> None:
+    """
+    Test the right watrmark is computed with two routes that
+    commit out of order.
+    """
     watermark = PartitionWatermark({"route1", "route2"})
 
     watermark.add_message("route1", 10)
@@ -140,7 +147,7 @@ def test_basic_deletion() -> None:
         watermark.rewind("route1")
 
 
-def test_delete_allow_commit() -> None:
+def test_invalid_deletion() -> None:
     watermark = PartitionWatermark({"route1", "route2"})
     watermark.add_message("route1", 10)
     watermark.add_message("route2", 20)
@@ -229,6 +236,11 @@ class EventRecorder:
 
 
 class TestStrategy(ProcessingStrategy[TStrategyPayload]):
+    """
+    Strategy to me used in tests. its only jobs are to record events
+    and commit.
+    """
+
     def __init__(
         self,
         commit: ArroyoCommit,
@@ -277,6 +289,9 @@ class TestStrategy(ProcessingStrategy[TStrategyPayload]):
 
 
 def selector(message: Message[Union[FilteredPayload, TStrategyPayload]]) -> str:
+    """
+    Picks a route based on the message content.
+    """
     return str(message.payload)
 
 

--- a/tests/processing/strategies/test_router.py
+++ b/tests/processing/strategies/test_router.py
@@ -135,12 +135,12 @@ def test_basic_deletion() -> None:
     assert watermark.uncommitted_offsets == 3
     assert watermark.committed_offsets == 0
 
-    watermark.remove_last("route1")
+    watermark.rewind("route1")
     assert watermark.uncommitted_offsets == 2
 
     watermark.advance_watermark("route1", 16)
     with pytest.raises(AssertionError):
-        watermark.remove_last("route1")
+        watermark.rewind("route1")
 
 
 def test_delete_allow_commit() -> None:
@@ -151,7 +151,7 @@ def test_delete_allow_commit() -> None:
 
     watermark.advance_watermark("route1", 25)
     assert watermark.get_watermark() == 10
-    watermark.remove_last("route2")
+    watermark.rewind("route2")
     assert watermark.get_watermark() == 25
 
 

--- a/tests/processing/strategies/test_router.py
+++ b/tests/processing/strategies/test_router.py
@@ -148,10 +148,8 @@ def test_delete_allow_commit() -> None:
 
     watermark.advance_watermark("route1", 25)
     assert watermark.high_watermark == 10
-    watermark.rewind("route2")
-    # I removed the only offset in route2 thus
-    # unlocking route1
-    assert watermark.high_watermark == 25
+    with pytest.raises(AssertionError):
+        watermark.rewind("route2")
 
 
 def test_commit_tracker() -> None:

--- a/tests/processing/strategies/test_router.py
+++ b/tests/processing/strategies/test_router.py
@@ -1,3 +1,5 @@
+import pytest
+
 from arroyo.processing.strategies.router import (
     CommitWatermarkTracker,
     PartitionWatermark,
@@ -5,36 +7,110 @@ from arroyo.processing.strategies.router import (
 from arroyo.types import Partition, Topic
 
 
-def test_base() -> None:
+def test_empty_watermark() -> None:
+    watermark = PartitionWatermark(set())
+    assert watermark.get_watermark() is None
+    watermark.purge()
+    assert watermark.get_watermark() is None
+    assert watermark.committed_offsets == 0
+    assert watermark.uncommitted_offsets == 0
+
     watermark = PartitionWatermark({"route1", "route2", "route3"})
+    assert watermark.get_watermark() is None
+    watermark.purge()
+    assert watermark.get_watermark() is None
+    assert watermark.committed_offsets == 0
+    assert watermark.uncommitted_offsets == 0
+
+
+def test_single_route() -> None:
+    watermark = PartitionWatermark({"route1"})
 
     watermark.add_message("route1", 10)
     watermark.add_message("route1", 15)
     watermark.add_message("route1", 16)
-    watermark.add_message("route1", 17)
-    watermark.add_message("route2", 25)
-    watermark.add_message("route2", 26)
-    watermark.add_message("route2", 27)
-    watermark.add_message("route3", 28)
+    assert watermark.committed_offsets == 0
+    assert watermark.uncommitted_offsets == 3
 
     assert watermark.get_watermark() is None
-
-    watermark.advance_watermark("route2", 25)
-
+    watermark.purge()
     assert watermark.get_watermark() is None
+    assert watermark.committed_offsets == 0
+    assert watermark.uncommitted_offsets == 3
 
+    watermark.advance_watermark("route1", 15)
+    assert watermark.committed_offsets == 2
+    assert watermark.uncommitted_offsets == 1
+    assert watermark.get_watermark() == 15
+    watermark.purge()
+    assert watermark.get_watermark() is None
+    assert watermark.committed_offsets == 0
+    assert watermark.uncommitted_offsets == 1
+
+    # Empty the route
     watermark.advance_watermark("route1", 16)
-
     assert watermark.get_watermark() == 16
+    watermark.purge()
+    assert watermark.committed_offsets == 0
+    assert watermark.uncommitted_offsets == 0
 
+    with pytest.raises(AssertionError):
+        watermark.advance_watermark("route1", 17)
+
+    # Refill. Test it keeps working consistently
+    watermark.add_message("route1", 17)
+    assert watermark.get_watermark() is None
     watermark.advance_watermark("route1", 17)
+    assert watermark.get_watermark() == 17
 
-    assert watermark.get_watermark() == 25
 
-    watermark.advance_watermark("route1", 27)
+def test_switching_routes() -> None:
+    watermark = PartitionWatermark({"route1", "route2"})
 
-    assert watermark.get_watermark() == 27
+    watermark.add_message("route1", 10)
+    watermark.add_message("route1", 15)
+    watermark.add_message("route1", 16)
 
+    watermark.add_message("route2", 17)
+    watermark.add_message("route2", 20)
+    watermark.add_message("route2", 21)
+
+    watermark.add_message("route1", 30)
+    watermark.add_message("route1", 32)
+
+    watermark.add_message("route2", 33)
+    watermark.add_message("route2", 34)
+
+    assert watermark.get_watermark() is None
+
+    watermark.advance_watermark("route2", 17)
+    assert watermark.committed_offsets == 1
+    watermark.advance_watermark("route2", 21)
+    assert watermark.committed_offsets == 3
+    assert watermark.uncommitted_offsets == 7
+
+    # We are still waiting for any commit on route 1
+    assert watermark.get_watermark() is None
+
+    # Now we unlock both route 1 and 2
+    watermark.advance_watermark("route1", 16)
+    assert watermark.get_watermark() == 21
+
+    watermark.purge()
+    # No watermark now
+    assert watermark.get_watermark() is None
+    assert watermark.committed_offsets == 0
+    assert watermark.uncommitted_offsets == 4
+
+    watermark.advance_watermark("route2", 33)
+    watermark.advance_watermark("route2", 34)
+    assert watermark.get_watermark() is None
+
+    watermark.advance_watermark("route1", 32)
+    assert watermark.get_watermark() == 34
+
+
+def test_commit_tracker() -> None:
     topic = Topic("mytopic")
     p1 = Partition(topic, 0)
     p2 = Partition(topic, 1)
@@ -45,19 +121,17 @@ def test_base() -> None:
 
     tracker.add_message("route1", p1, 10)
     tracker.add_message("route1", p1, 15)
+    tracker.add_message("route2", p1, 20)
+    tracker.add_message("route1", p1, 25)
 
     tracker.add_message("route1", p2, 5)
     tracker.add_message("route1", p2, 10)
-
-    tracker.add_message("route2", p1, 20)
     tracker.add_message("route2", p2, 11)
-
-    tracker.add_message("route1", p1, 25)
     tracker.add_message("route1", p2, 20)
 
     assert tracker.add_commit("route1", {p1: 10}) == {p1: 10}
     assert tracker.add_commit("route1", {p2: 10}) == {p2: 10}
-    assert tracker.add_commit("route1", {p1: 25, p2: 20}) == {}
+    assert tracker.add_commit("route1", {p1: 25, p2: 20}) == {p1: 15}
 
     tracker.add_message("route1", p1, 30)
     tracker.add_message("route1", p2, 21)

--- a/tests/processing/strategies/test_router.py
+++ b/tests/processing/strategies/test_router.py
@@ -36,6 +36,15 @@ def test_empty_watermark() -> None:
     assert watermark.uncommitted_offsets == 0
 
 
+def test_invalid_offset() -> None:
+    watermark = PartitionWatermark({"route1"})
+    watermark.add_message("route1", 10)
+    watermark.add_message("route1", 15)
+
+    with pytest.raises(AssertionError):
+        watermark.advance_watermark("route1", 13)
+
+
 def test_single_route() -> None:
     watermark = PartitionWatermark({"route1"})
 
@@ -138,7 +147,7 @@ def test_basic_deletion() -> None:
     watermark.rewind("route1")
     assert watermark.uncommitted_offsets == 2
 
-    watermark.advance_watermark("route1", 16)
+    watermark.advance_watermark("route1", 15)
     with pytest.raises(AssertionError):
         watermark.rewind("route1")
 

--- a/tests/processing/strategies/test_router.py
+++ b/tests/processing/strategies/test_router.py
@@ -1,0 +1,65 @@
+from arroyo.processing.strategies.router import (
+    CommitWatermarkTracker,
+    PartitionWatermark,
+)
+from arroyo.types import Partition, Topic
+
+
+def test_base() -> None:
+    watermark = PartitionWatermark({"route1", "route2", "route3"})
+
+    watermark.add_message("route1", 10)
+    watermark.add_message("route1", 15)
+    watermark.add_message("route1", 16)
+    watermark.add_message("route1", 17)
+    watermark.add_message("route2", 25)
+    watermark.add_message("route2", 26)
+    watermark.add_message("route2", 27)
+    watermark.add_message("route3", 28)
+
+    assert watermark.get_watermark() is None
+
+    watermark.advance_watermark("route2", 25)
+
+    assert watermark.get_watermark() is None
+
+    watermark.advance_watermark("route1", 16)
+
+    assert watermark.get_watermark() == 16
+
+    watermark.advance_watermark("route1", 17)
+
+    assert watermark.get_watermark() == 25
+
+    watermark.advance_watermark("route1", 27)
+
+    assert watermark.get_watermark() == 27
+
+    topic = Topic("mytopic")
+    p1 = Partition(topic, 0)
+    p2 = Partition(topic, 1)
+    tracker = CommitWatermarkTracker(
+        routes={"route1", "route2"},
+        partitions={p1, p2},
+    )
+
+    tracker.add_message("route1", p1, 10)
+    tracker.add_message("route1", p1, 15)
+
+    tracker.add_message("route1", p2, 5)
+    tracker.add_message("route1", p2, 10)
+
+    tracker.add_message("route2", p1, 20)
+    tracker.add_message("route2", p2, 11)
+
+    tracker.add_message("route1", p1, 25)
+    tracker.add_message("route1", p2, 20)
+
+    assert tracker.add_commit("route1", {p1: 10}) == {p1: 10}
+    assert tracker.add_commit("route1", {p2: 10}) == {p2: 10}
+    assert tracker.add_commit("route1", {p1: 25, p2: 20}) == {}
+
+    tracker.add_message("route1", p1, 30)
+    tracker.add_message("route1", p2, 21)
+
+    assert tracker.add_commit("route2", {p1: 20, p2: 11}) == {p1: 25, p2: 20}

--- a/tests/processing/strategies/test_router.py
+++ b/tests/processing/strategies/test_router.py
@@ -22,16 +22,12 @@ from arroyo.types import (
 
 def test_empty_watermark() -> None:
     watermark = PartitionWatermark(set())
-    assert watermark.get_high_watermark() is None
-    watermark.purge()
-    assert watermark.get_high_watermark() is None
+    assert watermark.high_watermark is None
     assert watermark.committed_offsets == 0
     assert watermark.uncommitted_offsets == 0
 
     watermark = PartitionWatermark({"route1", "route2", "route3"})
-    assert watermark.get_high_watermark() is None
-    watermark.purge()
-    assert watermark.get_high_watermark() is None
+    assert watermark.high_watermark is None
     assert watermark.committed_offsets == 0
     assert watermark.uncommitted_offsets == 0
 
@@ -51,39 +47,30 @@ def test_single_route() -> None:
     watermark.add_message("route1", 10)
     watermark.add_message("route1", 15)
     watermark.add_message("route1", 16)
+    watermark.add_message("route1", 17)
     assert watermark.committed_offsets == 0
-    assert watermark.uncommitted_offsets == 3
+    assert watermark.uncommitted_offsets == 4
 
-    assert watermark.get_high_watermark() is None
-    watermark.purge()
-    assert watermark.get_high_watermark() is None
-    assert watermark.committed_offsets == 0
-    assert watermark.uncommitted_offsets == 3
+    assert watermark.high_watermark is None
 
-    watermark.advance_watermark("route1", 15)
-    assert watermark.committed_offsets == 2
-    assert watermark.uncommitted_offsets == 1
-    assert watermark.get_high_watermark() == 15
-    watermark.purge()
-    assert watermark.get_high_watermark() is None
+    watermark.advance_watermark("route1", 16)
     assert watermark.committed_offsets == 0
     assert watermark.uncommitted_offsets == 1
+    assert watermark.high_watermark == 16
 
     # Empty the route
-    watermark.advance_watermark("route1", 16)
-    assert watermark.get_high_watermark() == 16
-    watermark.purge()
-    assert watermark.committed_offsets == 0
+    watermark.advance_watermark("route1", 17)
+    assert watermark.high_watermark == 17
     assert watermark.uncommitted_offsets == 0
 
     with pytest.raises(AssertionError):
-        watermark.advance_watermark("route1", 17)
+        watermark.advance_watermark("route1", 18)
 
     # Refill. Test it keeps working consistently
-    watermark.add_message("route1", 17)
-    assert watermark.get_high_watermark() is None
-    watermark.advance_watermark("route1", 17)
-    assert watermark.get_high_watermark() == 17
+    watermark.add_message("route1", 18)
+    assert watermark.high_watermark == 17
+    watermark.advance_watermark("route1", 18)
+    assert watermark.high_watermark == 18
 
 
 def test_switching_routes() -> None:
@@ -103,39 +90,40 @@ def test_switching_routes() -> None:
     watermark.add_message("route2", 33)
     watermark.add_message("route2", 34)
 
-    assert watermark.get_high_watermark() is None
+    assert watermark.high_watermark is None
 
     watermark.advance_watermark("route2", 17)
+    # I committed one offset in route2. Those
+    # on route 1 are not committed.
     assert watermark.committed_offsets == 1
     watermark.advance_watermark("route2", 21)
+    # As I did not committed anything from route1
+    # and they were lower than all offsets on route2
+    # No offset has been purged. I still need them
+    # around till I can advance the lower watermark
     assert watermark.committed_offsets == 3
     assert watermark.uncommitted_offsets == 7
 
     # We are still waiting for any commit on route 1
-    assert watermark.get_high_watermark() is None
+    assert watermark.high_watermark is None
 
     # Now we unlock both route 1 and 2
     watermark.advance_watermark("route1", 16)
-    assert watermark.get_high_watermark() == 21
-
-    watermark.purge()
-    # No watermark now
-    assert watermark.get_high_watermark() is None
+    assert watermark.high_watermark == 21
     assert watermark.committed_offsets == 0
     assert watermark.uncommitted_offsets == 4
 
-    watermark.advance_watermark("route2", 33)
     watermark.advance_watermark("route2", 34)
-    assert watermark.get_high_watermark() is None
+    assert watermark.high_watermark == 21
 
     watermark.advance_watermark("route1", 32)
-    assert watermark.get_high_watermark() == 34
+    assert watermark.high_watermark == 34
 
 
 def test_basic_deletion() -> None:
     watermark = PartitionWatermark({"route1", "route2"})
 
-    assert watermark.get_high_watermark() is None
+    assert watermark.high_watermark is None
 
     watermark.add_message("route1", 10)
     watermark.add_message("route1", 15)
@@ -159,9 +147,11 @@ def test_delete_allow_commit() -> None:
     watermark.add_message("route1", 25)
 
     watermark.advance_watermark("route1", 25)
-    assert watermark.get_high_watermark() == 10
+    assert watermark.high_watermark == 10
     watermark.rewind("route2")
-    assert watermark.get_high_watermark() == 25
+    # I removed the only offset in route2 thus
+    # unlocking route1
+    assert watermark.high_watermark == 25
 
 
 def test_commit_tracker() -> None:
@@ -183,8 +173,8 @@ def test_commit_tracker() -> None:
     tracker.add_message("route1", p2, 20)
 
     assert tracker.commit("route1", {p1: 10}) == {p1: 10}
-    assert tracker.commit("route1", {p2: 10}) == {p2: 10}
-    assert tracker.commit("route1", {p1: 25, p2: 20}) == {p1: 15}
+    assert tracker.commit("route1", {p2: 10}) == {p1: 10, p2: 10}
+    assert tracker.commit("route1", {p1: 25, p2: 20}) == {p1: 15, p2: 10}
 
     tracker.add_message("route1", p1, 30)
     tracker.add_message("route1", p2, 21)

--- a/tests/processing/strategies/test_router.py
+++ b/tests/processing/strategies/test_router.py
@@ -5,9 +5,9 @@ import pytest
 
 from arroyo.processing.strategies import MessageRejected, ProcessingStrategy
 from arroyo.processing.strategies.router import (
-    CommitWatermarkTracker,
     PartitionWatermark,
     RouterStrategy,
+    TopicCommitWatermark,
 )
 from arroyo.types import Commit as ArroyoCommit
 from arroyo.types import (
@@ -22,16 +22,16 @@ from arroyo.types import (
 
 def test_empty_watermark() -> None:
     watermark = PartitionWatermark(set())
-    assert watermark.get_watermark() is None
+    assert watermark.get_high_watermark() is None
     watermark.purge()
-    assert watermark.get_watermark() is None
+    assert watermark.get_high_watermark() is None
     assert watermark.committed_offsets == 0
     assert watermark.uncommitted_offsets == 0
 
     watermark = PartitionWatermark({"route1", "route2", "route3"})
-    assert watermark.get_watermark() is None
+    assert watermark.get_high_watermark() is None
     watermark.purge()
-    assert watermark.get_watermark() is None
+    assert watermark.get_high_watermark() is None
     assert watermark.committed_offsets == 0
     assert watermark.uncommitted_offsets == 0
 
@@ -45,24 +45,24 @@ def test_single_route() -> None:
     assert watermark.committed_offsets == 0
     assert watermark.uncommitted_offsets == 3
 
-    assert watermark.get_watermark() is None
+    assert watermark.get_high_watermark() is None
     watermark.purge()
-    assert watermark.get_watermark() is None
+    assert watermark.get_high_watermark() is None
     assert watermark.committed_offsets == 0
     assert watermark.uncommitted_offsets == 3
 
     watermark.advance_watermark("route1", 15)
     assert watermark.committed_offsets == 2
     assert watermark.uncommitted_offsets == 1
-    assert watermark.get_watermark() == 15
+    assert watermark.get_high_watermark() == 15
     watermark.purge()
-    assert watermark.get_watermark() is None
+    assert watermark.get_high_watermark() is None
     assert watermark.committed_offsets == 0
     assert watermark.uncommitted_offsets == 1
 
     # Empty the route
     watermark.advance_watermark("route1", 16)
-    assert watermark.get_watermark() == 16
+    assert watermark.get_high_watermark() == 16
     watermark.purge()
     assert watermark.committed_offsets == 0
     assert watermark.uncommitted_offsets == 0
@@ -72,9 +72,9 @@ def test_single_route() -> None:
 
     # Refill. Test it keeps working consistently
     watermark.add_message("route1", 17)
-    assert watermark.get_watermark() is None
+    assert watermark.get_high_watermark() is None
     watermark.advance_watermark("route1", 17)
-    assert watermark.get_watermark() == 17
+    assert watermark.get_high_watermark() == 17
 
 
 def test_switching_routes() -> None:
@@ -94,7 +94,7 @@ def test_switching_routes() -> None:
     watermark.add_message("route2", 33)
     watermark.add_message("route2", 34)
 
-    assert watermark.get_watermark() is None
+    assert watermark.get_high_watermark() is None
 
     watermark.advance_watermark("route2", 17)
     assert watermark.committed_offsets == 1
@@ -103,30 +103,30 @@ def test_switching_routes() -> None:
     assert watermark.uncommitted_offsets == 7
 
     # We are still waiting for any commit on route 1
-    assert watermark.get_watermark() is None
+    assert watermark.get_high_watermark() is None
 
     # Now we unlock both route 1 and 2
     watermark.advance_watermark("route1", 16)
-    assert watermark.get_watermark() == 21
+    assert watermark.get_high_watermark() == 21
 
     watermark.purge()
     # No watermark now
-    assert watermark.get_watermark() is None
+    assert watermark.get_high_watermark() is None
     assert watermark.committed_offsets == 0
     assert watermark.uncommitted_offsets == 4
 
     watermark.advance_watermark("route2", 33)
     watermark.advance_watermark("route2", 34)
-    assert watermark.get_watermark() is None
+    assert watermark.get_high_watermark() is None
 
     watermark.advance_watermark("route1", 32)
-    assert watermark.get_watermark() == 34
+    assert watermark.get_high_watermark() == 34
 
 
 def test_basic_deletion() -> None:
     watermark = PartitionWatermark({"route1", "route2"})
 
-    assert watermark.get_watermark() is None
+    assert watermark.get_high_watermark() is None
 
     watermark.add_message("route1", 10)
     watermark.add_message("route1", 15)
@@ -150,16 +150,16 @@ def test_delete_allow_commit() -> None:
     watermark.add_message("route1", 25)
 
     watermark.advance_watermark("route1", 25)
-    assert watermark.get_watermark() == 10
+    assert watermark.get_high_watermark() == 10
     watermark.rewind("route2")
-    assert watermark.get_watermark() == 25
+    assert watermark.get_high_watermark() == 25
 
 
 def test_commit_tracker() -> None:
     topic = Topic("mytopic")
     p1 = Partition(topic, 0)
     p2 = Partition(topic, 1)
-    tracker = CommitWatermarkTracker(
+    tracker = TopicCommitWatermark(
         routes={"route1", "route2"},
     )
 
@@ -173,14 +173,14 @@ def test_commit_tracker() -> None:
     tracker.add_message("route2", p2, 11)
     tracker.add_message("route1", p2, 20)
 
-    assert tracker.add_commit("route1", {p1: 10}) == {p1: 10}
-    assert tracker.add_commit("route1", {p2: 10}) == {p2: 10}
-    assert tracker.add_commit("route1", {p1: 25, p2: 20}) == {p1: 15}
+    assert tracker.commit("route1", {p1: 10}) == {p1: 10}
+    assert tracker.commit("route1", {p2: 10}) == {p2: 10}
+    assert tracker.commit("route1", {p1: 25, p2: 20}) == {p1: 15}
 
     tracker.add_message("route1", p1, 30)
     tracker.add_message("route1", p2, 21)
 
-    assert tracker.add_commit("route2", {p1: 20, p2: 11}) == {p1: 25, p2: 20}
+    assert tracker.commit("route2", {p1: 20, p2: 11}) == {p1: 25, p2: 20}
 
 
 @dataclass


### PR DESCRIPTION
This PR introduces a Router processing strategy that delivers messages to multiple independent strategies, keeps track of the commits that can happen out of order and commit in the right order on Kafka.

Why a router strategy?
There are multiple use cases. In the specific this is to route messages to a low priority second topic to put old messages aside and prioritize new ones. This is meant to automate the process that we employ to route messages to ingest-events-2. 
There are other scenarios like sending messages to different topics in the indexer, divide processing in multiple classes on different multiprocess pools, etc.

How does it work ? 
- the strategy is provided a selector and a list of strategies to route messages to.
- the selector inspects a message and routes it. Ideally this should be based on the message header to avoid parsing the message.
- the strategy wraps the commit function passed to the destinations in order to intercept all commits.
- all commits are registered into an object that keeps track of the watermark to commit.

What's the commit policy ?
Each strategy can have its own commit policy, they can commit when they want. Each strategy is expected to commit offsets in order per partition. This is not different than the standard Kafka behavior. Different parallel destination strategies can commit out of order with respect to each other.

How will this be used ?
The first use case will be to automate the ingest-events2 process to put older messages aside during ingestion when we are trying to burn a backlog.
Today that process requires people to manually change the Relay configuration to route new messages to a separate topic and start a consumer there.
This strategy will be used in the ingest consumer so that really old messages will be sent to a strategy that produces on a backup topic reaching the newer messages soon.
If this works well we will expand the usage to all consumers where in order delivery is not strictly needed. We could consider adding it inside the StreamProcessor to ensire it will always be there.