### PR TITLE
fix: fix logging for dlq buffer exceeded

### DIFF
--- a/arroyo/dlq.py
+++ b/arroyo/dlq.py
@@ -304,8 +304,9 @@ class BufferedMessages(Generic[TStrategyPayload]):
         if self.__dlq_policy.max_buffered_messages_per_partition is not None:
             buffered = self.__buffered_messages[message.partition]
             if len(buffered) >= self.__dlq_policy.max_buffered_messages_per_partition:
-                logger.warning(
-                    f"DLQ buffer exceeded, dropping message on partition {message.partition.index}",
+                self.__metrics.increment(
+                    "arroyo.consumer.dlq_buffer.exceeded",
+                    tags={"partition_id": str(message.partition.index)},
                 )
                 buffered.popleft()
 

--- a/arroyo/utils/metric_defs.py
+++ b/arroyo/utils/metric_defs.py
@@ -102,4 +102,6 @@ MetricName = Literal[
     "arroyo.consumer.dlq.dropped_messages",
     # Gauge: Current length of the DLQ buffer deque
     "arroyo.consumer.dlq_buffer.len",
+    # Counter: Number of times the DLQ buffer size has been exceeded, causing messages to be dropped
+    "arroyo.consumer.dlq_buffer.exceeded",
 ]


### PR DESCRIPTION
the previous way was creating too many logs slowing the consumer down and filling up gcp logs. this is the same as #422 but for python.