### PR TITLE
fix(produce): Ensure produce waits for buffer flush

### DIFF
--- a/rust-arroyo/src/backends/kafka/errors.rs
+++ b/rust-arroyo/src/backends/kafka/errors.rs
@@ -28,8 +28,12 @@ impl From<KafkaError> for ProducerError {
                 ProducerError::FlushFailed { code }
             }
             other => {
-                let code = other.rdkafka_error_code().unwrap();
-                ProducerError::BrokerError { code }
+                let code = other.rdkafka_error_code();
+                if let Some(code) = code {
+                    ProducerError::BrokerError { code }
+                } else {
+                    ProducerError::KafkaError { error: other }
+                }
             }
         }
     }

--- a/rust-arroyo/src/backends/kafka/errors.rs
+++ b/rust-arroyo/src/backends/kafka/errors.rs
@@ -1,6 +1,7 @@
 use rdkafka::error::{KafkaError, RDKafkaErrorCode};
 
 use crate::backends::ConsumerError;
+use crate::backends::ProducerError;
 
 impl From<KafkaError> for ConsumerError {
     fn from(err: KafkaError) -> Self {
@@ -11,6 +12,25 @@ impl From<KafkaError> for ConsumerError {
                 }
             }
             other => ConsumerError::BrokerError(Box::new(other)),
+        }
+    }
+}
+
+impl From<KafkaError> for ProducerError {
+    fn from(err: KafkaError) -> Self {
+        match err {
+            KafkaError::MessageProduction(_) => {
+                let code = err.rdkafka_error_code().unwrap();
+                ProducerError::MessageProductionFailed { code }
+            }
+            KafkaError::Flush(_) => {
+                let code = err.rdkafka_error_code().unwrap();
+                ProducerError::FlushFailed { code }
+            }
+            other => {
+                let code = other.rdkafka_error_code().unwrap();
+                ProducerError::BrokerError { code }
+            }
         }
     }
 }

--- a/rust-arroyo/src/backends/kafka/types.rs
+++ b/rust-arroyo/src/backends/kafka/types.rs
@@ -1,5 +1,5 @@
 use crate::types::TopicOrPartition;
-use rdkafka::error::KafkaError;
+use rdkafka::error::{KafkaError, RDKafkaErrorCode};
 use rdkafka::message::Headers as _;
 use rdkafka::message::{BorrowedHeaders, Header, OwnedHeaders};
 use rdkafka::producer::BaseRecord;
@@ -61,7 +61,7 @@ struct KafkaPayloadInner {
     pub payload: Option<Vec<u8>>,
 }
 
-type KafkaCallback = Box<Sender<Result<(), KafkaError>>>;
+type KafkaCallback = Box<Sender<Option<RDKafkaErrorCode>>>;
 
 #[derive(Clone, Debug)]
 pub struct KafkaPayload {
@@ -138,7 +138,7 @@ mod tests {
     fn test_kafka_payload() {
         let destination = TopicOrPartition::Topic(Topic::new("test"));
         let p: KafkaPayload = KafkaPayload::new(None, None, None);
-        let (tx, _) = channel::<Result<(), KafkaError>>();
+        let (tx, _) = channel::<Option<RDKafkaErrorCode>>();
         let base_record = p.to_base_record(&destination, Box::new(tx));
         assert_eq!(base_record.topic, "test");
         assert_eq!(base_record.key, None);
@@ -153,7 +153,7 @@ mod tests {
             Some(b"message".to_vec()),
         );
 
-        let (tx, _) = channel::<Result<(), KafkaError>>();
+        let (tx, _) = channel::<Option<RDKafkaErrorCode>>();
         let base_record = p2.to_base_record(&destination, Box::new(tx));
         assert_eq!(base_record.topic, "test");
         assert_eq!(base_record.key, Some(&b"key".to_vec()));

--- a/rust-arroyo/src/backends/local/mod.rs
+++ b/rust-arroyo/src/backends/local/mod.rs
@@ -237,7 +237,7 @@ impl<TPayload: Send + Sync + 'static> Producer<TPayload> for LocalProducer<TPayl
             TopicOrPartition::Topic(t) => {
                 let max_partitions = broker
                     .get_topic_partition_count(t)
-                    .map_err(|_| ProducerError::ProducerErrorred)?;
+                    .map_err(|_| ProducerError::ProducerErrored)?;
                 let partition = thread_rng().gen_range(0..max_partitions);
                 Partition::new(*t, partition)
             }
@@ -246,7 +246,7 @@ impl<TPayload: Send + Sync + 'static> Producer<TPayload> for LocalProducer<TPayl
 
         broker
             .produce(&partition, payload)
-            .map_err(|_| ProducerError::ProducerErrorred)?;
+            .map_err(|_| ProducerError::ProducerErrored)?;
 
         Ok(())
     }

--- a/rust-arroyo/src/backends/mod.rs
+++ b/rust-arroyo/src/backends/mod.rs
@@ -42,6 +42,9 @@ pub enum ProducerError {
     #[error("The producer errored")]
     ProducerErrorred,
 
+    #[error("Produce wait timeout")]
+    ProduceWaitTimeout,
+
     #[error("Message production failed")]
     MessageProductionFailed { code: RDKafkaErrorCode },
 

--- a/rust-arroyo/src/backends/mod.rs
+++ b/rust-arroyo/src/backends/mod.rs
@@ -1,4 +1,5 @@
 use super::types::{BrokerMessage, Partition, TopicOrPartition};
+use rdkafka::error::RDKafkaErrorCode;
 use std::collections::{HashMap, HashSet};
 use std::time::Duration;
 use thiserror::Error;
@@ -40,6 +41,15 @@ pub enum ConsumerError {
 pub enum ProducerError {
     #[error("The producer errored")]
     ProducerErrorred,
+
+    #[error("Message production failed")]
+    MessageProductionFailed { code: RDKafkaErrorCode },
+
+    #[error("Flush failed")]
+    FlushFailed { code: RDKafkaErrorCode },
+
+    #[error(transparent)]
+    BrokerError { code: RDKafkaErrorCode },
 }
 
 /// This abstracts the committing of partition offsets.

--- a/rust-arroyo/src/backends/mod.rs
+++ b/rust-arroyo/src/backends/mod.rs
@@ -1,5 +1,5 @@
 use super::types::{BrokerMessage, Partition, TopicOrPartition};
-use rdkafka::error::RDKafkaErrorCode;
+use rdkafka::error::{KafkaError, RDKafkaErrorCode};
 use std::collections::{HashMap, HashSet};
 use std::time::Duration;
 use thiserror::Error;
@@ -40,7 +40,7 @@ pub enum ConsumerError {
 #[derive(Error, Debug)]
 pub enum ProducerError {
     #[error("The producer errored")]
-    ProducerErrorred,
+    ProducerErrored,
 
     #[error("Produce wait timeout")]
     ProduceWaitTimeout,
@@ -53,6 +53,9 @@ pub enum ProducerError {
 
     #[error(transparent)]
     BrokerError { code: RDKafkaErrorCode },
+
+    #[error(transparent)]
+    KafkaError { error: KafkaError },
 }
 
 /// This abstracts the committing of partition offsets.

--- a/rust-arroyo/src/processing/strategies/produce.rs
+++ b/rust-arroyo/src/processing/strategies/produce.rs
@@ -40,7 +40,20 @@ impl TaskRunner<KafkaPayload, KafkaPayload, ProducerError> for ProduceMessage {
                     Ok(message)
                 }
                 Err(err) => {
-                    counter!("arroyo.producer.produce_status", 1, "status" => "error");
+                    match err {
+                        ProducerError::BrokerError { code } => {
+                            counter!("arroyo.producer.produce_status", 1, "status" => "error", "code" => code.to_string());
+                        }
+                        ProducerError::MessageProductionFailed { code } => {
+                            counter!("arroyo.producer.produce_status", 1, "status" => "error", "code" => code.to_string());
+                        }
+                        ProducerError::FlushFailed { code } => {
+                            counter!("arroyo.producer.produce_status", 1, "status" => "error", "code" => code.to_string());
+                        }
+                        _ => {
+                            counter!("arroyo.producer.produce_status", 1, "status" => "error", "code" => "unknown");
+                        }
+                    }
                     Err(RunTaskError::Other(err))
                 }
             }

--- a/rust-arroyo/src/processing/strategies/produce.rs
+++ b/rust-arroyo/src/processing/strategies/produce.rs
@@ -50,6 +50,13 @@ impl TaskRunner<KafkaPayload, KafkaPayload, ProducerError> for ProduceMessage {
                         ProducerError::FlushFailed { code } => {
                             counter!("arroyo.producer.produce_status", 1, "status" => "error", "code" => code.to_string());
                         }
+                        ProducerError::KafkaError { ref error } => {
+                            if let Some(code) = error.rdkafka_error_code() {
+                                counter!("arroyo.producer.produce_status", 1, "status" => "error", "code" => code.to_string());
+                            } else {
+                                counter!("arroyo.producer.produce_status", 1, "status" => "error", "code" => "unknown");
+                            }
+                        }
                         _ => {
                             counter!("arroyo.producer.produce_status", 1, "status" => "error", "code" => "unknown");
                         }


### PR DESCRIPTION
The rdkafka library has two times when it will return error messages: if the message fails to be added to the produce buffer, and if the message fails to be flushed out of the buffer. Currently only the first case was being handled.

When a message is sent, attach a channel using the `DeliveryOpaque` concept. When the message is flushed from the buffer, the context callback is called. Use that channel to forward on the success or failure to the `send` function.

The `send` function will now wait on the receive channel for the message to be sent. If it takes longer than 5 seconds, a new error `ProduceWaitTimeout` will be sent.

Since this `send` function is already called inside a synchronous thread, this won't block other messages from producing.

Depends on some concepts added in https://github.com/getsentry/arroyo/pull/472
