### PR TITLE
fix(dlq): Remove from buffer on partition revoke

### DIFF
--- a/rust-arroyo/src/processing/dlq.rs
+++ b/rust-arroyo/src/processing/dlq.rs
@@ -485,9 +485,9 @@ impl<TPayload> BufferedMessages<TPayload> {
         None
     }
 
-    // Clear the buffer. Should be called on rebalance.
-    pub fn reset(&mut self) {
-        self.buffered_messages.clear();
+    /// Wipe one partition from the buffer, as part of rebalancing.
+    pub fn remove(&mut self, partition: &Partition) {
+        self.buffered_messages.remove(partition);
     }
 }
 

--- a/rust-arroyo/src/processing/mod.rs
+++ b/rust-arroyo/src/processing/mod.rs
@@ -176,6 +176,12 @@ impl<TPayload: Send + Sync + 'static> AssignmentCallbacks for Callbacks<TPayload
         self.0.set_paused(false);
         state.clear_backpressure();
 
+        if let Some(dlq_buffer) = state.dlq_policy.buffered_messages() {
+            for partition in &partitions {
+                dlq_buffer.remove(partition);
+            }
+        }
+
         timer!("arroyo.consumer.join.time", start.elapsed_since_recent());
 
         tracing::info!("Partition revocation complete.");


### PR DESCRIPTION
We never actually clear the DLQ buffer if a partition got revoked.

We wanted to release separately from the other recent changes to
DLQ to see the impact in prod.
