### PR TITLE
dlq: Add metrics on DLQ buffer to python-arroyo

### DIFF
--- a/arroyo/dlq.py
+++ b/arroyo/dlq.py
@@ -290,7 +290,7 @@ class BufferedMessages(Generic[TStrategyPayload]):
         ] = defaultdict(deque)
         self.__metrics = get_metrics()
 
-    def report_partition_metrics(self, buffered: Deque[BrokerValue[TStrategyPayload]]):
+    def report_partition_metrics(self, buffered: Deque[BrokerValue[TStrategyPayload]]) -> None:
 
         self.__metrics.gauge("arroyo.consumer.dlq_buffer.len", len(buffered))
 

--- a/arroyo/dlq.py
+++ b/arroyo/dlq.py
@@ -28,6 +28,7 @@ from arroyo.types import (
     TStrategyPayload,
     Value,
 )
+from arroyo.utils.metrics import get_metrics
 
 logger = logging.getLogger(__name__)
 
@@ -287,6 +288,11 @@ class BufferedMessages(Generic[TStrategyPayload]):
         self.__buffered_messages: MutableMapping[
             Partition, Deque[BrokerValue[TStrategyPayload]]
         ] = defaultdict(deque)
+        self.__metrics = get_metrics()
+
+    def report_partition_metrics(self, buffered: Deque[BrokerValue[TStrategyPayload]]):
+
+        self.__metrics.gauge("arroyo.consumer.dlq_buffer.len", len(buffered))
 
     def append(self, message: BrokerValue[TStrategyPayload]) -> None:
         """
@@ -304,6 +310,7 @@ class BufferedMessages(Generic[TStrategyPayload]):
                 buffered.popleft()
 
         self.__buffered_messages[message.partition].append(message)
+        self.report_partition_metrics(message.partition)
 
     def pop(
         self, partition: Partition, offset: int
@@ -317,9 +324,14 @@ class BufferedMessages(Generic[TStrategyPayload]):
 
             while buffered:
                 if buffered[0].offset == offset:
-                    return buffered.popleft()
+                    msg = buffered.popleft()
+                    self.report_partition_metrics(buffered)
+                    return msg
                 if buffered[0].offset > offset:
+                    self.report_partition_metrics(buffered)
                     break
+
+                self.report_partition_metrics(buffered)
                 self.__buffered_messages[partition].popleft()
 
             return None

--- a/arroyo/dlq.py
+++ b/arroyo/dlq.py
@@ -310,7 +310,7 @@ class BufferedMessages(Generic[TStrategyPayload]):
                 buffered.popleft()
 
         self.__buffered_messages[message.partition].append(message)
-        self.report_partition_metrics(message.partition)
+        self.report_partition_metrics(self.__buffered_messages[message.partition])
 
     def pop(
         self, partition: Partition, offset: int

--- a/arroyo/utils/metric_defs.py
+++ b/arroyo/utils/metric_defs.py
@@ -100,5 +100,7 @@ MetricName = Literal[
     "arroyo.strategies.filter.dropped_messages",
     # Counter: how many messages are dropped due to errors producing to the dlq
     "arroyo.consumer.dlq.dropped_messages",
+    # Gauge: Current length of the DLQ buffer deque
+    "arroyo.consumer.dlq_buffer.len"
 
 ]

--- a/arroyo/utils/metric_defs.py
+++ b/arroyo/utils/metric_defs.py
@@ -101,6 +101,5 @@ MetricName = Literal[
     # Counter: how many messages are dropped due to errors producing to the dlq
     "arroyo.consumer.dlq.dropped_messages",
     # Gauge: Current length of the DLQ buffer deque
-    "arroyo.consumer.dlq_buffer.len"
-
+    "arroyo.consumer.dlq_buffer.len",
 ]


### PR DESCRIPTION
We had these in Rust-arroyo but not in python

Add metrics to track the length of the DLQ deque