### PR TITLE
Remove non-existent @getsentry/processing from CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,2 @@
 * @getsentry/owners-snuba @getsentry/ops
-/rust-arroyo @getsentry/owners-snuba @getsentry/ops @getsentry/processing
+/rust-arroyo @getsentry/owners-snuba @getsentry/ops


### PR DESCRIPTION
`@getsentry/processing` no longer exists and it showed the following error in the CODEOWNERS:

![Screenshot 2024-09-11 at 11 35 25 AM](https://github.com/user-attachments/assets/c35435ea-cb28-4bba-a1c4-817245701ae9)

The same team was removed from Snuba's codeowners previously: https://github.com/getsentry/snuba/pull/6259#discussion_r1741202790 