### PR TITLE
fix(unfold): Do not block forever on backpressure

### DIFF
--- a/arroyo/processing/strategies/unfold.py
+++ b/arroyo/processing/strategies/unfold.py
@@ -94,7 +94,7 @@ class Unfold(
                 self.__next_step.submit(message)
                 self.__pending.popleft()
             except MessageRejected:
-                pass
+                break
 
     def poll(self) -> None:
         self.__flush()

--- a/tests/processing/strategies/test_unfold.py
+++ b/tests/processing/strategies/test_unfold.py
@@ -49,6 +49,13 @@ def test_message_rejected() -> None:
         call(Message(Value(0, {}, NOW))),
     ]
 
+    # poll again, to show that it does not block (regression)
+    strategy.poll()
+    assert next_step.submit.call_args_list == [
+        call(Message(Value(0, {}, NOW))),
+        call(Message(Value(0, {}, NOW))),
+    ]
+
     # clear the side effect, both messages should be submitted now
     next_step.submit.reset_mock(side_effect=True)
 


### PR DESCRIPTION
`poll()` can block the main thread when backpressure lasts "forever", such as when unfolding a particularly huge array. Instead, let's exit early and forward the backpressure.