### PR TITLE
fix(inc-1003): use a metric instead of a logline

### DIFF
--- a/rust-arroyo/src/processing/dlq.rs
+++ b/rust-arroyo/src/processing/dlq.rs
@@ -11,8 +11,8 @@ use tokio::task::JoinHandle;
 use crate::backends::kafka::producer::KafkaProducer;
 use crate::backends::kafka::types::KafkaPayload;
 use crate::backends::Producer;
-use crate::gauge;
 use crate::counter;
+use crate::gauge;
 use crate::types::{BrokerMessage, Partition, Topic, TopicOrPartition};
 
 // This is a per-partition max


### PR DESCRIPTION
This causes excessive logging when the buffer starts rejecting many messages, slowing down the consumer
