### PR TITLE
feat: Initial support for cooperative-sticky rebalancing

### DIFF
--- a/arroyo/backends/kafka/consumer.py
+++ b/arroyo/backends/kafka/consumer.py
@@ -273,7 +273,7 @@ class KafkaConsumer(Consumer[KafkaPayload]):
         def assignment_callback(
             consumer: ConfluentConsumer, partitions: Sequence[ConfluentTopicPartition]
         ) -> None:
-            if not partitions and self.__is_incremental:
+            if not partitions:
                 logger.info("skipping empty assignment")
                 return
 

--- a/arroyo/backends/kafka/consumer.py
+++ b/arroyo/backends/kafka/consumer.py
@@ -161,6 +161,7 @@ class KafkaConsumer(Consumer[KafkaPayload]):
         )
 
         configuration = dict(configuration)
+        self.__assignment_strategy = configuration.get("partition.assignment.strategy")
         auto_offset_reset = configuration.get("auto.offset.reset", "largest")
 
         # This is a special flag that controls the auto offset behavior for
@@ -269,6 +270,10 @@ class KafkaConsumer(Consumer[KafkaPayload]):
         def assignment_callback(
             consumer: ConfluentConsumer, partitions: Sequence[ConfluentTopicPartition]
         ) -> None:
+            if not partitions and self.__assignment_strategy == "cooperative-sticky":
+                logger.info("skipping empty assignment")
+                return
+
             self.__state = KafkaConsumerState.ASSIGNING
 
             try:
@@ -451,12 +456,14 @@ class KafkaConsumer(Consumer[KafkaPayload]):
 
     def __assign(self, offsets: Mapping[Partition, int]) -> None:
         self.__validate_offsets(offsets)
-        self.__consumer.assign(
-            [
-                ConfluentTopicPartition(partition.topic.name, partition.index, offset)
-                for partition, offset in offsets.items()
-            ]
-        )
+        partitions = [
+            ConfluentTopicPartition(partition.topic.name, partition.index, offset)
+            for partition, offset in offsets.items()
+        ]
+        if self.__assignment_strategy == "cooperative-sticky":
+            self.__consumer.incremental_assign(partitions)
+        else:
+            self.__consumer.assign(partitions)
         self.__offsets.update(offsets)
 
     def seek(self, offsets: Mapping[Partition, int]) -> None:

--- a/arroyo/dlq.py
+++ b/arroyo/dlq.py
@@ -315,11 +315,11 @@ class BufferedMessages(Generic[TStrategyPayload]):
 
         return None
 
-    def reset(self) -> None:
+    def remove(self, partition: Partition) -> None:
         """
-        Reset the buffer.
+        Remove a revoked partition from the buffer.
         """
-        self.__buffered_messages = defaultdict(deque)
+        self.__buffered_messages.pop(partition, None)
 
 
 class DlqPolicyWrapper(Generic[TStrategyPayload]):
@@ -343,9 +343,9 @@ class DlqPolicyWrapper(Generic[TStrategyPayload]):
                 ]
             ],
         ] = defaultdict(deque)
-        self.reset_offsets({})
+        self.reset_dlq_limits({})
 
-    def reset_offsets(self, assignment: Mapping[Partition, int]) -> None:
+    def reset_dlq_limits(self, assignment: Mapping[Partition, int]) -> None:
         """
         Called on consumer assignment
         """

--- a/arroyo/processing/processor.py
+++ b/arroyo/processing/processor.py
@@ -250,7 +250,7 @@ class StreamProcessor(Generic[TStrategyPayload]):
                     # ProcessingStrategyFactory that we made in Rust: Remove
                     # create_with_partitions, replace with create +
                     # update_partitions
-                    logger.error(
+                    logger.warning(
                         "Partition assignment while processing strategy active"
                     )
                     _close_strategy()

--- a/arroyo/processing/processor.py
+++ b/arroyo/processing/processor.py
@@ -238,16 +238,23 @@ class StreamProcessor(Generic[TStrategyPayload]):
                 "arroyo.consumer.partitions_assigned.count", len(partitions)
             )
 
-            self.__buffered_messages.reset()
+            current_partitions = dict(self.__consumer.tell())
+            current_partitions.update(partitions)
+
             if self.__dlq_policy:
-                self.__dlq_policy.reset_offsets(partitions)
-            if partitions:
+                self.__dlq_policy.reset_dlq_limits(current_partitions)
+            if current_partitions:
                 if self.__processing_strategy is not None:
-                    logger.exception(
+                    # TODO: for cooperative-sticky rebalancing this can happen
+                    # quite often. we should port the changes to
+                    # ProcessingStrategyFactory that we made in Rust: Remove
+                    # create_with_partitions, replace with create +
+                    # update_partitions
+                    logger.error(
                         "Partition assignment while processing strategy active"
                     )
                     _close_strategy()
-                _create_strategy(partitions)
+                _create_strategy(current_partitions)
 
         @_rdkafka_callback(metrics=self.__metrics_buffer)
         def on_partitions_revoked(partitions: Sequence[Partition]) -> None:
@@ -277,6 +284,9 @@ class StreamProcessor(Generic[TStrategyPayload]):
                         _create_strategy(active_partitions)
                 except RuntimeError:
                     pass
+
+            for partition in partitions:
+                self.__buffered_messages.remove(partition)
 
             # Partition revocation can happen anytime during the consumer lifecycle and happen
             # multiple times. What we want to know is that the consumer is not stuck somewhere.

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,2 @@
 [pytest]
 addopts = --benchmark-disable
-python_files = tests/backends/mixins.py

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,2 +1,3 @@
 [pytest]
 addopts = --benchmark-disable
+python_files = tests/backends/mixins.py

--- a/tests/backends/mixins.py
+++ b/tests/backends/mixins.py
@@ -2,7 +2,7 @@ import time
 import uuid
 from abc import ABC, abstractmethod
 from contextlib import closing
-from typing import ContextManager, Generic, Iterator, Mapping, Optional, Sequence
+from typing import Any, ContextManager, Generic, Iterator, Mapping, Optional, Sequence
 from unittest import mock
 
 import pytest
@@ -14,6 +14,8 @@ from tests.assertions import assert_changes, assert_does_not_change
 
 
 class StreamsTestMixin(ABC, Generic[TStrategyPayload]):
+    incremental_rebalancing = False
+
     @abstractmethod
     def get_topic(self, partitions: int = 1) -> ContextManager[Topic]:
         raise NotImplementedError
@@ -397,6 +399,11 @@ class StreamsTestMixin(ABC, Generic[TStrategyPayload]):
     def test_pause_resume_rebalancing(self) -> None:
         payloads = self.get_payloads()
 
+        consumer_a_on_assign = mock.Mock()
+        consumer_a_on_revoke = mock.Mock()
+        consumer_b_on_assign = mock.Mock()
+        consumer_b_on_revoke = mock.Mock()
+
         with self.get_topic(2) as topic, closing(
             self.get_producer()
         ) as producer, closing(
@@ -408,10 +415,22 @@ class StreamsTestMixin(ABC, Generic[TStrategyPayload]):
                 producer.produce(Partition(topic, i), next(payloads)).result(
                     timeout=5.0
                 )
-                for i in range(2)
+                for i in [0, 1]
             ]
 
-            consumer_a.subscribe([topic])
+            def wait_until_rebalancing(
+                from_consumer: Consumer[Any], to_consumer: Consumer[Any]
+            ) -> None:
+                for _ in range(10):
+                    assert from_consumer.poll(0) is None
+                    if to_consumer.poll(1.0) is not None:
+                        return
+
+                raise RuntimeError("no rebalancing happened")
+
+            consumer_a.subscribe(
+                [topic], on_assign=consumer_a_on_assign, on_revoke=consumer_a_on_revoke
+            )
 
             # It doesn't really matter which message is fetched first -- we
             # just want to know the assignment occurred.
@@ -428,19 +447,69 @@ class StreamsTestMixin(ABC, Generic[TStrategyPayload]):
                 [Partition(topic, 0), Partition(topic, 1)]
             )
 
-            consumer_b.subscribe([topic])
-            for i in range(10):
-                assert consumer_a.poll(0) is None  # attempt to force session timeout
-                if consumer_b.poll(1.0) is not None:
-                    break
-            else:
-                assert False, "rebalance did not occur"
+            consumer_b.subscribe(
+                [topic], on_assign=consumer_b_on_assign, on_revoke=consumer_b_on_revoke
+            )
 
-            # The first consumer should have had its offsets rolled back, as
-            # well as should have had it's partition resumed during
-            # rebalancing.
-            assert consumer_a.paused() == []
-            assert consumer_a.poll(10.0) is not None
+            wait_until_rebalancing(consumer_a, consumer_b)
+
+            if self.incremental_rebalancing:
+                # within incremental rebalancing, only one partition should have been reassigned to the consumer_b, and consumer_a should remain paused
+                assert consumer_a.paused() == [Partition(topic, 1)]
+                assert consumer_a.poll(10.0) is None
+            else:
+                # The first consumer should have had its offsets rolled back, as
+                # well as should have had it's partition resumed during
+                # rebalancing.
+                assert consumer_a.paused() == []
+                assert consumer_a.poll(10.0) is not None
 
             assert len(consumer_a.tell()) == 1
             assert len(consumer_b.tell()) == 1
+
+            (consumer_a_partition,) = consumer_a.tell()
+            (consumer_b_partition,) = consumer_b.tell()
+
+            # Pause consumer_a again.
+            consumer_a.pause(list(consumer_a.tell()))
+            # if we close consumer_a, consumer_b should get all partitions
+            producer.produce(next(iter(consumer_a.tell())), next(payloads)).result(
+                timeout=5.0
+            )
+            consumer_a.unsubscribe()
+            wait_until_rebalancing(consumer_a, consumer_b)
+
+            assert len(consumer_b.tell()) == 2
+
+            if self.incremental_rebalancing:
+
+                assert consumer_a_on_assign.mock_calls == [
+                    mock.call({Partition(topic, 0): 0, Partition(topic, 1): 0}),
+                ]
+                assert consumer_a_on_revoke.mock_calls == [
+                    mock.call([Partition(topic, 0)]),
+                    mock.call([Partition(topic, 1)]),
+                ]
+
+                assert consumer_b_on_assign.mock_calls == [
+                    mock.call({Partition(topic, 0): 0}),
+                    mock.call({Partition(topic, 1): 0}),
+                ]
+                assert consumer_b_on_revoke.mock_calls == []
+            else:
+                assert consumer_a_on_assign.mock_calls == [
+                    mock.call({Partition(topic, 0): 0, Partition(topic, 1): 0}),
+                    mock.call({consumer_a_partition: 0}),
+                ]
+                assert consumer_a_on_revoke.mock_calls == [
+                    mock.call([Partition(topic, 0), Partition(topic, 1)]),
+                    mock.call([consumer_a_partition]),
+                ]
+
+                assert consumer_b_on_assign.mock_calls == [
+                    mock.call({consumer_b_partition: 0}),
+                    mock.call({Partition(topic, 0): 0, Partition(topic, 1): 0}),
+                ]
+                assert consumer_b_on_revoke.mock_calls == [
+                    mock.call([consumer_b_partition])
+                ]

--- a/tests/backends/mixins.py
+++ b/tests/backends/mixins.py
@@ -14,7 +14,7 @@ from tests.assertions import assert_changes, assert_does_not_change
 
 
 class StreamsTestMixin(ABC, Generic[TStrategyPayload]):
-    incremental_rebalancing = False
+    cooperative_sticky = False
 
     @abstractmethod
     def get_topic(self, partitions: int = 1) -> ContextManager[Topic]:
@@ -453,7 +453,7 @@ class StreamsTestMixin(ABC, Generic[TStrategyPayload]):
 
             wait_until_rebalancing(consumer_a, consumer_b)
 
-            if self.incremental_rebalancing:
+            if self.cooperative_sticky:
                 # within incremental rebalancing, only one partition should have been reassigned to the consumer_b, and consumer_a should remain paused
                 assert consumer_a.paused() == [Partition(topic, 1)]
                 assert consumer_a.poll(10.0) is None
@@ -481,7 +481,7 @@ class StreamsTestMixin(ABC, Generic[TStrategyPayload]):
 
             assert len(consumer_b.tell()) == 2
 
-            if self.incremental_rebalancing:
+            if self.cooperative_sticky:
 
                 assert consumer_a_on_assign.mock_calls == [
                     mock.call({Partition(topic, 0): 0, Partition(topic, 1): 0}),

--- a/tests/backends/test_kafka.py
+++ b/tests/backends/test_kafka.py
@@ -257,6 +257,7 @@ class TestKafkaStreams(StreamsTestMixin[KafkaPayload]):
 
 
 class TestKafkaStreamsIncrementalRebalancing(TestKafkaStreams):
+    # re-test the kafka consumer with cooperative-sticky rebalancing
     incremental_rebalancing = True
 
 

--- a/tests/test_dlq.py
+++ b/tests/test_dlq.py
@@ -107,7 +107,7 @@ def test_dlq_policy_wrapper() -> None:
     )
     partition = Partition(topic, 0)
     wrapper = DlqPolicyWrapper(dlq_policy)
-    wrapper.reset_offsets({partition: 0})
+    wrapper.reset_dlq_limits({partition: 0})
     wrapper.MAX_PENDING_FUTURES = 1
     for i in range(10):
         message = BrokerValue(KafkaPayload(None, b"", []), partition, i, datetime.now())
@@ -123,7 +123,7 @@ def test_dlq_policy_wrapper_limit_exceeded() -> None:
     )
     partition = Partition(topic, 0)
     wrapper = DlqPolicyWrapper(dlq_policy)
-    wrapper.reset_offsets({partition: 0})
+    wrapper.reset_dlq_limits({partition: 0})
     wrapper.MAX_PENDING_FUTURES = 1
 
     message = BrokerValue(KafkaPayload(None, b"", []), partition, 1, datetime.now())


### PR DESCRIPTION
Fix one bug in StreamProcessor where it assumed the passed assignments
are replacing the old ones.

Our consumer backends mostly work as-is, and are already passing the
right values in callbacks.
