### PR TITLE
ref(produce): Add faster way to produce

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,5 +1,5 @@
 [flake8]
-ignore = E203,E266,E501,W503,W504,W605,E402,E302,E712
+ignore = E203,E266,E501,W503,W504,W605,E402,E302,E712,E704
 max-line-length = 100
 select = B,E,F,W,T4,B9
 exclude = .git

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,7 +17,7 @@ repos:
       - id: fix-encoding-pragma
         args: ["--remove"]
   - repo: https://github.com/pycqa/flake8
-    rev: 5.0.4
+    rev: 7.2.0
     hooks:
       - id: flake8
         language_version: python3.12

--- a/arroyo/backends/abstract.py
+++ b/arroyo/backends/abstract.py
@@ -220,7 +220,7 @@ class SimpleProducerFuture(Generic[T]):
         self.result_exception: Exception | None = None
 
     def done(self) -> bool:
-        return self.result_value is not None and self.result_exception is not None
+        return self.result_value is not None or self.result_exception is not None
 
     def result(self, timeout: float | None = None) -> T:
         if self.result_exception is not None:

--- a/arroyo/backends/abstract.py
+++ b/arroyo/backends/abstract.py
@@ -223,9 +223,6 @@ class SimpleProducerFuture(Generic[T]):
         return self.result_value is not None or self.result_exception is not None
 
     def result(self, timeout: float | None = None) -> T:
-        if self.result_exception is not None:
-            raise self.result_exception
-
         if timeout is not None:
             deadline = time.time() + timeout
         else:
@@ -236,6 +233,8 @@ class SimpleProducerFuture(Generic[T]):
         # the contract. If you really need result with timeout>0, you should
         # use the stdlib future.
         while deadline is None or time.time() < deadline:
+            if self.result_exception is not None:
+                raise self.result_exception
             if self.result_value is not None:
                 return self.result_value
             time.sleep(0.1)

--- a/arroyo/backends/abstract.py
+++ b/arroyo/backends/abstract.py
@@ -220,7 +220,7 @@ class SimpleProducerFuture(Generic[T]):
         self.result_exception: Exception | None = None
 
     def done(self) -> bool:
-        return self.result_value is not None
+        return self.result_value is not None and self.result_exception is not None
 
     def result(self, timeout: float | None = None) -> T:
         if self.result_exception is not None:
@@ -231,6 +231,10 @@ class SimpleProducerFuture(Generic[T]):
         else:
             deadline = None
 
+        # This implementation is bogus and shouldn't be used in production,
+        # only in tests at most. It is only here for the sake of implementing
+        # the contract. If you really need result with timeout>0, you should
+        # use the stdlib future.
         while deadline is None or time.time() < deadline:
             if self.result_value is not None:
                 return self.result_value

--- a/arroyo/processing/processor.py
+++ b/arroyo/processing/processor.py
@@ -144,9 +144,9 @@ class StreamProcessor(Generic[TStrategyPayload]):
         self.__processor_factory = processor_factory
         self.__metrics_buffer = MetricsBuffer()
 
-        self.__processing_strategy: Optional[ProcessingStrategy[TStrategyPayload]] = (
-            None
-        )
+        self.__processing_strategy: Optional[
+            ProcessingStrategy[TStrategyPayload]
+        ] = None
 
         self.__message: Optional[BrokerValue[TStrategyPayload]] = None
 
@@ -381,8 +381,12 @@ class StreamProcessor(Generic[TStrategyPayload]):
             try:
                 self.__dlq_policy.produce(invalid_message, exc.reason)
             except Exception:
-                logger.exception(f"Failed to produce message (partition: {exc.partition} offset: {exc.offset}) to DLQ topic, dropping")
-                self.__metrics_buffer.incr_counter("arroyo.consumer.dlq.dropped_messages", 1)
+                logger.exception(
+                    f"Failed to produce message (partition: {exc.partition} offset: {exc.offset}) to DLQ topic, dropping"
+                )
+                self.__metrics_buffer.incr_counter(
+                    "arroyo.consumer.dlq.dropped_messages", 1
+                )
 
             self.__metrics_buffer.incr_timing(
                 "arroyo.consumer.dlq.time", time.time() - start_dlq

--- a/arroyo/processing/strategies/produce.py
+++ b/arroyo/processing/strategies/produce.py
@@ -1,10 +1,9 @@
 import logging
 import time
 from collections import deque
-from concurrent.futures import Future
 from typing import Deque, Optional, Tuple, Union
 
-from arroyo.backends.abstract import Producer
+from arroyo.backends.abstract import Producer, ProducerFuture
 from arroyo.processing.strategies.abstract import MessageRejected, ProcessingStrategy
 from arroyo.types import (
     BrokerValue,
@@ -52,7 +51,7 @@ class Produce(ProcessingStrategy[Union[FilteredPayload, TStrategyPayload]]):
         self.__queue: Deque[
             Tuple[
                 Message[Union[FilteredPayload, TStrategyPayload]],
-                Optional[Future[BrokerValue[TStrategyPayload]]],
+                Optional[ProducerFuture[BrokerValue[TStrategyPayload]]],
             ]
         ] = deque()
 
@@ -92,7 +91,7 @@ class Produce(ProcessingStrategy[Union[FilteredPayload, TStrategyPayload]]):
         if len(self.__queue) >= self.__max_buffer_size:
             raise MessageRejected
 
-        future: Optional[Future[BrokerValue[TStrategyPayload]]] = None
+        future: Optional[ProducerFuture[BrokerValue[TStrategyPayload]]] = None
 
         if not isinstance(message.payload, FilteredPayload):
             try:

--- a/tests/backends/test_kafka.py
+++ b/tests/backends/test_kafka.py
@@ -132,7 +132,7 @@ class TestKafkaStreams(StreamsTestMixin[KafkaPayload]):
         return KafkaConsumer(configuration)
 
     def get_producer(self) -> KafkaProducer:
-        return KafkaProducer(self.configuration)
+        return KafkaProducer(self.configuration, use_simple_futures=True)
 
     def get_payloads(self) -> Iterator[KafkaPayload]:
         for i in itertools.count():

--- a/tests/backends/test_kafka.py
+++ b/tests/backends/test_kafka.py
@@ -131,8 +131,8 @@ class TestKafkaStreams(StreamsTestMixin[KafkaPayload]):
 
         return KafkaConsumer(configuration)
 
-    def get_producer(self) -> KafkaProducer:
-        return KafkaProducer(self.configuration, use_simple_futures=True)
+    def get_producer(self, use_simple_futures: bool = False) -> KafkaProducer:
+        return KafkaProducer(self.configuration, use_simple_futures=use_simple_futures)
 
     def get_payloads(self) -> Iterator[KafkaPayload]:
         for i in itertools.count():
@@ -150,9 +150,10 @@ class TestKafkaStreams(StreamsTestMixin[KafkaPayload]):
                 assert isinstance(value, BrokerValue)
                 assert value.payload.value == b"0"
 
-    def test_auto_offset_reset_latest(self) -> None:
+    @pytest.mark.parametrize("use_simple_futures", [True, False])
+    def test_auto_offset_reset_latest(self, use_simple_futures: bool) -> None:
         with self.get_topic() as topic:
-            with closing(self.get_producer()) as producer:
+            with closing(self.get_producer(use_simple_futures)) as producer:
                 producer.produce(topic, next(self.get_payloads())).result(5.0)
 
             with closing(self.get_consumer(auto_offset_reset="latest")) as consumer:

--- a/tests/processing/test_processor.py
+++ b/tests/processing/test_processor.py
@@ -583,7 +583,6 @@ def test_dlq() -> None:
     assert dlq_policy.producer.produce.call_count == 1
 
 
-
 def test_healthcheck(tmpdir: py.path.local) -> None:
     """
     Test healthcheck strategy e2e with StreamProcessor, to ensure the


### PR DESCRIPTION
When producing a large amount of messages, it can be that the profile
consists only of `Future()` calls, and most of the time is being spent
on running that ctor.

When you look inside of Future.__init__, all it does is create
threading.Condition so that `result()` can be blocking.

However, in the Produce step, we do not actually need synchronized
access to the future, nor do we need to have a blocking result(). We
only need done() and non-blocking result().

Introduce ab abstract interface for futures that is fulfilled by stdlib
Future() and a new class that does not offer performant result().

The new future type is not enabled by default as we have uses of the
`Producer` in sentry that do use the full `Future` interface (see `SingletonProducer`)