### PR TITLE
ref(rust/run_task): Remove unnecessary boxing, make FnMut, change return type

### DIFF
--- a/rust-arroyo/examples/transform_and_produce.rs
+++ b/rust-arroyo/examples/transform_and_produce.rs
@@ -14,12 +14,14 @@ use rust_arroyo::processing::strategies::produce::Produce;
 use rust_arroyo::processing::strategies::run_task::RunTask;
 use rust_arroyo::processing::strategies::run_task_in_threads::ConcurrencyConfig;
 use rust_arroyo::processing::strategies::{
-    InvalidMessage, ProcessingStrategy, ProcessingStrategyFactory,
+    ProcessingStrategy, ProcessingStrategyFactory, SubmitError,
 };
 use rust_arroyo::processing::StreamProcessor;
 use rust_arroyo::types::{Message, Topic, TopicOrPartition};
 
-fn reverse_string(message: Message<KafkaPayload>) -> Result<Message<KafkaPayload>, InvalidMessage> {
+fn reverse_string(
+    message: Message<KafkaPayload>,
+) -> Result<Message<KafkaPayload>, SubmitError<KafkaPayload>> {
     let value = message.payload();
     let payload = value.payload().unwrap();
     let str_payload = std::str::from_utf8(payload).unwrap();

--- a/rust-arroyo/src/processing/dlq.rs
+++ b/rust-arroyo/src/processing/dlq.rs
@@ -32,7 +32,7 @@ pub trait DlqProducer<TPayload>: Send + Sync {
 }
 
 // Drops all invalid messages. Produce returns an immediately resolved future.
-struct NoopDlqProducer {}
+pub struct NoopDlqProducer;
 
 impl<TPayload: Send + Sync + 'static> DlqProducer<TPayload> for NoopDlqProducer {
     fn produce(

--- a/rust-arroyo/src/processing/strategies/commit_offsets.rs
+++ b/rust-arroyo/src/processing/strategies/commit_offsets.rs
@@ -95,7 +95,6 @@ mod tests {
     #[test]
     fn test_commit_offsets() {
         tracing_subscriber::fmt().with_test_writer().init();
-        let updater = coarsetime::Updater::new(10).start().unwrap();
 
         let partition1 = Partition::new(Topic::new("noop-commit"), 0);
         let partition2 = Partition::new(Topic::new("noop-commit"), 1);

--- a/rust-arroyo/src/processing/strategies/commit_offsets.rs
+++ b/rust-arroyo/src/processing/strategies/commit_offsets.rs
@@ -95,6 +95,7 @@ mod tests {
     #[test]
     fn test_commit_offsets() {
         tracing_subscriber::fmt().with_test_writer().init();
+        let _updater = coarsetime::Updater::new(10).start().unwrap();
 
         let partition1 = Partition::new(Topic::new("noop-commit"), 0);
         let partition2 = Partition::new(Topic::new("noop-commit"), 1);

--- a/rust-arroyo/src/processing/strategies/mod.rs
+++ b/rust-arroyo/src/processing/strategies/mod.rs
@@ -16,6 +16,12 @@ pub enum SubmitError<T> {
     InvalidMessage(InvalidMessage),
 }
 
+impl<T> From<MessageRejected<T>> for SubmitError<T> {
+    fn from(other: MessageRejected<T>) -> Self {
+        SubmitError::MessageRejected(other)
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct MessageRejected<T> {
     pub message: Message<T>,

--- a/rust-arroyo/src/processing/strategies/run_task.rs
+++ b/rust-arroyo/src/processing/strategies/run_task.rs
@@ -5,38 +5,32 @@ use crate::processing::strategies::{
 use crate::types::Message;
 use std::time::Duration;
 
-type Function<TPayload, TTransformed> = dyn Fn(Message<TPayload>) -> Result<Message<TTransformed>, InvalidMessage>
-    + Send
-    + Sync
-    + 'static;
-
-pub struct RunTask<TPayload, TTransformed> {
-    pub function: Box<Function<TPayload, TTransformed>>,
-    pub next_step: Box<dyn ProcessingStrategy<TTransformed>>,
+pub struct RunTask<TTransformed, F, N> {
+    pub function: F,
+    pub next_step: N,
     pub message_carried_over: Option<Message<TTransformed>>,
     pub commit_request_carried_over: Option<CommitRequest>,
 }
 
-impl<TPayload, TTransformed> RunTask<TPayload, TTransformed> {
-    pub fn new<N, F>(function: F, next_step: N) -> Self
-    where
-        N: ProcessingStrategy<TTransformed> + 'static,
-        F: Fn(Message<TPayload>) -> Result<Message<TTransformed>, InvalidMessage>
-            + Send
-            + Sync
-            + 'static,
-    {
+impl<TTransformed, F, N> RunTask<TTransformed, F, N> {
+    pub fn new(function: F, next_step: N) -> Self {
         Self {
-            function: Box::new(function),
-            next_step: Box::new(next_step),
+            function,
+            next_step,
             message_carried_over: None,
             commit_request_carried_over: None,
         }
     }
 }
 
-impl<TPayload, TTransformed: Send + Sync> ProcessingStrategy<TPayload>
-    for RunTask<TPayload, TTransformed>
+impl<TPayload, TTransformed, F, N> ProcessingStrategy<TPayload> for RunTask<TTransformed, F, N>
+where
+    TTransformed: Send + Sync,
+    F: FnMut(Message<TPayload>) -> Result<Message<TTransformed>, InvalidMessage>
+        + Send
+        + Sync
+        + 'static,
+    N: ProcessingStrategy<TTransformed> + 'static,
 {
     fn poll(&mut self) -> Result<Option<CommitRequest>, StrategyError> {
         match self.next_step.poll() {


### PR DESCRIPTION
This will allow you to use mutable state from within RunTask where
previously one couldn't, and remove some boilerplate

Also fix a warning drive-by.
