### PR TITLE
feat: add consumer_member_id to metrics by default

### DIFF
--- a/arroyo/processing/processor.py
+++ b/arroyo/processing/processor.py
@@ -29,7 +29,7 @@ from arroyo.processing.strategies.abstract import (
 )
 from arroyo.types import BrokerValue, Message, Partition, Topic, TStrategyPayload
 from arroyo.utils.logging import handle_internal_error
-from arroyo.utils.metrics import get_consumer_metrics, Tags
+from arroyo.utils.metrics import get_consumer_metrics, Tags, MetricName
 
 logger = logging.getLogger(__name__)
 
@@ -123,15 +123,15 @@ class MetricsBuffer:
         if time.time() - self.__last_record_time > METRICS_FREQUENCY_SEC:
             self.flush()
 
-    def record_timing(self, metric: str, value: Union[int, float], additional_tags: Optional[Tags] = None) -> None:
+    def record_timing(self, metric: MetricName, value: Union[int, float], additional_tags: Optional[Tags] = None) -> None:
         """Record a timing metric with default tags automatically included."""
         self.metrics.timing(metric, value, tags=additional_tags)
 
-    def record_increment(self, metric: str, value: Union[int, float] = 1, additional_tags: Optional[Tags] = None) -> None:
+    def record_increment(self, metric: MetricName, value: Union[int, float] = 1, additional_tags: Optional[Tags] = None) -> None:
         """Record an increment metric with default tags automatically included."""
         self.metrics.increment(metric, value, tags=additional_tags)
 
-    def record_gauge(self, metric: str, value: Union[int, float], additional_tags: Optional[Tags] = None) -> None:
+    def record_gauge(self, metric: MetricName, value: Union[int, float], additional_tags: Optional[Tags] = None) -> None:
         """Record a gauge metric with default tags automatically included."""
         self.metrics.gauge(metric, value, tags=additional_tags)
 

--- a/arroyo/processing/processor.py
+++ b/arroyo/processing/processor.py
@@ -29,7 +29,7 @@ from arroyo.processing.strategies.abstract import (
 )
 from arroyo.types import BrokerValue, Message, Partition, Topic, TStrategyPayload
 from arroyo.utils.logging import handle_internal_error
-from arroyo.utils.metrics import get_consumer_metrics, Tags, MetricName
+from arroyo.utils.metrics import get_consumer_metrics
 
 logger = logging.getLogger(__name__)
 

--- a/arroyo/utils/metrics.py
+++ b/arroyo/utils/metrics.py
@@ -45,6 +45,42 @@ class Metrics(Protocol):
         raise NotImplementedError
 
 
+class ConsumerMetricsWrapper(Metrics):
+    """
+    A wrapper around a metrics backend that automatically adds consumer_member_id
+    to all metrics calls.
+    """
+
+    def __init__(self, metrics: Metrics, consumer_member_id: str) -> None:
+        self.__metrics = metrics
+        self.__consumer_member_id = consumer_member_id
+
+    def _add_consumer_tag(self, tags: Optional[Tags]) -> Tags:
+        """Add consumer_member_id to the provided tags."""
+        consumer_tags = {"consumer_member_id": self.__consumer_member_id}
+        if tags:
+            return {**consumer_tags, **tags}
+        return consumer_tags
+
+    def increment(
+        self,
+        name: MetricName,
+        value: Union[int, float] = 1,
+        tags: Optional[Tags] = None,
+    ) -> None:
+        self.__metrics.increment(name, value, tags=self._add_consumer_tag(tags))
+
+    def gauge(
+        self, name: MetricName, value: Union[int, float], tags: Optional[Tags] = None
+    ) -> None:
+        self.__metrics.gauge(name, value, tags=self._add_consumer_tag(tags))
+
+    def timing(
+        self, name: MetricName, value: Union[int, float], tags: Optional[Tags] = None
+    ) -> None:
+        self.__metrics.timing(name, value, tags=self._add_consumer_tag(tags))
+
+
 class DummyMetricsBackend(Metrics):
     """
     Default metrics backend that does not record anything.
@@ -133,4 +169,12 @@ def get_metrics() -> Metrics:
     return _metrics_backend
 
 
-__all__ = ["configure_metrics", "Metrics", "MetricName"]
+def get_consumer_metrics(consumer_member_id: str) -> Metrics:
+    """
+    Get a metrics backend that automatically adds consumer_member_id to all metrics.
+    """
+    base_metrics = get_metrics()
+    return ConsumerMetricsWrapper(base_metrics, consumer_member_id)
+
+
+__all__ = ["configure_metrics", "Metrics", "MetricName", "Tags", "get_consumer_metrics"]

--- a/tests/utils/test_metrics.py
+++ b/tests/utils/test_metrics.py
@@ -1,8 +1,8 @@
 import pytest
 
-from arroyo.utils.metrics import Gauge, MetricName, configure_metrics, get_metrics
+from arroyo.utils.metrics import Gauge, MetricName, configure_metrics, get_metrics, get_consumer_metrics
 from tests.metrics import Gauge as GaugeCall
-from tests.metrics import TestingMetricsBackend, _TestingMetricsBackend
+from tests.metrics import Increment, Timing, TestingMetricsBackend, _TestingMetricsBackend
 
 
 def test_gauge_simple() -> None:
@@ -31,3 +31,30 @@ def test_configure_metrics() -> None:
     # Can be reset to something else with force
     configure_metrics(_TestingMetricsBackend(), force=True)
     assert get_metrics() != TestingMetricsBackend
+
+
+def test_consumer_metrics_wrapper() -> None:
+    """Test that ConsumerMetricsWrapper automatically adds consumer_member_id to all metrics."""
+    # Reset to a fresh backend
+    backend = _TestingMetricsBackend()
+    configure_metrics(backend, force=True)
+
+    consumer_member_id = "test-consumer-123"
+    consumer_metrics = get_consumer_metrics(consumer_member_id)
+
+    # Test increment
+    consumer_metrics.increment("test.counter", 5, tags={"extra": "tag"})
+
+    # Test gauge
+    consumer_metrics.gauge("test.gauge", 10.5)
+
+    # Test timing
+    consumer_metrics.timing("test.timer", 100, tags={"another": "tag"})
+
+    expected_calls = [
+        Increment("test.counter", 5, {"consumer_member_id": consumer_member_id, "extra": "tag"}),
+        GaugeCall("test.gauge", 10.5, {"consumer_member_id": consumer_member_id}),
+        Timing("test.timer", 100, {"consumer_member_id": consumer_member_id, "another": "tag"}),
+    ]
+
+    assert backend.calls == expected_calls

--- a/tests/utils/test_metrics.py
+++ b/tests/utils/test_metrics.py
@@ -43,18 +43,18 @@ def test_consumer_metrics_wrapper() -> None:
     consumer_metrics = get_consumer_metrics(consumer_member_id)
 
     # Test increment
-    consumer_metrics.increment("test.counter", 5, tags={"extra": "tag"})
+    consumer_metrics.increment("arroyo.consumer.run.count", 5, tags={"extra": "tag"})
 
     # Test gauge
-    consumer_metrics.gauge("test.gauge", 10.5)
+    consumer_metrics.gauge("arroyo.consumer.librdkafka.total_queue_size", 10.5)
 
     # Test timing
-    consumer_metrics.timing("test.timer", 100, tags={"another": "tag"})
+    consumer_metrics.timing("arroyo.consumer.poll.time", 100, tags={"another": "tag"})
 
     expected_calls = [
-        Increment("test.counter", 5, {"consumer_member_id": consumer_member_id, "extra": "tag"}),
-        GaugeCall("test.gauge", 10.5, {"consumer_member_id": consumer_member_id}),
-        Timing("test.timer", 100, {"consumer_member_id": consumer_member_id, "another": "tag"}),
+        Increment("arroyo.consumer.run.count", 5, {"consumer_member_id": consumer_member_id, "extra": "tag"}),
+        GaugeCall("arroyo.consumer.librdkafka.total_queue_size", 10.5, {"consumer_member_id": consumer_member_id}),
+        Timing("arroyo.consumer.poll.time", 100, {"consumer_member_id": consumer_member_id, "another": "tag"}),
     ]
 
     assert backend.calls == expected_calls


### PR DESCRIPTION
# Add consumer_member_id to metrics by default

Fixes #357 

## Summary

This PR automatically adds `consumer_member_id` tags to all consumer-related metrics, improving observability and debugging capabilities in distributed consumer environments.
