### PR TITLE
Add logs to identify paused issue

### DIFF
--- a/arroyo/backends/kafka/consumer.py
+++ b/arroyo/backends/kafka/consumer.py
@@ -316,6 +316,7 @@ class KafkaConsumer(Consumer[KafkaPayload]):
                     on_assign(offsets)
             finally:
                 self.__state = KafkaConsumerState.CONSUMING
+                logger.info("Paused partitions after assignment: %s", self.__paused)
 
         def revocation_callback(
             consumer: ConfluentConsumer, partitions: Sequence[ConfluentTopicPartition]
@@ -353,6 +354,7 @@ class KafkaConsumer(Consumer[KafkaPayload]):
                     self.__paused.discard(partition)
 
                 self.__state = KafkaConsumerState.CONSUMING
+                logger.info("Paused partitions after revocation: %s", self.__paused)
 
         self.__consumer.subscribe(
             [topic.name for topic in topics],


### PR DESCRIPTION
THis is meant to troubleshoot SENTRY-3N9F 

https://sentry.sentry.io/issues/6268915744/?project=1&query=server_name%3Agetsentry-consumer-ingest-events%2A&referrer=issue-stream
All the evidence seems to point to a scenario where we do not cleanup the state of the consumer properly between a partition revocation and partition assignemnts whenm the consumer is paused.

Logs from the issue
```
Aug 8, 7:58:50.629 AM   Caught exception, shutting down...
Aug 8, 7:58:47.495 AM   Member id: 'rdkafka-1e9f43ea-923b-4406-aac2-3a97c7cd8673'
Aug 8, 7:58:47.494 AM   New partitions assigned: {Partition(topic=Topic(name='ingest-occurrences'), index=8): 258338255, Partition(topic=Topic(name='ingest-occurrences'), index=9): 254545584, Partition(topic=Topic(name='ingest-occurrences'), index=10): 266927758}
Aug 8, 7:58:47.484 AM   Partition revocation complete.
Aug 8, 7:58:47.482 AM   <arroyo.processing.strategies.run_task_with_multiprocessing.RunTaskWithMultiprocessing object at 0x790dffc686b0> exited successfully
Aug 8, 7:58:34.097 AM   Waiting for <arroyo.processing.strategies.run_task_with_multiprocessing.RunTaskWithMultiprocessing object at 0x790dffc686b0> to exit...
Aug 8, 7:58:34.097 AM   Member id: 'rdkafka-1e9f43ea-923b-4406-aac2-3a97c7cd8673'
Aug 8, 7:58:34.097 AM   Closing <arroyo.processing.strategies.run_task_with_multiprocessing.RunTaskWithMultiprocessing object at 0x790dffc686b0>...
Aug 8, 7:58:34.096 AM   Partitions to revoke: [Partition(topic=Topic(name='ingest-occurrences'), index=12), Partition(topic=Topic(name='ingest-occurrences'), index=13), Partition(topic=Topic(name='ingest-occurrences'), index=14), Partition(topic=Topic(name='ingest-occurrences'), index=15)]
Aug 8, 7:58:28.902 AM   Member id: 'rdkafka-1e9f43ea-923b-4406-aac2-3a97c7cd8673'
```

The error shows this state at the moment of the exception
```
paused_partitions = [
Partition(topic=Topic(name='ingest-occurrences'), index=13),
Partition(topic=Topic(name='ingest-occurrences'), index=14),
Partition(topic=Topic(name='ingest-occurrences'), index=15),
Partition(topic=Topic(name='ingest-occurrences'), index=12)
]
carried over message for partition 15
```

Which should be impossible as different partitions were assigned before the error.

So this log should at least confirm whether we have a wrong state after partition revocation
