### PR TITLE
ref(dlq): Move DLQ buffer into DLQ policy

### DIFF
--- a/rust-arroyo/src/processing/dlq.rs
+++ b/rust-arroyo/src/processing/dlq.rs
@@ -701,13 +701,6 @@ mod tests {
         assert!(!state.record_invalid_message(&msg));
     }
 
-    // struct TestFactory {}
-    // impl ProcessingStrategyFactory<String> for TestFactory {
-    //     fn create(&self) -> Box<dyn ProcessingStrategy<String>> {
-    //         Box::new(ProcessingTestStrategy { message: None })
-    //     }
-    // }
-
     #[test]
     fn test_state_with_limited_dlq_policy() {
         let producer = TestDlqProducer::new();

--- a/rust-arroyo/src/processing/dlq.rs
+++ b/rust-arroyo/src/processing/dlq.rs
@@ -501,9 +501,8 @@ mod tests {
     use chrono::Utc;
 
     use crate::processing::strategies::run_task_in_threads::ConcurrencyConfig;
-    use crate::processing::strategies::{ProcessingStrategy, ProcessingStrategyFactory};
     use crate::processing::ConsumerState;
-    use crate::testutils::ProcessingTestStrategy;
+    use crate::testutils::TestFactory;
     use crate::types::Topic;
 
     #[test]
@@ -702,12 +701,12 @@ mod tests {
         assert!(!state.record_invalid_message(&msg));
     }
 
-    struct TestFactory {}
-    impl ProcessingStrategyFactory<String> for TestFactory {
-        fn create(&self) -> Box<dyn ProcessingStrategy<String>> {
-            Box::new(ProcessingTestStrategy { message: None })
-        }
-    }
+    // struct TestFactory {}
+    // impl ProcessingStrategyFactory<String> for TestFactory {
+    //     fn create(&self) -> Box<dyn ProcessingStrategy<String>> {
+    //         Box::new(ProcessingTestStrategy { message: None })
+    //     }
+    // }
 
     #[test]
     fn test_state_with_limited_dlq_policy() {

--- a/rust-arroyo/src/processing/dlq.rs
+++ b/rust-arroyo/src/processing/dlq.rs
@@ -302,6 +302,7 @@ impl<TPayload: Send + Sync + 'static> DlqPolicyWrapper<TPayload> {
 
     pub fn buffered_messages(&mut self) -> Option<&mut BufferedMessages<TPayload>> {
         match self.inner {
+            // If there is no DLQ policy configued, we don't need to maintain a DLQ buffer
             None => None,
             Some(ref mut i) => Some(&mut i.buffered_messages),
         }

--- a/rust-arroyo/src/processing/mod.rs
+++ b/rust-arroyo/src/processing/mod.rs
@@ -11,7 +11,7 @@ use crate::backends::kafka::config::KafkaConfig;
 use crate::backends::kafka::types::KafkaPayload;
 use crate::backends::kafka::KafkaConsumer;
 use crate::backends::{AssignmentCallbacks, CommitOffsets, Consumer, ConsumerError};
-use crate::processing::dlq::{BufferedMessages, DlqPolicy, DlqPolicyWrapper};
+use crate::processing::dlq::{DlqPolicy, DlqPolicyWrapper};
 use crate::processing::strategies::{MessageRejected, StrategyError, SubmitError};
 use crate::types::{InnerMessage, Message, Partition, Topic};
 use crate::utils::timing::Deadline;
@@ -193,7 +193,6 @@ pub struct StreamProcessor<TPayload: Clone> {
     consumer_state: ConsumerState<TPayload>,
     message: Option<Message<TPayload>>,
     processor_handle: ProcessorHandle,
-    buffered_messages: BufferedMessages<TPayload>,
     metrics_buffer: metrics_buffer::MetricsBuffer,
     _time_updater: coarsetime::Updater,
 }
@@ -220,11 +219,6 @@ impl<TPayload: Clone + Send + Sync + 'static> StreamProcessor<TPayload> {
         consumer: Box<dyn Consumer<TPayload, Callbacks<TPayload>>>,
         consumer_state: ConsumerState<TPayload>,
     ) -> Self {
-        let max_buffered_messages_per_partition = consumer_state
-            .locked_state()
-            .dlq_policy
-            .max_buffered_messages_per_partition();
-
         Self {
             consumer,
             consumer_state,
@@ -232,7 +226,6 @@ impl<TPayload: Clone + Send + Sync + 'static> StreamProcessor<TPayload> {
             processor_handle: ProcessorHandle {
                 shutdown_requested: Arc::new(AtomicBool::new(false)),
             },
-            buffered_messages: BufferedMessages::new(max_buffered_messages_per_partition),
             metrics_buffer: metrics_buffer::MetricsBuffer::new(),
             _time_updater: coarsetime::Updater::new(10).start().unwrap(),
         }
@@ -273,7 +266,14 @@ impl<TPayload: Clone + Send + Sync + 'static> StreamProcessor<TPayload> {
                             inner_message: InnerMessage::BrokerMessage(broker_msg.clone()),
                         });
 
-                        self.buffered_messages.append(broker_msg);
+                        if let Some(dlq_buffer) = self
+                            .consumer_state
+                            .locked_state()
+                            .dlq_policy
+                            .buffered_messages()
+                        {
+                            dlq_buffer.append(broker_msg)
+                        }
                     }
                 }
                 Err(err) => {
@@ -302,21 +302,29 @@ impl<TPayload: Clone + Send + Sync + 'static> StreamProcessor<TPayload> {
             Ok(None) => {}
             Ok(Some(request)) => {
                 for (partition, offset) in &request.positions {
-                    self.buffered_messages.pop(partition, offset - 1);
+                    if let Some(dlq_buffer) = consumer_state.dlq_policy.buffered_messages() {
+                        dlq_buffer.pop(partition, offset - 1);
+                    }
                 }
 
                 consumer_state.dlq_policy.flush(&request.positions);
                 self.consumer.commit_offsets(request.positions).unwrap();
             }
             Err(StrategyError::InvalidMessage(e)) => {
-                match self.buffered_messages.pop(&e.partition, e.offset) {
-                    Some(msg) => {
-                        tracing::error!(?e, "Invalid message");
-                        consumer_state.dlq_policy.produce(msg);
+                if let Some(dlq_buffer) = consumer_state.dlq_policy.buffered_messages() {
+                    let message = dlq_buffer.pop(&e.partition, e.offset);
+
+                    match message {
+                        Some(msg) => {
+                            tracing::error!(?e, "Invalid message");
+                            consumer_state.dlq_policy.produce(msg);
+                        }
+                        None => {
+                            tracing::error!("Could not find invalid message in buffer");
+                        }
                     }
-                    None => {
-                        tracing::error!("Could not find invalid message in buffer");
-                    }
+                } else {
+                    tracing::error!(?e, "Invalid message, but no DLQ policy configured");
                 }
             }
 
@@ -392,16 +400,22 @@ impl<TPayload: Clone + Send + Sync + 'static> StreamProcessor<TPayload> {
                     }
                 }
             }
-            Err(SubmitError::InvalidMessage(message)) => {
-                let invalid_message = self
-                    .buffered_messages
-                    .pop(&message.partition, message.offset);
 
-                if let Some(msg) = invalid_message {
-                    tracing::error!(?message, "Invalid message");
-                    consumer_state.dlq_policy.produce(msg);
+            Err(SubmitError::InvalidMessage(e)) => {
+                if let Some(dlq_buffer) = consumer_state.dlq_policy.buffered_messages() {
+                    let message = dlq_buffer.pop(&e.partition, e.offset);
+
+                    match message {
+                        Some(msg) => {
+                            tracing::error!(?e, "Invalid message");
+                            consumer_state.dlq_policy.produce(msg);
+                        }
+                        None => {
+                            tracing::error!("Could not find invalid message in buffer");
+                        }
+                    }
                 } else {
-                    tracing::error!(?message, "Could not retrieve invalid message from buffer");
+                    tracing::error!(?e, "Invalid message, but no DLQ policy configured");
                 }
             }
         }

--- a/rust-arroyo/src/processing/mod.rs
+++ b/rust-arroyo/src/processing/mod.rs
@@ -263,10 +263,6 @@ impl<TPayload: Clone + Send + Sync + 'static> StreamProcessor<TPayload> {
                     );
 
                     if let Some(broker_msg) = msg {
-                        self.message = Some(Message {
-                            inner_message: InnerMessage::BrokerMessage(broker_msg.clone()),
-                        });
-
                         if let Some(dlq_buffer) = self
                             .consumer_state
                             .locked_state()
@@ -275,6 +271,10 @@ impl<TPayload: Clone + Send + Sync + 'static> StreamProcessor<TPayload> {
                         {
                             dlq_buffer.append(&broker_msg)
                         }
+
+                        self.message = Some(Message {
+                            inner_message: InnerMessage::BrokerMessage(broker_msg),
+                        });
                     }
                 }
                 Err(err) => {


### PR DESCRIPTION
The goal of this PR is to make all DLQ buffer management happen through DLQ policy.

Specifically:
- Ensure no DLQ buffer gets created if there is no DLQ policy defined
- Adding, removing messages to/from buffer goes through DLQ policy
- Log better errors if there are Invalid Messages but no DLQ policy defined

The next step after this refactor is to clear DLQ buffer during rebalancing. This refactor makes it so that we can access the DLQ buffer within the `on_assign` or `on_revoke` callbacks. 