### PR TITLE
fix(inc-1013): Don't fail the consumer when the DLQ produce fails

### DIFF
--- a/arroyo/processing/processor.py
+++ b/arroyo/processing/processor.py
@@ -377,7 +377,11 @@ class StreamProcessor(Generic[TStrategyPayload]):
                 ) from None
 
             # XXX: This blocks if there are more than MAX_PENDING_FUTURES in the queue.
-            self.__dlq_policy.produce(invalid_message, exc.reason)
+            try:
+                self.__dlq_policy.produce(invalid_message, exc.reason)
+            except Exception as e:
+                logger.exception(f"Failed to produce message (partition: {exc.partition} offset: {exc.offset}) to DLQ topic, dropping")
+                self.__metrics_buffer.incr("arroyo.consumer.dlq.dropped_messages", tags={"partition": exc.partition})
 
             self.__metrics_buffer.incr_timing(
                 "arroyo.consumer.dlq.time", time.time() - start_dlq

--- a/arroyo/processing/processor.py
+++ b/arroyo/processing/processor.py
@@ -84,6 +84,7 @@ ConsumerCounter = Literal[
     "arroyo.consumer.invalid_message.count",
     "arroyo.consumer.pause",
     "arroyo.consumer.resume",
+    "arroyo.consumer.dlq.dropped_messages",
 ]
 
 
@@ -379,9 +380,9 @@ class StreamProcessor(Generic[TStrategyPayload]):
             # XXX: This blocks if there are more than MAX_PENDING_FUTURES in the queue.
             try:
                 self.__dlq_policy.produce(invalid_message, exc.reason)
-            except Exception as e:
+            except Exception:
                 logger.exception(f"Failed to produce message (partition: {exc.partition} offset: {exc.offset}) to DLQ topic, dropping")
-                self.__metrics_buffer.incr("arroyo.consumer.dlq.dropped_messages", tags={"partition": exc.partition})
+                self.__metrics_buffer.incr_counter("arroyo.consumer.dlq.dropped_messages", 1)
 
             self.__metrics_buffer.incr_timing(
                 "arroyo.consumer.dlq.time", time.time() - start_dlq

--- a/arroyo/utils/metric_defs.py
+++ b/arroyo/utils/metric_defs.py
@@ -98,4 +98,8 @@ MetricName = Literal[
     "arroyo.processing.strategies.healthcheck.touch",
     # Counter: Number of messages dropped in the FilterStep strategy
     "arroyo.strategies.filter.dropped_messages",
+
+    # how many messages are dropped due to errors producing to the dlq
+    "arroyo.consumer.dlq.dropped_messages",
+
 ]

--- a/arroyo/utils/metric_defs.py
+++ b/arroyo/utils/metric_defs.py
@@ -98,8 +98,7 @@ MetricName = Literal[
     "arroyo.processing.strategies.healthcheck.touch",
     # Counter: Number of messages dropped in the FilterStep strategy
     "arroyo.strategies.filter.dropped_messages",
-
-    # how many messages are dropped due to errors producing to the dlq
+    # Counter: how many messages are dropped due to errors producing to the dlq
     "arroyo.consumer.dlq.dropped_messages",
 
 ]

--- a/tests/processing/test_processor.py
+++ b/tests/processing/test_processor.py
@@ -583,6 +583,7 @@ def test_dlq() -> None:
     assert dlq_policy.producer.produce.call_count == 1
 
 
+
 def test_healthcheck(tmpdir: py.path.local) -> None:
     """
     Test healthcheck strategy e2e with StreamProcessor, to ensure the


### PR DESCRIPTION
Right now, if the produce fails for any reason, the consumer backlogs, allow graceful degradation instead