### PR TITLE
metric: Track the number of partitions in the DLQ buffer

### DIFF
--- a/arroyo/dlq.py
+++ b/arroyo/dlq.py
@@ -307,6 +307,11 @@ class BufferedMessages(Generic[TStrategyPayload]):
         if self.__dlq_policy is None:
             return
 
+        self.__metrics.gauge(
+            "arroyo.consumer.dlq_buffer.assigned_partitions",
+            len(self.__buffered_messages),
+        )
+
         if self.__dlq_policy.max_buffered_messages_per_partition is not None:
             buffered = self.__buffered_messages[message.partition]
             if len(buffered) >= self.__dlq_policy.max_buffered_messages_per_partition:
@@ -330,6 +335,11 @@ class BufferedMessages(Generic[TStrategyPayload]):
         """
         if self.__dlq_policy is not None:
             buffered = self.__buffered_messages[partition]
+
+            self.__metrics.gauge(
+                "arroyo.consumer.dlq_buffer.assigned_partitions",
+                len(self.__buffered_messages),
+            )
 
             while buffered:
                 if buffered[0].offset == offset:

--- a/arroyo/utils/metric_defs.py
+++ b/arroyo/utils/metric_defs.py
@@ -104,4 +104,6 @@ MetricName = Literal[
     "arroyo.consumer.dlq_buffer.len",
     # Counter: Number of times the DLQ buffer size has been exceeded, causing messages to be dropped
     "arroyo.consumer.dlq_buffer.exceeded",
+    # Gauge: Number of partitions being tracked in the DLQ buffer
+    "arroyo.consumer.dlq_buffer.assigned_partitions"
 ]

--- a/arroyo/utils/metric_defs.py
+++ b/arroyo/utils/metric_defs.py
@@ -105,5 +105,5 @@ MetricName = Literal[
     # Counter: Number of times the DLQ buffer size has been exceeded, causing messages to be dropped
     "arroyo.consumer.dlq_buffer.exceeded",
     # Gauge: Number of partitions being tracked in the DLQ buffer
-    "arroyo.consumer.dlq_buffer.assigned_partitions"
+    "arroyo.consumer.dlq_buffer.assigned_partitions",
 ]


### PR DESCRIPTION
We have this in Rust arroyo