### PR TITLE
metric: Add partition tag to DLQ buffer capacity metric

### DIFF
--- a/rust-arroyo/src/processing/dlq.rs
+++ b/rust-arroyo/src/processing/dlq.rs
@@ -1,10 +1,9 @@
-use std::borrow::Borrow;
 use std::cmp::Ordering;
 use std::collections::{BTreeMap, HashMap, VecDeque};
+use std::fmt;
 use std::future::Future;
 use std::pin::Pin;
 use std::sync::Arc;
-use std::{clone, fmt};
 
 use tokio::runtime::Handle;
 use tokio::task::JoinHandle;

--- a/rust-arroyo/src/processing/dlq.rs
+++ b/rust-arroyo/src/processing/dlq.rs
@@ -400,11 +400,11 @@ impl<TPayload> BufferedMessages<TPayload> {
     ///
     /// If the configured `max_per_partition` is `0`, this is a no-op.
     pub fn append(&mut self, message: BrokerMessage<TPayload>) {
+        let partition_index = message.partition.index;
+
         if self.max_per_partition == Some(0) {
             return;
         }
-
-        let cloned = message.clone();
 
         // Number of partitions in the buffer map
         gauge!(
@@ -423,13 +423,13 @@ impl<TPayload> BufferedMessages<TPayload> {
             }
         }
 
-        buffered.push_back(cloned);
+        buffered.push_back(message);
 
         // Number of elements that can be held in buffer deque without reallocating
         gauge!(
             "arroyo.consumer.dlq_buffer.capacity",
             buffered.capacity() as u64,
-            "partition_id" => cloned.partition.index
+            "partition_id" => partition_index
         );
     }
 

--- a/rust-arroyo/src/processing/dlq.rs
+++ b/rust-arroyo/src/processing/dlq.rs
@@ -425,7 +425,8 @@ impl<TPayload> BufferedMessages<TPayload> {
         // Number of elements that can be held in buffer deque without reallocating
         gauge!(
             "arroyo.consumer.dlq_buffer.capacity",
-            buffered.capacity() as u64
+            buffered.capacity() as u64,
+            "partition_id" => message.partition.index
         );
     }
 
@@ -446,7 +447,8 @@ impl<TPayload> BufferedMessages<TPayload> {
 
                     gauge!(
                         "arroyo.consumer.dlq_buffer.capacity",
-                        messages.capacity() as u64
+                        messages.capacity() as u64,
+                        "partition_id" => partition.index
                     );
 
                     return first;
@@ -459,7 +461,8 @@ impl<TPayload> BufferedMessages<TPayload> {
 
                     gauge!(
                         "arroyo.consumer.dlq_buffer.capacity",
-                        messages.capacity() as u64
+                        messages.capacity() as u64,
+                        "partition_id" => partition.index
                     );
                 }
             };

--- a/rust-arroyo/src/processing/dlq.rs
+++ b/rust-arroyo/src/processing/dlq.rs
@@ -1,9 +1,10 @@
+use std::borrow::Borrow;
 use std::cmp::Ordering;
 use std::collections::{BTreeMap, HashMap, VecDeque};
-use std::fmt;
 use std::future::Future;
 use std::pin::Pin;
 use std::sync::Arc;
+use std::{clone, fmt};
 
 use tokio::runtime::Handle;
 use tokio::task::JoinHandle;
@@ -403,6 +404,8 @@ impl<TPayload> BufferedMessages<TPayload> {
             return;
         }
 
+        let cloned = message.clone();
+
         // Number of partitions in the buffer map
         gauge!(
             "arroyo.consumer.dlq_buffer.assigned_partitions",
@@ -420,13 +423,13 @@ impl<TPayload> BufferedMessages<TPayload> {
             }
         }
 
-        buffered.push_back(message);
+        buffered.push_back(cloned);
 
         // Number of elements that can be held in buffer deque without reallocating
         gauge!(
             "arroyo.consumer.dlq_buffer.capacity",
             buffered.capacity() as u64,
-            "partition_id" => message.partition.index
+            "partition_id" => cloned.partition.index
         );
     }
 


### PR DESCRIPTION
This buffer is tracked per partition. Add partition as a tag to see the breakdown.