### PR TITLE
fix(dlq): Set limit correctly if no dlq-topic is configured

### DIFF
--- a/rust-arroyo/src/processing/dlq.rs
+++ b/rust-arroyo/src/processing/dlq.rs
@@ -294,9 +294,11 @@ impl<TPayload: Send + Sync + 'static> DlqPolicyWrapper<TPayload> {
     }
 
     pub fn max_buffered_messages_per_partition(&self) -> Option<usize> {
-        self.inner
-            .as_ref()
-            .and_then(|i| i.dlq_policy.max_buffered_messages_per_partition)
+        match self.inner {
+            // there is no DLQ topic, so we don't need to retain any messages at all
+            None => Some(0),
+            Some(ref i) => i.dlq_policy.max_buffered_messages_per_partition,
+        }
     }
 
     /// Clears the DLQ limits.


### PR DESCRIPTION
When no DLQ topic is configured, arroyo will not create a DLQ policy,
which in turn will leave us with an unbounded DLQ buffer.
