### PR TITLE
feat(run_task_in_threads): Allow passing closures to RunTaskInThreads

### DIFF
--- a/rust-arroyo/src/processing/strategies/produce.rs
+++ b/rust-arroyo/src/processing/strategies/produce.rs
@@ -56,7 +56,7 @@ where
     ) -> Self {
         let inner = RunTaskInThreads::new(
             next_step,
-            Box::new(ProduceMessage::new(producer, topic)),
+            ProduceMessage::new(producer, topic),
             concurrency,
             Some("produce"),
         );


### PR DESCRIPTION
Don't require manually implementing TaskRunner, now some closures
implement it too.
