### PR TITLE
fix(unfold): Do not forward empty committable

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,7 +17,7 @@ repos:
       - id: fix-encoding-pragma
         args: ["--remove"]
   - repo: https://github.com/pycqa/flake8
-    rev: 3.8.4
+    rev: 5.0.4
     hooks:
       - id: flake8
         language_version: python3.12
@@ -42,4 +42,4 @@ repos:
         entry: rustfmt --edition 2021
         files: ^rust-arroyo/.*\.rs$
 default_language_version:
-  python: python3.12
+  python: python3.13

--- a/arroyo/processing/strategies/unfold.py
+++ b/arroyo/processing/strategies/unfold.py
@@ -58,15 +58,16 @@ class Unfold(
             )
             return
 
-        iterable = self.__generator(message.payload)
+        iterable = list(self.__generator(message.payload))
+        num_messages = len(iterable)
 
         store_remaining_messages = False
 
-        for value in iterable:
+        for i, value in enumerate(iterable):
             next_message = Message(value=value)
             # If generator did not provide committable, patch our own
             # committable onto it
-            if not next_message.committable:
+            if i == num_messages - 1 and not next_message.committable:
                 next_message = Message(
                     Value(
                         next_message.payload,

--- a/tests/processing/strategies/test_unfold.py
+++ b/tests/processing/strategies/test_unfold.py
@@ -23,7 +23,9 @@ def test_unfold() -> None:
     strategy.submit(message)
 
     assert next_step.submit.call_args_list == [
-        call(Message(Value(0, {PARTITION: 1}, NOW))),
+        # first message has no committable since the original message has not fully been processed
+        call(Message(Value(0, {}, NOW))),
+        # second message is last message from batch, so we can say the original msg was fully processed
         call(Message(Value(1, {PARTITION: 1}, NOW))),
     ]
 
@@ -44,7 +46,7 @@ def test_message_rejected() -> None:
 
     # Message doesn't actually go through since it was rejected
     assert next_step.submit.call_args_list == [
-        call(Message(Value(0, {PARTITION: 1}, NOW))),
+        call(Message(Value(0, {}, NOW))),
     ]
 
     # clear the side effect, both messages should be submitted now
@@ -53,7 +55,7 @@ def test_message_rejected() -> None:
     strategy.poll()
 
     assert next_step.submit.call_args_list == [
-        call(Message(Value(0, {PARTITION: 1}, NOW))),
+        call(Message(Value(0, {}, NOW))),
         call(Message(Value(1, {PARTITION: 1}, NOW))),
     ]
 

--- a/tests/processing/strategies/test_unfold.py
+++ b/tests/processing/strategies/test_unfold.py
@@ -11,7 +11,7 @@ NOW = datetime.now()
 
 
 def generator(num: int) -> Sequence[Value[int]]:
-    return [Value(i, {PARTITION: i}, NOW) for i in range(num)]
+    return [Value(i, {}, NOW) for i in range(num)]
 
 
 def test_unfold() -> None:
@@ -23,7 +23,7 @@ def test_unfold() -> None:
     strategy.submit(message)
 
     assert next_step.submit.call_args_list == [
-        call(Message(Value(0, {PARTITION: 0}, NOW))),
+        call(Message(Value(0, {PARTITION: 1}, NOW))),
         call(Message(Value(1, {PARTITION: 1}, NOW))),
     ]
 
@@ -44,7 +44,7 @@ def test_message_rejected() -> None:
 
     # Message doesn't actually go through since it was rejected
     assert next_step.submit.call_args_list == [
-        call(Message(Value(0, {PARTITION: 0}, NOW))),
+        call(Message(Value(0, {PARTITION: 1}, NOW))),
     ]
 
     # clear the side effect, both messages should be submitted now
@@ -53,7 +53,7 @@ def test_message_rejected() -> None:
     strategy.poll()
 
     assert next_step.submit.call_args_list == [
-        call(Message(Value(0, {PARTITION: 0}, NOW))),
+        call(Message(Value(0, {PARTITION: 1}, NOW))),
         call(Message(Value(1, {PARTITION: 1}, NOW))),
     ]
 


### PR DESCRIPTION
In https://github.com/getsentry/arroyo/pull/371 we changed the API for
Unfold to allow for custom committable. However, we also made it
mandatory to figure out a committable at all in order for committing to
work.

The callbacks for unfold do not get access to the original committable,
so it's actually not possible to satisfy the 99% usecase with this.

cc @mj0nez
