### PR TITLE
fix(dlq): Do not clone the message if the DLQ is disabled.

### DIFF
--- a/rust-arroyo/src/processing/dlq.rs
+++ b/rust-arroyo/src/processing/dlq.rs
@@ -400,7 +400,10 @@ impl<TPayload> BufferedMessages<TPayload> {
     /// Add a message to the buffer.
     ///
     /// If the configured `max_per_partition` is `0`, this is a no-op.
-    pub fn append(&mut self, message: BrokerMessage<TPayload>) {
+    pub fn append(&mut self, message: &BrokerMessage<TPayload>)
+    where
+        TPayload: Clone,
+    {
         let partition_index = message.partition.index;
 
         if self.max_per_partition == Some(0) {
@@ -424,7 +427,7 @@ impl<TPayload> BufferedMessages<TPayload> {
             }
         }
 
-        buffered.push_back(message);
+        buffered.push_back(message.clone());
 
         // Number of elements that can be held in buffer deque without reallocating
         gauge!(
@@ -502,7 +505,7 @@ mod tests {
         };
 
         for i in 0..10 {
-            buffer.append(BrokerMessage {
+            buffer.append(&BrokerMessage {
                 partition,
                 offset: i,
                 payload: i,
@@ -526,7 +529,7 @@ mod tests {
         };
 
         for i in 0..10 {
-            buffer.append(BrokerMessage {
+            buffer.append(&BrokerMessage {
                 partition,
                 offset: i,
                 payload: i,
@@ -549,7 +552,7 @@ mod tests {
         };
 
         for i in 0..10 {
-            buffer.append(BrokerMessage {
+            buffer.append(&BrokerMessage {
                 partition,
                 offset: i,
                 payload: i,

--- a/rust-arroyo/src/processing/mod.rs
+++ b/rust-arroyo/src/processing/mod.rs
@@ -269,11 +269,10 @@ impl<TPayload: Clone + Send + Sync + 'static> StreamProcessor<TPayload> {
                     );
 
                     if let Some(broker_msg) = msg {
+                        self.buffered_messages.append(&broker_msg);
                         self.message = Some(Message {
-                            inner_message: InnerMessage::BrokerMessage(broker_msg.clone()),
+                            inner_message: InnerMessage::BrokerMessage(broker_msg),
                         });
-
-                        self.buffered_messages.append(broker_msg);
                     }
                 }
                 Err(err) => {


### PR DESCRIPTION
If the DLQ is disabled, we can save cloning of the message entirely,
saving 1 allocation
