### PR TITLE
add reject reason to dlq interfaces

### DIFF
--- a/arroyo/dlq.py
+++ b/arroyo/dlq.py
@@ -32,6 +32,11 @@ from arroyo.types import (
 logger = logging.getLogger(__name__)
 
 
+class RejectReason(Enum):
+    INVALID = "invalid"
+    STALE = "stale"
+
+
 class InvalidMessage(Exception):
     """
     InvalidMessage should be raised if a message is not valid for processing and
@@ -44,11 +49,12 @@ class InvalidMessage(Exception):
     """
 
     def __init__(
-        self, partition: Partition, offset: int, needs_commit: bool = True
+        self, partition: Partition, offset: int, needs_commit: bool = True, reason: RejectReason = RejectReason.INVALID,
     ) -> None:
         self.partition = partition
         self.offset = offset
         self.needs_commit = needs_commit
+        self.reason = reason
 
     @classmethod
     def from_value(cls, value: BrokerValue[Any]) -> InvalidMessage:
@@ -177,7 +183,7 @@ class DlqLimitState:
 class DlqProducer(ABC, Generic[TStrategyPayload]):
     @abstractmethod
     def produce(
-        self, value: BrokerValue[TStrategyPayload]
+        self, value: BrokerValue[TStrategyPayload], reason: RejectReason
     ) -> Future[BrokerValue[TStrategyPayload]]:
         """
         Produce a message to DLQ.
@@ -201,7 +207,7 @@ class NoopDlqProducer(DlqProducer[Any]):
     """
 
     def produce(
-        self, value: BrokerValue[KafkaPayload]
+        self, value: BrokerValue[KafkaPayload], reason: RejectReason
     ) -> Future[BrokerValue[KafkaPayload]]:
         future: Future[BrokerValue[KafkaPayload]] = Future()
         future.set_running_or_notify_cancel()
@@ -229,7 +235,9 @@ class KafkaDlqProducer(DlqProducer[KafkaPayload]):
         self.__topic = topic
 
     def produce(
-        self, value: BrokerValue[KafkaPayload]
+        self,
+        value: BrokerValue[KafkaPayload],
+        reason: RejectReason,
     ) -> Future[BrokerValue[KafkaPayload]]:
         value.payload.headers.append(
             ("original_partition", f"{value.partition.index}".encode("utf-8"))
@@ -353,7 +361,7 @@ class DlqPolicyWrapper(Generic[TStrategyPayload]):
             self.__dlq_policy.limit, assignment
         )
 
-    def produce(self, message: BrokerValue[TStrategyPayload]) -> None:
+    def produce(self, message: BrokerValue[TStrategyPayload], reason: RejectReason) -> None:
         """
         Removes all completed futures, then appends the given future to the list.
         Blocks if the list is full. If the DLQ limit is exceeded, an exception is raised.
@@ -371,7 +379,7 @@ class DlqPolicyWrapper(Generic[TStrategyPayload]):
 
         should_accept = self.__dlq_limit_state.record_invalid_message(message)
         if should_accept:
-            future = self.__dlq_policy.producer.produce(message)
+            future = self.__dlq_policy.producer.produce(message, reason)
             self.__futures[message.partition].append((message, future))
         else:
             raise RuntimeError("Dlq limit exceeded")

--- a/arroyo/processing/processor.py
+++ b/arroyo/processing/processor.py
@@ -366,7 +366,7 @@ class StreamProcessor(Generic[TStrategyPayload]):
                 ) from None
 
             # XXX: This blocks if there are more than MAX_PENDING_FUTURES in the queue.
-            self.__dlq_policy.produce(invalid_message)
+            self.__dlq_policy.produce(invalid_message, exc.reason)
 
             self.__metrics_buffer.incr_timing(
                 "arroyo.consumer.dlq.time", time.time() - start_dlq


### PR DESCRIPTION
enables a reason to be passed to the dlq producer as we may want to do different things with the message depending on why it was rejected

right now the motivation is to route stale messages to a separate topic as the malformed or  unprocessable ones