### PR TITLE
fix: avoid partition revocation on paused consumers

### DIFF
--- a/arroyo/processing/processor.py
+++ b/arroyo/processing/processor.py
@@ -435,6 +435,10 @@ class StreamProcessor(Generic[TStrategyPayload]):
                         self.__consumer.pause([*self.__consumer.tell().keys()])
                         self.__is_paused = True
 
+                    elif self.__is_paused:
+                        # A paused consumer should still poll periodically to avoid it's partitions
+                        # getting revoked by the broker after reaching thte max.poll.interval.ms
+                        self.__consumer.poll(0.1)
                     else:
                         time.sleep(0.01)
 


### PR DESCRIPTION
it is valid for consumers to be paused for periods of time that exceed the max.poll.interval.ms.

we need to continue polling the consumer in this scenario so that the partitions do not get revoked.

librdkafka will not yield any new messages when polling a paused consumer