### PR TITLE
inc: Add a unit test that demonstrates InvalidMessage failure mode

### DIFF
--- a/tests/processing/test_processor.py
+++ b/tests/processing/test_processor.py
@@ -657,15 +657,15 @@ def test_processor_pause_with_invalid_message() -> None:
     with assert_changes(lambda: int(consumer.pause.call_count), 0, 1):
         processor._run_once()
         assert strategy.submit.call_args_list[-1] == mock.call(message)
-        assert processor.__message == message.value
+        assert processor.StreamProcessor__message == message.value
 
         with mock.patch("time.time", return_value=time.time() + 5):
             processor._run_once()  # Should pause now
 
     # Consumer is in paused state
-    assert processor.__is_paused is True
+    assert processor.StreamProcessor__is_paused is True  # type: ignore
     # The same rejected message should be carried over
-    assert processor.__message is not None
+    assert processor.StreamProcessor__message is not None  # type: ignore
 
     # All partitions are paused
     consumer.paused.return_value = set(p for p in offsets)
@@ -678,31 +678,31 @@ def test_processor_pause_with_invalid_message() -> None:
     # The next poll returns nothing, but we are still carrying over the rejected message
     processor._run_once()
     assert consumer.poll.return_value is None
-    assert processor.__is_paused is True
-    assert processor.__message is not None
+    assert processor.StreamProcessor__is_paused is True  # type: ignore
+    assert processor.StreamProcessor__message is not None  # type: ignore
 
     # At this point, let's say the message carried over is invalid (e.g. it could be stale)
     strategy.submit.side_effect = InvalidMessage(partition, 0, needs_commit=False)
 
     processor._run_once()
-    assert processor.__is_paused is True
+    assert processor.StreamProcessor__is_paused is True  # type: ignore
     assert consumer.resume.call_count == 0
 
     # The processor no longer has a message to keep track of
     # Now we have no message being carried over
-    assert processor.__message is None
+    assert processor.StreamProcessor__message is None  # type: ignore
 
     # Nothing gets submitted, processor is stuck
     # We ran the processor loop 4 times up to this point
     with assert_does_not_change(lambda: int(strategy.submit.call_count), 4):
         processor._run_once()
 
-    assert processor.__message is None
-    assert processor.__is_paused is True
+    assert processor.StreamProcessor__message is None  # type: ignore
+    assert processor.StreamProcessor__is_paused is True  # type: ignore
     assert consumer.resume.call_count == 0
 
     # Nothing gets submitted, processor is stuck
     with assert_does_not_change(lambda: int(strategy.submit.call_count), 4):
         processor._run_once()
 
-    assert processor.__is_paused == True
+    assert processor.StreamProcessor__is_paused == True  # type: ignore

--- a/tests/processing/test_processor.py
+++ b/tests/processing/test_processor.py
@@ -678,8 +678,8 @@ def test_processor_pause_with_invalid_message() -> None:
     # The next poll returns nothing, but we are still carrying over the rejected message
     processor._run_once()
     assert consumer.poll.return_value is None
-    assert processor._StreamProcessor__is_paused is True
-    assert processor._StreamProcessor__message is not None
+    assert processor.__is_paused is True
+    assert processor.__message is not None
 
     # At this point, let's say the message carried over is invalid (e.g. it could be stale)
     strategy.submit.side_effect = InvalidMessage(partition, 0, needs_commit=False)

--- a/tests/processing/test_processor.py
+++ b/tests/processing/test_processor.py
@@ -657,7 +657,7 @@ def test_processor_pause_with_invalid_message() -> None:
     with assert_changes(lambda: int(consumer.pause.call_count), 0, 1):
         processor._run_once()
         assert strategy.submit.call_args_list[-1] == mock.call(message)
-        assert processor.StreamProcessor__message == message.value
+        assert processor.StreamProcessor__message == message.value  # type: ignore
 
         with mock.patch("time.time", return_value=time.time() + 5):
             processor._run_once()  # Should pause now

--- a/tests/processing/test_processor.py
+++ b/tests/processing/test_processor.py
@@ -657,15 +657,15 @@ def test_processor_pause_with_invalid_message() -> None:
     with assert_changes(lambda: int(consumer.pause.call_count), 0, 1):
         processor._run_once()
         assert strategy.submit.call_args_list[-1] == mock.call(message)
-        assert processor.StreamProcessor__message == message.value  # type: ignore
+        assert processor._StreamProcessor__message == message.value  # type: ignore
 
         with mock.patch("time.time", return_value=time.time() + 5):
             processor._run_once()  # Should pause now
 
     # Consumer is in paused state
-    assert processor.StreamProcessor__is_paused is True  # type: ignore
+    assert processor._StreamProcessor__is_paused is True  # type: ignore
     # The same rejected message should be carried over
-    assert processor.StreamProcessor__message is not None  # type: ignore
+    assert processor._StreamProcessor__message is not None  # type: ignore
 
     # All partitions are paused
     consumer.paused.return_value = set(p for p in offsets)
@@ -678,31 +678,31 @@ def test_processor_pause_with_invalid_message() -> None:
     # The next poll returns nothing, but we are still carrying over the rejected message
     processor._run_once()
     assert consumer.poll.return_value is None
-    assert processor.StreamProcessor__is_paused is True  # type: ignore
-    assert processor.StreamProcessor__message is not None  # type: ignore
+    assert processor._StreamProcessor__is_paused is True  # type: ignore
+    assert processor._StreamProcessor__message is not None  # type: ignore
 
     # At this point, let's say the message carried over is invalid (e.g. it could be stale)
     strategy.submit.side_effect = InvalidMessage(partition, 0, needs_commit=False)
 
     processor._run_once()
-    assert processor.StreamProcessor__is_paused is True  # type: ignore
+    assert processor._StreamProcessor__is_paused is True  # type: ignore
     assert consumer.resume.call_count == 0
 
     # The processor no longer has a message to keep track of
     # Now we have no message being carried over
-    assert processor.StreamProcessor__message is None  # type: ignore
+    assert processor._StreamProcessor__message is None  # type: ignore
 
     # Nothing gets submitted, processor is stuck
     # We ran the processor loop 4 times up to this point
     with assert_does_not_change(lambda: int(strategy.submit.call_count), 4):
         processor._run_once()
 
-    assert processor.StreamProcessor__message is None  # type: ignore
-    assert processor.StreamProcessor__is_paused is True  # type: ignore
+    assert processor._StreamProcessor__message is None  # type: ignore
+    assert processor._StreamProcessor__is_paused is True  # type: ignore
     assert consumer.resume.call_count == 0
 
     # Nothing gets submitted, processor is stuck
     with assert_does_not_change(lambda: int(strategy.submit.call_count), 4):
         processor._run_once()
 
-    assert processor.StreamProcessor__is_paused == True  # type: ignore
+    assert processor._StreamProcessor__is_paused == True  # type: ignore

--- a/tests/processing/test_processor.py
+++ b/tests/processing/test_processor.py
@@ -657,15 +657,12 @@ def test_processor_pause_with_invalid_message() -> None:
     with assert_changes(lambda: int(consumer.pause.call_count), 0, 1):
         processor._run_once()
         assert strategy.submit.call_args_list[-1] == mock.call(message)
-        assert processor._StreamProcessor__message == message.value  # type: ignore
 
         with mock.patch("time.time", return_value=time.time() + 5):
             processor._run_once()  # Should pause now
 
     # Consumer is in paused state
-    assert processor._StreamProcessor__is_paused is True  # type: ignore
     # The same rejected message should be carried over
-    assert processor._StreamProcessor__message is not None  # type: ignore
 
     # All partitions are paused
     consumer.paused.return_value = set(p for p in offsets)
@@ -678,31 +675,25 @@ def test_processor_pause_with_invalid_message() -> None:
     # The next poll returns nothing, but we are still carrying over the rejected message
     processor._run_once()
     assert consumer.poll.return_value is None
-    assert processor._StreamProcessor__is_paused is True  # type: ignore
-    assert processor._StreamProcessor__message is not None  # type: ignore
 
     # At this point, let's say the message carried over is invalid (e.g. it could be stale)
     strategy.submit.side_effect = InvalidMessage(partition, 0, needs_commit=False)
 
     processor._run_once()
-    assert processor._StreamProcessor__is_paused is True  # type: ignore
     assert consumer.resume.call_count == 0
 
     # The processor no longer has a message to keep track of
-    # Now we have no message being carried over
-    assert processor._StreamProcessor__message is None  # type: ignore
+    # Now we have no message being carried over (self.__message = None)
 
     # Nothing gets submitted, processor is stuck
     # We ran the processor loop 4 times up to this point
     with assert_does_not_change(lambda: int(strategy.submit.call_count), 4):
         processor._run_once()
 
-    assert processor._StreamProcessor__message is None  # type: ignore
-    assert processor._StreamProcessor__is_paused is True  # type: ignore
     assert consumer.resume.call_count == 0
 
     # Nothing gets submitted, processor is stuck
     with assert_does_not_change(lambda: int(strategy.submit.call_count), 4):
         processor._run_once()
 
-    assert processor._StreamProcessor__is_paused == True  # type: ignore
+    # And the consumer is still paused

--- a/tests/processing/test_processor.py
+++ b/tests/processing/test_processor.py
@@ -622,3 +622,87 @@ def test_healthcheck(tmpdir: py.path.local) -> None:
 
     processor._run_once()
     assert tmpdir.join("health.txt").mtime() == health_mtime
+
+
+def test_processor_pause_with_invalid_message() -> None:
+
+    topic = Topic("topic")
+
+    consumer = mock.Mock()
+    strategy = mock.Mock()
+    factory = mock.Mock()
+    factory.create_with_partitions.return_value = strategy
+
+    processor: StreamProcessor[int] = StreamProcessor(
+        consumer, topic, factory, IMMEDIATE
+    )
+
+    # Subscribe to topic
+    subscribe_args, subscribe_kwargs = consumer.subscribe.call_args
+    assert subscribe_args[0] == [topic]
+
+    # Partition assignment
+    partition = Partition(topic, 0)
+    consumer.tell.return_value = {}
+    assignment_callback = subscribe_kwargs["on_assign"]
+    offsets = {partition: 0}
+    assignment_callback(offsets)
+
+    # Message that we will get from polling
+    message = Message(BrokerValue(0, partition, 0, datetime.now()))
+
+    # Message will be rejected
+    consumer.poll.return_value = message.value
+    strategy.submit.side_effect = MessageRejected()
+    with assert_changes(lambda: int(consumer.pause.call_count), 0, 1):
+        processor._run_once()
+        assert strategy.submit.call_args_list[-1] == mock.call(message)
+        assert processor._StreamProcessor__message == message.value
+
+        with mock.patch("time.time", return_value=time.time() + 5):
+            processor._run_once()  # Should pause now
+
+    # Consumer is in paused state
+    assert processor._StreamProcessor__is_paused is True
+    # The same rejected message should be carried over
+    assert processor._StreamProcessor__message is not None
+
+    # All partitions are paused
+    consumer.paused.return_value = set(p for p in offsets)
+    # Simulate a continuous backpressure state where messages are being rejected
+    strategy.submit.side_effect = MessageRejected()
+
+    # Simulate Kafka returning nothing since the consumer is paused
+    consumer.poll.return_value = None
+
+    # The next poll returns nothing, but we are still carrying over the rejected message
+    processor._run_once()
+    assert consumer.poll.return_value is None
+    assert processor._StreamProcessor__is_paused is True
+    assert processor._StreamProcessor__message is not None
+
+    # At this point, let's say the message carried over is invalid (e.g. it could be stale)
+    strategy.submit.side_effect = InvalidMessage(partition, 0, needs_commit=False)
+
+    processor._run_once()
+    assert processor._StreamProcessor__is_paused is True
+    assert consumer.resume.call_count == 0
+
+    # The processor no longer has a message to keep track of
+    # Now we have no message being carried over
+    assert processor._StreamProcessor__message is None
+
+    # Nothing gets submitted, processor is stuck
+    # We ran the processor loop 4 times up to this point
+    with assert_does_not_change(lambda: int(strategy.submit.call_count), 4):
+        processor._run_once()
+
+    assert processor._StreamProcessor__message is None
+    assert processor._StreamProcessor__is_paused is True
+    assert consumer.resume.call_count == 0
+
+    # Nothing gets submitted, processor is stuck
+    with assert_does_not_change(lambda: int(strategy.submit.call_count), 4):
+        processor._run_once()
+
+    assert processor._StreamProcessor__is_paused == True

--- a/tests/processing/test_processor.py
+++ b/tests/processing/test_processor.py
@@ -697,3 +697,4 @@ def test_processor_pause_with_invalid_message() -> None:
         processor._run_once()
 
     # And the consumer is still paused
+    assert consumer.resume.call_count == 0

--- a/tests/processing/test_processor.py
+++ b/tests/processing/test_processor.py
@@ -657,15 +657,15 @@ def test_processor_pause_with_invalid_message() -> None:
     with assert_changes(lambda: int(consumer.pause.call_count), 0, 1):
         processor._run_once()
         assert strategy.submit.call_args_list[-1] == mock.call(message)
-        assert processor._StreamProcessor__message == message.value
+        assert processor.__message == message.value
 
         with mock.patch("time.time", return_value=time.time() + 5):
             processor._run_once()  # Should pause now
 
     # Consumer is in paused state
-    assert processor._StreamProcessor__is_paused is True
+    assert processor.__is_paused is True
     # The same rejected message should be carried over
-    assert processor._StreamProcessor__message is not None
+    assert processor.__message is not None
 
     # All partitions are paused
     consumer.paused.return_value = set(p for p in offsets)
@@ -685,24 +685,24 @@ def test_processor_pause_with_invalid_message() -> None:
     strategy.submit.side_effect = InvalidMessage(partition, 0, needs_commit=False)
 
     processor._run_once()
-    assert processor._StreamProcessor__is_paused is True
+    assert processor.__is_paused is True
     assert consumer.resume.call_count == 0
 
     # The processor no longer has a message to keep track of
     # Now we have no message being carried over
-    assert processor._StreamProcessor__message is None
+    assert processor.__message is None
 
     # Nothing gets submitted, processor is stuck
     # We ran the processor loop 4 times up to this point
     with assert_does_not_change(lambda: int(strategy.submit.call_count), 4):
         processor._run_once()
 
-    assert processor._StreamProcessor__message is None
-    assert processor._StreamProcessor__is_paused is True
+    assert processor.__message is None
+    assert processor.__is_paused is True
     assert consumer.resume.call_count == 0
 
     # Nothing gets submitted, processor is stuck
     with assert_does_not_change(lambda: int(strategy.submit.call_count), 4):
         processor._run_once()
 
-    assert processor._StreamProcessor__is_paused == True
+    assert processor.__is_paused == True


### PR DESCRIPTION
If the consumer is paused, and is carrying over a message, and then that same message ends up being Invalid, the consumer gets stuck forever. It never leaves the paused state. 

This unit test demonstrates this failure mode. A following PR will introduce a fix and an adjustment to this unit test. 