### PR TITLE
fix: Allow sending committable from Unfold

### DIFF
--- a/arroyo/processing/processor.py
+++ b/arroyo/processing/processor.py
@@ -143,9 +143,9 @@ class StreamProcessor(Generic[TStrategyPayload]):
         self.__processor_factory = processor_factory
         self.__metrics_buffer = MetricsBuffer()
 
-        self.__processing_strategy: Optional[
-            ProcessingStrategy[TStrategyPayload]
-        ] = None
+        self.__processing_strategy: Optional[ProcessingStrategy[TStrategyPayload]] = (
+            None
+        )
 
         self.__message: Optional[BrokerValue[TStrategyPayload]] = None
 
@@ -405,10 +405,8 @@ class StreamProcessor(Generic[TStrategyPayload]):
             if self.__message is not None:
                 try:
                     start_submit = time.time()
-                    message = (
-                        Message(self.__message) if self.__message is not None else None
-                    )
-                    self.__processing_strategy.submit(message)
+
+                    self.__processing_strategy.submit(Message(self.__message))
 
                     self.__metrics_buffer.incr_timing(
                         "arroyo.consumer.processing.time",

--- a/arroyo/processing/processor.py
+++ b/arroyo/processing/processor.py
@@ -143,9 +143,9 @@ class StreamProcessor(Generic[TStrategyPayload]):
         self.__processor_factory = processor_factory
         self.__metrics_buffer = MetricsBuffer()
 
-        self.__processing_strategy: Optional[ProcessingStrategy[TStrategyPayload]] = (
-            None
-        )
+        self.__processing_strategy: Optional[
+            ProcessingStrategy[TStrategyPayload]
+        ] = None
 
         self.__message: Optional[BrokerValue[TStrategyPayload]] = None
 
@@ -405,8 +405,10 @@ class StreamProcessor(Generic[TStrategyPayload]):
             if self.__message is not None:
                 try:
                     start_submit = time.time()
-
-                    self.__processing_strategy.submit(Message(self.__message))
+                    message = (
+                        Message(self.__message) if self.__message is not None else None
+                    )
+                    self.__processing_strategy.submit(message)
 
                     self.__metrics_buffer.incr_timing(
                         "arroyo.consumer.processing.time",

--- a/arroyo/processing/strategies/batching.py
+++ b/arroyo/processing/strategies/batching.py
@@ -112,8 +112,8 @@ class UnbatchStep(
     ) -> None:
         def generator(
             values: ValuesBatch[TStrategyPayload],
-        ) -> MutableSequence[TStrategyPayload]:
-            return [value for value in values]
+        ) -> ValuesBatch[TStrategyPayload]:
+            return values
 
         self.__unfold_step = Unfold(generator, next_step)
 

--- a/arroyo/processing/strategies/batching.py
+++ b/arroyo/processing/strategies/batching.py
@@ -48,14 +48,14 @@ class BatchStep(ProcessingStrategy[Union[FilteredPayload, TStrategyPayload]]):
             result.append(value)
             return result
 
-        self.__reduce_step: Reduce[TStrategyPayload, ValuesBatch[TStrategyPayload]] = (
-            Reduce(
-                max_batch_size,
-                max_batch_time,
-                accumulator,
-                lambda: [],
-                next_step,
-            )
+        self.__reduce_step: Reduce[
+            TStrategyPayload, ValuesBatch[TStrategyPayload]
+        ] = Reduce(
+            max_batch_size,
+            max_batch_time,
+            accumulator,
+            lambda: [],
+            next_step,
         )
 
     def submit(

--- a/arroyo/processing/strategies/batching.py
+++ b/arroyo/processing/strategies/batching.py
@@ -48,14 +48,14 @@ class BatchStep(ProcessingStrategy[Union[FilteredPayload, TStrategyPayload]]):
             result.append(value)
             return result
 
-        self.__reduce_step: Reduce[
-            TStrategyPayload, ValuesBatch[TStrategyPayload]
-        ] = Reduce(
-            max_batch_size,
-            max_batch_time,
-            accumulator,
-            lambda: [],
-            next_step,
+        self.__reduce_step: Reduce[TStrategyPayload, ValuesBatch[TStrategyPayload]] = (
+            Reduce(
+                max_batch_size,
+                max_batch_time,
+                accumulator,
+                lambda: [],
+                next_step,
+            )
         )
 
     def submit(
@@ -113,7 +113,7 @@ class UnbatchStep(
         def generator(
             values: ValuesBatch[TStrategyPayload],
         ) -> MutableSequence[TStrategyPayload]:
-            return [value.payload for value in values]
+            return [value for value in values]
 
         self.__unfold_step = Unfold(generator, next_step)
 

--- a/arroyo/processing/strategies/unfold.py
+++ b/arroyo/processing/strategies/unfold.py
@@ -1,9 +1,9 @@
 import time
 from collections import deque
-from typing import Callable, Iterable, Deque, Generic, Optional, TypeVar, Union, cast
+from typing import Callable, Deque, Generic, Iterable, Optional, TypeVar, Union, cast
 
 from arroyo.processing.strategies.abstract import MessageRejected, ProcessingStrategy
-from arroyo.types import FilteredPayload, Message
+from arroyo.types import BaseValue, FilteredPayload, Message
 
 TInput = TypeVar("TInput")
 TOutput = TypeVar("TOutput")
@@ -27,7 +27,7 @@ class Unfold(
 
     def __init__(
         self,
-        generator: Callable[[TInput], Iterable[TOutput]],
+        generator: Callable[[TInput], Iterable[BaseValue[TOutput]]],
         next_step: ProcessingStrategy[Union[FilteredPayload, TOutput]],
     ) -> None:
         self.__generator = generator

--- a/arroyo/processing/strategies/unfold.py
+++ b/arroyo/processing/strategies/unfold.py
@@ -17,8 +17,8 @@ class Unfold(
     messages submitting them one by one to the next step. The generated
     messages are created according to the generator function provided by the user.
 
-    The generator function provided must return a collection (i.e. a class that
-    implements sized + iterable).
+    The generator function provided must return an iterable (i.e. a class that
+    implements `__iter__` ).
 
     If this step receives a `MessageRejected` exception from the next
     step it keeps the remaining messages and attempts to submit
@@ -48,18 +48,13 @@ class Unfold(
             return
 
         iterable = self.__generator(message.payload)
-        num_messages = len(iterable)
 
         store_remaining_messages = False
 
-        for idx, value in enumerate(iterable):
-            # Last message is special because offsets can be committed along with it
-            if idx == num_messages - 1:
-                next_message = Message(
-                    Value(value, message.committable, message.timestamp)
-                )
-            else:
-                next_message = Message(Value(value, {}, message.timestamp))
+        for value in iterable:
+            next_message = Message(
+                value=cast(Value[TOutput], value),
+            )
 
             if store_remaining_messages == False:
                 try:

--- a/arroyo/processing/strategies/unfold.py
+++ b/arroyo/processing/strategies/unfold.py
@@ -1,9 +1,9 @@
 import time
 from collections import deque
-from typing import Callable, Collection, Deque, Generic, Optional, TypeVar, Union, cast
+from typing import Callable, Iterable, Deque, Generic, Optional, TypeVar, Union, cast
 
 from arroyo.processing.strategies.abstract import MessageRejected, ProcessingStrategy
-from arroyo.types import FilteredPayload, Message, Value
+from arroyo.types import FilteredPayload, Message
 
 TInput = TypeVar("TInput")
 TOutput = TypeVar("TOutput")
@@ -27,7 +27,7 @@ class Unfold(
 
     def __init__(
         self,
-        generator: Callable[[TInput], Collection[TOutput]],
+        generator: Callable[[TInput], Iterable[TOutput]],
         next_step: ProcessingStrategy[Union[FilteredPayload, TOutput]],
     ) -> None:
         self.__generator = generator
@@ -52,9 +52,7 @@ class Unfold(
         store_remaining_messages = False
 
         for value in iterable:
-            next_message = Message(
-                value=cast(Value[TOutput], value),
-            )
+            next_message = Message(value=value)
 
             if store_remaining_messages == False:
                 try:

--- a/tests/processing/strategies/test_unfold.py
+++ b/tests/processing/strategies/test_unfold.py
@@ -22,8 +22,8 @@ def test_unfold() -> None:
     strategy.submit(message)
 
     assert next_step.submit.call_args_list == [
-        call(Message(Value(0, committable={}, timestamp=now))),
-        call(Message(Value(1, committable={partition: 1}, timestamp=now))),
+        call(Message(0)),
+        call(Message(1)),
     ]
 
     strategy.close()
@@ -45,7 +45,7 @@ def test_message_rejected() -> None:
 
     # Message doesn't actually go through since it was rejected
     assert next_step.submit.call_args_list == [
-        call(Message(Value(0, committable={}, timestamp=now))),
+        call(Message(0)),
     ]
 
     # clear the side effect, both messages should be submitted now
@@ -54,8 +54,8 @@ def test_message_rejected() -> None:
     strategy.poll()
 
     assert next_step.submit.call_args_list == [
-        call(Message(Value(0, committable={}, timestamp=now))),
-        call(Message(Value(1, committable={partition: 1}, timestamp=now))),
+        call(Message(0)),
+        call(Message(1)),
     ]
 
     strategy.close()

--- a/tests/processing/strategies/test_unfold.py
+++ b/tests/processing/strategies/test_unfold.py
@@ -6,24 +6,25 @@ from arroyo.processing.strategies import MessageRejected
 from arroyo.processing.strategies.unfold import Unfold
 from arroyo.types import Message, Partition, Topic, Value
 
+PARTITION = Partition(Topic("topic"), 0)
+NOW = datetime.now()
 
-def generator(num: int) -> Sequence[int]:
-    return [i for i in range(num)]
+
+def generator(num: int) -> Sequence[Value[int]]:
+    return [Value(i, {PARTITION: i}, NOW) for i in range(num)]
 
 
 def test_unfold() -> None:
-    partition = Partition(Topic("topic"), 0)
-    now = datetime.now()
 
-    message = Message(Value(2, {partition: 1}, now))
+    message = Message(Value(2, {PARTITION: 1}, NOW))
     next_step = Mock()
 
     strategy = Unfold(generator, next_step)
     strategy.submit(message)
 
     assert next_step.submit.call_args_list == [
-        call(Message(0)),
-        call(Message(1)),
+        call(Message(Value(0, {PARTITION: 0}, NOW))),
+        call(Message(Value(1, {PARTITION: 1}, NOW))),
     ]
 
     strategy.close()
@@ -31,21 +32,19 @@ def test_unfold() -> None:
 
 
 def test_message_rejected() -> None:
-    partition = Partition(Topic("topic"), 0)
-    now = datetime.now()
     next_step = Mock()
     next_step.submit.side_effect = MessageRejected()
 
     strategy = Unfold(generator, next_step)
 
-    message = Message(Value(2, {partition: 1}, now))
+    message = Message(Value(2, {PARTITION: 1}, NOW))
     strategy.submit(message)
 
     assert next_step.submit.call_count == 1
 
     # Message doesn't actually go through since it was rejected
     assert next_step.submit.call_args_list == [
-        call(Message(0)),
+        call(Message(Value(0, {PARTITION: 0}, NOW))),
     ]
 
     # clear the side effect, both messages should be submitted now
@@ -54,8 +53,8 @@ def test_message_rejected() -> None:
     strategy.poll()
 
     assert next_step.submit.call_args_list == [
-        call(Message(0)),
-        call(Message(1)),
+        call(Message(Value(0, {PARTITION: 0}, NOW))),
+        call(Message(Value(1, {PARTITION: 1}, NOW))),
     ]
 
     strategy.close()


### PR DESCRIPTION
This PR aligns the `Unbatch` and `Unfold` strategies to the behavior of their counterparts `Batch` and `Reduce`. 
`Unbatch` now just submits the values of a submitted `ValuesBatch` one after another to the next step. Therefore, the logic  was reduced to rely fully on the passed generator function for building a `Message`'s `Value`.   


I tried my best fixing the typing issues but there is still one in `arroyo/processing/strategies/batching.py:116` with which I had no luck.


Closes  #369 