### PR TITLE
perf: invalid message logging configuration

### DIFF
--- a/arroyo/dlq.py
+++ b/arroyo/dlq.py
@@ -44,12 +44,18 @@ class InvalidMessage(Exception):
     """
 
     def __init__(
-        self, partition: Partition, offset: int, needs_commit: bool = True, reason: Optional[str] = None,
+        self,
+        partition: Partition,
+        offset: int,
+        needs_commit: bool = True,
+        reason: Optional[str] = None,
+        log_exception: bool = True
     ) -> None:
         self.partition = partition
         self.offset = offset
         self.needs_commit = needs_commit
         self.reason = reason
+        self.log_exception = log_exception
 
     @classmethod
     def from_value(cls, value: BrokerValue[Any]) -> InvalidMessage:

--- a/arroyo/processing/processor.py
+++ b/arroyo/processing/processor.py
@@ -365,7 +365,8 @@ class StreamProcessor(Generic[TStrategyPayload]):
         ):
             self.__message = None
 
-        logger.exception(exc)
+        if exc.log_exception:
+            logger.exception(exc)
         self.__metrics_buffer.incr_counter("arroyo.consumer.invalid_message.count", 1)
         if self.__dlq_policy:
             start_dlq = time.time()


### PR DESCRIPTION
this enables a user to choose whether an invalid message exception is logged or not

default is unchanged and does log the exception

for stale messages we don't want to log them, we will just reroute to the lowpri topic