### PR TITLE
fix(metrics): Log producer metrics in the callback

### DIFF
--- a/rust-arroyo/src/backends/kafka/errors.rs
+++ b/rust-arroyo/src/backends/kafka/errors.rs
@@ -3,6 +3,44 @@ use rdkafka::error::{KafkaError, RDKafkaErrorCode};
 use crate::backends::ConsumerError;
 use crate::backends::ProducerError;
 
+/// Returns a string representation of the KafkaError variant name and any embedded RDKafkaErrorCode
+pub fn get_error_name(error: &KafkaError) -> String {
+    match error {
+        // Variants with RDKafkaErrorCode - include the error code
+        KafkaError::AdminOp(code) => format!("AdminOp({})", code),
+        KafkaError::ConsumerCommit(code) => format!("ConsumerCommit({})", code),
+        KafkaError::ConsumerQueueClose(code) => format!("ConsumerQueueClose({})", code),
+        KafkaError::Flush(code) => format!("Flush({})", code),
+        KafkaError::Global(code) => format!("Global({})", code),
+        KafkaError::GroupListFetch(code) => format!("GroupListFetch({})", code),
+        KafkaError::MessageConsumption(code) => format!("MessageConsumption({})", code),
+        KafkaError::MessageConsumptionFatal(code) => format!("MessageConsumptionFatal({})", code),
+        KafkaError::MessageProduction(code) => format!("MessageProduction({})", code),
+        KafkaError::MetadataFetch(code) => format!("MetadataFetch({})", code),
+        KafkaError::OffsetFetch(code) => format!("OffsetFetch({})", code),
+        KafkaError::SetPartitionOffset(code) => format!("SetPartitionOffset({})", code),
+        KafkaError::StoreOffset(code) => format!("StoreOffset({})", code),
+        KafkaError::Transaction(code) => format!("Transaction({})", code),
+        KafkaError::MockCluster(code) => format!("MockCluster({})", code),
+
+        // Variants without RDKafkaErrorCode - just return variant name
+        KafkaError::AdminOpCreation(_) => "AdminOpCreation".to_string(),
+        KafkaError::Canceled => "Canceled".to_string(),
+        KafkaError::ClientConfig(_, _, _, _) => "ClientConfig".to_string(),
+        KafkaError::ClientCreation(_) => "ClientCreation".to_string(),
+        KafkaError::NoMessageReceived => "NoMessageReceived".to_string(),
+        KafkaError::Nul(_) => "Nul".to_string(),
+        KafkaError::PartitionEOF(_) => "PartitionEOF".to_string(),
+        KafkaError::PauseResume(_) => "PauseResume".to_string(),
+        KafkaError::Rebalance(_) => "Rebalance".to_string(),
+        KafkaError::Seek(_) => "Seek".to_string(),
+        KafkaError::Subscription(_) => "Subscription".to_string(),
+
+        #[allow(unreachable_patterns)]
+        _ => "Unknown".to_string(),
+    }
+}
+
 impl From<KafkaError> for ConsumerError {
     fn from(err: KafkaError) -> Self {
         match err {
@@ -18,19 +56,8 @@ impl From<KafkaError> for ConsumerError {
 
 impl From<KafkaError> for ProducerError {
     fn from(err: KafkaError) -> Self {
-        match err {
-            KafkaError::MessageProduction(_) => {
-                let code = err.rdkafka_error_code().unwrap();
-                ProducerError::MessageProductionFailed { code }
-            }
-            KafkaError::Flush(_) => {
-                let code = err.rdkafka_error_code().unwrap();
-                ProducerError::FlushFailed { code }
-            }
-            other => {
-                let code = other.rdkafka_error_code().unwrap();
-                ProducerError::BrokerError { code }
-            }
+        ProducerError::ProducerFailure {
+            error: get_error_name(&err),
         }
     }
 }

--- a/rust-arroyo/src/backends/local/mod.rs
+++ b/rust-arroyo/src/backends/local/mod.rs
@@ -237,7 +237,7 @@ impl<TPayload: Send + Sync + 'static> Producer<TPayload> for LocalProducer<TPayl
             TopicOrPartition::Topic(t) => {
                 let max_partitions = broker
                     .get_topic_partition_count(t)
-                    .map_err(|_| ProducerError::ProducerErrorred)?;
+                    .map_err(|_| ProducerError::ProducerErrored)?;
                 let partition = thread_rng().gen_range(0..max_partitions);
                 Partition::new(*t, partition)
             }
@@ -246,7 +246,7 @@ impl<TPayload: Send + Sync + 'static> Producer<TPayload> for LocalProducer<TPayl
 
         broker
             .produce(&partition, payload)
-            .map_err(|_| ProducerError::ProducerErrorred)?;
+            .map_err(|_| ProducerError::ProducerErrored)?;
 
         Ok(())
     }

--- a/rust-arroyo/src/backends/mod.rs
+++ b/rust-arroyo/src/backends/mod.rs
@@ -1,5 +1,4 @@
 use super::types::{BrokerMessage, Partition, TopicOrPartition};
-use rdkafka::error::RDKafkaErrorCode;
 use std::collections::{HashMap, HashSet};
 use std::time::Duration;
 use thiserror::Error;
@@ -40,16 +39,10 @@ pub enum ConsumerError {
 #[derive(Error, Debug)]
 pub enum ProducerError {
     #[error("The producer errored")]
-    ProducerErrorred,
+    ProducerErrored,
 
-    #[error("Message production failed")]
-    MessageProductionFailed { code: RDKafkaErrorCode },
-
-    #[error("Flush failed")]
-    FlushFailed { code: RDKafkaErrorCode },
-
-    #[error(transparent)]
-    BrokerError { code: RDKafkaErrorCode },
+    #[error("Producer errored with code")]
+    ProducerFailure { error: String },
 }
 
 /// This abstracts the committing of partition offsets.


### PR DESCRIPTION
Instead of trying to log metrics at the strategy level, instead log the metrics in the Producer.
This has two advantages:
- The Kafka callback can be used to capture all errors
- Metrics will be collected for those producers that don't use the strategy
