### PR TITLE
fix: increase dlq buffer size

### DIFF
--- a/arroyo/dlq.py
+++ b/arroyo/dlq.py
@@ -334,7 +334,7 @@ class DlqPolicyWrapper(Generic[TStrategyPayload]):
         self,
         policy: DlqPolicy[TStrategyPayload],
     ) -> None:
-        self.MAX_PENDING_FUTURES = 1000  # This is a per partition max
+        self.MAX_PENDING_FUTURES = 2000  # This is a per partition max
         self.__dlq_policy = policy
 
         self.__futures: MutableMapping[

--- a/rust-arroyo/src/processing/dlq.rs
+++ b/rust-arroyo/src/processing/dlq.rs
@@ -15,7 +15,7 @@ use crate::gauge;
 use crate::types::{BrokerMessage, Partition, Topic, TopicOrPartition};
 
 // This is a per-partition max
-const MAX_PENDING_FUTURES: usize = 1000;
+const MAX_PENDING_FUTURES: usize = 2000;
 
 pub trait DlqProducer<TPayload>: Send + Sync {
     // Send a message to the DLQ.


### PR DESCRIPTION
for our high throughput consumers (which do >1000 messages/sec), this is too small

it's important not to drop messages as we are going to be using dlq more for stale messages too

fixes SENTRY-FOR-SENTRY-A1Z