### PR TITLE
fix: retry on COORDINATOR_LOAD_IN_PROGRESS

### DIFF
--- a/arroyo/backends/kafka/consumer.py
+++ b/arroyo/backends/kafka/consumer.py
@@ -163,6 +163,7 @@ class KafkaConsumer(Consumer[KafkaPayload]):
                 KafkaError.NOT_COORDINATOR,
                 KafkaError._WAIT_COORD,
                 KafkaError.STALE_MEMBER_EPOCH,  # kip-848
+                KafkaError.COORDINATOR_LOAD_IN_PROGRESS,
             ),
         )
 


### PR DESCRIPTION
`COORDINATOR_LOAD_IN_PROGRESS` errors were causing some consumer crashes in ST when restarting the kafka cluster.
This error isn't actually something the consumer should care about, so we should retry on it.