### PR TITLE
Add a basic metric for tracking the capacity in VecDeque buffer

### DIFF
--- a/rust-arroyo/src/processing/dlq.rs
+++ b/rust-arroyo/src/processing/dlq.rs
@@ -11,6 +11,7 @@ use tokio::task::JoinHandle;
 use crate::backends::kafka::producer::KafkaProducer;
 use crate::backends::kafka::types::KafkaPayload;
 use crate::backends::Producer;
+use crate::gauge;
 use crate::types::{BrokerMessage, Partition, Topic, TopicOrPartition};
 
 // This is a per-partition max
@@ -414,6 +415,11 @@ impl<TPayload> BufferedMessages<TPayload> {
         }
 
         buffered.push_back(message);
+
+        gauge!(
+            "Number of elements in buffer deque without reallocating",
+            buffered.capacity()
+        );
     }
 
     /// Return the message at the given offset or None if it is not found in the buffer.

--- a/rust-arroyo/src/processing/dlq.rs
+++ b/rust-arroyo/src/processing/dlq.rs
@@ -416,8 +416,9 @@ impl<TPayload> BufferedMessages<TPayload> {
 
         buffered.push_back(message);
 
+        // Number of elements that can be held in buffer deque without reallocating
         gauge!(
-            "Number of elements that can be held in buffer deque without reallocating",
+            "arroyo.consumer.dlq_buffer.capacity",
             buffered.capacity() as u64
         );
     }
@@ -431,7 +432,7 @@ impl<TPayload> BufferedMessages<TPayload> {
                 Ordering::Equal => {
                     let first = messages.pop_front();
                     gauge!(
-                        "Number of elements that can be held in buffer deque without reallocating",
+                        "arroyo.consumer.dlq_buffer.capacity",
                         messages.capacity() as u64
                     );
                     return first;
@@ -442,7 +443,7 @@ impl<TPayload> BufferedMessages<TPayload> {
                 Ordering::Less => {
                     messages.pop_front();
                     gauge!(
-                        "Number of elements that can be held in buffer deque without reallocating",
+                        "arroyo.consumer.dlq_buffer.capacity",
                         messages.capacity() as u64
                     );
                 }

--- a/rust-arroyo/src/processing/dlq.rs
+++ b/rust-arroyo/src/processing/dlq.rs
@@ -1,5 +1,3 @@
-use rand::seq::index::sample;
-use rand::Rng;
 use std::cmp::Ordering;
 use std::collections::{BTreeMap, HashMap, VecDeque};
 use std::fmt;

--- a/rust-arroyo/src/processing/dlq.rs
+++ b/rust-arroyo/src/processing/dlq.rs
@@ -425,13 +425,10 @@ impl<TPayload> BufferedMessages<TPayload> {
         buffered.push_back(message);
 
         // Number of elements that can be held in buffer deque without reallocating
-        if metric_prob <= 0.01 {
-            // Number of partitions in the buffer map
-            gauge!(
-                "arroyo.consumer.dlq_buffer.assigned_partitions",
-                self.buffered_messages.len() as u64,
-            );
-        }
+        gauge!(
+            "arroyo.consumer.dlq_buffer.capacity",
+            buffered.capacity() as u64
+        );
     }
 
     /// Return the message at the given offset or None if it is not found in the buffer.

--- a/rust-arroyo/src/processing/dlq.rs
+++ b/rust-arroyo/src/processing/dlq.rs
@@ -417,7 +417,7 @@ impl<TPayload> BufferedMessages<TPayload> {
         buffered.push_back(message);
 
         gauge!(
-            "Number of elements in buffer deque without reallocating",
+            "Number of elements that can be held in buffer deque without reallocating",
             buffered.capacity()
         );
     }
@@ -429,13 +429,22 @@ impl<TPayload> BufferedMessages<TPayload> {
         while let Some(message) = messages.front() {
             match message.offset.cmp(&offset) {
                 Ordering::Equal => {
-                    return messages.pop_front();
+                    let first = messages.pop_front();
+                    gauge!(
+                        "Number of elements that can be held in buffer deque without reallocating",
+                        messages.capacity()
+                    );
+                    return first;
                 }
                 Ordering::Greater => {
                     return None;
                 }
                 Ordering::Less => {
                     messages.pop_front();
+                    gauge!(
+                        "Number of elements that can be held in buffer deque without reallocating",
+                        messages.capacity()
+                    );
                 }
             };
         }

--- a/rust-arroyo/src/processing/dlq.rs
+++ b/rust-arroyo/src/processing/dlq.rs
@@ -403,6 +403,12 @@ impl<TPayload> BufferedMessages<TPayload> {
             return;
         }
 
+        // Number of partitions in the buffer map
+        gauge!(
+            "arroyo.consumer.dlq_buffer.assigned_partitions",
+            self.buffered_messages.len() as u64,
+        );
+
         let buffered = self.buffered_messages.entry(message.partition).or_default();
         if let Some(max) = self.max_per_partition {
             if buffered.len() >= max {
@@ -426,6 +432,12 @@ impl<TPayload> BufferedMessages<TPayload> {
     /// Return the message at the given offset or None if it is not found in the buffer.
     /// Messages up to the offset for the given partition are removed.
     pub fn pop(&mut self, partition: &Partition, offset: u64) -> Option<BrokerMessage<TPayload>> {
+        // Number of partitions in the buffer map
+        gauge!(
+            "arroyo.consumer.dlq_buffer.assigned_partitions",
+            self.buffered_messages.len() as u64,
+        );
+
         let messages = self.buffered_messages.get_mut(partition)?;
         while let Some(message) = messages.front() {
             match message.offset.cmp(&offset) {

--- a/rust-arroyo/src/processing/dlq.rs
+++ b/rust-arroyo/src/processing/dlq.rs
@@ -418,7 +418,7 @@ impl<TPayload> BufferedMessages<TPayload> {
 
         gauge!(
             "Number of elements that can be held in buffer deque without reallocating",
-            buffered.capacity()
+            buffered.capacity() as u64
         );
     }
 
@@ -432,7 +432,7 @@ impl<TPayload> BufferedMessages<TPayload> {
                     let first = messages.pop_front();
                     gauge!(
                         "Number of elements that can be held in buffer deque without reallocating",
-                        messages.capacity()
+                        messages.capacity() as u64
                     );
                     return first;
                 }
@@ -443,7 +443,7 @@ impl<TPayload> BufferedMessages<TPayload> {
                     messages.pop_front();
                     gauge!(
                         "Number of elements that can be held in buffer deque without reallocating",
-                        messages.capacity()
+                        messages.capacity() as u64
                     );
                 }
             };


### PR DESCRIPTION
We can also measure the length of the queue, but as far as I can tell `VecDeque` only really has the `capacity()` function. 

If we see this metric drop to 0 and then spike up to a new very high value, we would be able to detect the scenario where the buffer is being reallocated. Not sure if we need anything more complicated than this since we have the mutable buffer being accessed in both of these functions anyways and we can just check in these functions. 

Also tracks the number of partitions in the BTreeMap 