### PR TITLE
fix(slo): Add error codes to producer failure in Rust

### DIFF
--- a/rust-arroyo/src/backends/kafka/errors.rs
+++ b/rust-arroyo/src/backends/kafka/errors.rs
@@ -1,6 +1,7 @@
 use rdkafka::error::{KafkaError, RDKafkaErrorCode};
 
 use crate::backends::ConsumerError;
+use crate::backends::ProducerError;
 
 impl From<KafkaError> for ConsumerError {
     fn from(err: KafkaError) -> Self {
@@ -11,6 +12,25 @@ impl From<KafkaError> for ConsumerError {
                 }
             }
             other => ConsumerError::BrokerError(Box::new(other)),
+        }
+    }
+}
+
+impl From<KafkaError> for ProducerError {
+    fn from(err: KafkaError) -> Self {
+        match err {
+            KafkaError::MessageProduction(_) => {
+                let code = err.rdkafka_error_code().unwrap();
+                ProducerError::MessageProductionFailed { code }
+            }
+            KafkaError::Flush(_) => {
+                let code = err.rdkafka_error_code().unwrap();
+                ProducerError::FlushFailed { code }
+            }
+            other => {
+                let code = other.rdkafka_error_code().unwrap();
+                ProducerError::BrokerError { code }
+            }
         }
     }
 }

--- a/rust-arroyo/src/backends/mod.rs
+++ b/rust-arroyo/src/backends/mod.rs
@@ -1,4 +1,5 @@
 use super::types::{BrokerMessage, Partition, TopicOrPartition};
+use rdkafka::error::RDKafkaErrorCode;
 use std::collections::{HashMap, HashSet};
 use std::time::Duration;
 use thiserror::Error;
@@ -40,6 +41,15 @@ pub enum ConsumerError {
 pub enum ProducerError {
     #[error("The producer errored")]
     ProducerErrorred,
+
+    #[error("Message production failed")]
+    MessageProductionFailed { code: RDKafkaErrorCode },
+
+    #[error("Flush failed")]
+    FlushFailed { code: RDKafkaErrorCode },
+
+    #[error(transparent)]
+    BrokerError { code: RDKafkaErrorCode },
 }
 
 /// This abstracts the committing of partition offsets.

--- a/rust-arroyo/src/processing/strategies/produce.rs
+++ b/rust-arroyo/src/processing/strategies/produce.rs
@@ -40,7 +40,20 @@ impl TaskRunner<KafkaPayload, KafkaPayload, ProducerError> for ProduceMessage {
                     Ok(message)
                 }
                 Err(err) => {
-                    counter!("arroyo.producer.produce_status", 1, "status" => "error");
+                    match err {
+                        ProducerError::BrokerError { code } => {
+                            counter!("arroyo.producer.produce_status", 1, "status" => "error", "code" => code.to_string());
+                        }
+                        ProducerError::MessageProductionFailed { code } => {
+                            counter!("arroyo.producer.produce_status", 1, "status" => "error", "code" => code.to_string());
+                        }
+                        ProducerError::FlushFailed { code } => {
+                            counter!("arroyo.producer.produce_status", 1, "status" => "error", "code" => code.to_string());
+                        }
+                        _ => {
+                            counter!("arroyo.producer.produce_status", 1, "status" => "error", "code" => "unknown");
+                        }
+                    }
                     Err(RunTaskError::Other(err))
                 }
             }


### PR DESCRIPTION
This adds the error codes to the producer failure metric in Rust. Some new producer errors were also
added that explicitly deal with producing (similar to the consumer errors).
