### PR TITLE
Limit the confluent library version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,3 @@
-confluent-kafka>=2.7.0
+# It seems 2.10.0 is problematic for the kip 848 tests.
+# It needs some time to be fixed.
+confluent-kafka>=2.7.0,<2.10.0


### PR DESCRIPTION
It sems the recently released confluent-kafka 2.10.0 is breaking
several of our KIP848 tests. 
Limiting the version range while we fix them.
