### PR TITLE
chore(deps): depend on sentry-core >=0.32

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,14 @@ coarsetime = "0.1.33"
 once_cell = "1.18.0"
 rand = "0.8.5"
 rdkafka = { version = "0.37.0", features = ["cmake-build", "tracing"] }
-sentry = { version = "0.32.0" }
+sentry = { version = "0.41.0", default-features = false, features = [
+    # default features, except `release-health` is disabled
+    "backtrace",
+    "contexts",
+    "debug-images",
+    "panic",
+    "transport",
+] }
 serde = { version = "1.0.137", features = ["derive"] }
 serde_json = "1.0.81"
 thiserror = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ coarsetime = "0.1.33"
 once_cell = "1.18.0"
 rand = "0.8.5"
 rdkafka = { version = "0.37.0", features = ["cmake-build", "tracing"] }
-sentry-core = { version = "0.41.0", features = ["client"] }
+sentry-core = { version = ">=0.32", features = ["client"] }
 serde = { version = "1.0.137", features = ["derive"] }
 serde_json = "1.0.81"
 thiserror = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,14 +21,7 @@ coarsetime = "0.1.33"
 once_cell = "1.18.0"
 rand = "0.8.5"
 rdkafka = { version = "0.37.0", features = ["cmake-build", "tracing"] }
-sentry = { version = "0.41.0", default-features = false, features = [
-    # default features, except `release-health` is disabled
-    "backtrace",
-    "contexts",
-    "debug-images",
-    "panic",
-    "transport",
-] }
+sentry-core = { version = "0.41.0", features = ["client"] }
 serde = { version = "1.0.137", features = ["derive"] }
 serde_json = "1.0.81"
 thiserror = "1.0"

--- a/rust-arroyo/src/backends/kafka/mod.rs
+++ b/rust-arroyo/src/backends/kafka/mod.rs
@@ -18,7 +18,7 @@ use rdkafka::message::{BorrowedMessage, Message};
 use rdkafka::topic_partition_list::{Offset, TopicPartitionList};
 use rdkafka::types::{RDKafkaErrorCode, RDKafkaRespErr};
 use rdkafka::Statistics;
-use sentry::Hub;
+use sentry_core::Hub;
 use std::collections::HashMap;
 use std::collections::HashSet;
 use std::fmt;


### PR DESCRIPTION
This allows us to upgrade the SDK in crates that depend on both the SDK and `arroyo` itself, and not end up with two separate versions in the lockfile and at runtime.
Additionally, we just need to depend on `sentry_core`, as the only functionality we're using here is the `Hub`.

Ref https://github.com/getsentry/snuba/pull/7250