### PR TITLE
ref(metrics): Remove Unused `librdkafka` Metrics

### DIFF
--- a/arroyo/backends/kafka/configuration.py
+++ b/arroyo/backends/kafka/configuration.py
@@ -159,27 +159,6 @@ def producer_stats_callback(stats_json: str, producer_name: Optional[str]) -> No
             tags={"producer_name": producer_name_tag},
         )
 
-    if stats.get("msg_size"):
-        metrics.gauge(
-            "arroyo.producer.librdkafka.message_size",
-            stats["msg_size"],
-            tags={"producer_name": producer_name_tag},
-        )
-
-    if stats.get("msg_size_max"):
-        metrics.gauge(
-            "arroyo.producer.librdkafka.message_size_max",
-            stats["msg_size_max"],
-            tags={"producer_name": producer_name_tag},
-        )
-
-    if stats.get("txmsgs"):
-        metrics.gauge(
-            "arroyo.producer.librdkafka.txmsgs",
-            stats["txmsgs"],
-            tags={"producer_name": producer_name_tag},
-        )
-
 
 def build_kafka_producer_configuration(
     default_config: Mapping[str, Any],

--- a/arroyo/backends/kafka/configuration.py
+++ b/arroyo/backends/kafka/configuration.py
@@ -121,33 +121,11 @@ def producer_stats_callback(stats_json: str, producer_name: Optional[str]) -> No
                 tags=broker_tags,
             )
 
-        # Record broker buffer metrics
-        if broker_stats.get("outbuf_cnt"):
-            metrics.gauge(
-                "arroyo.producer.librdkafka.broker_outbuf_requests",
-                broker_stats["outbuf_cnt"],
-                tags=broker_tags,
-            )
-
-        if broker_stats.get("outbuf_msg_cnt"):
-            metrics.gauge(
-                "arroyo.producer.librdkafka.broker_outbuf_messages",
-                broker_stats["outbuf_msg_cnt"],
-                tags=broker_tags,
-            )
-
         # Record broker connection metrics
         if broker_stats.get("connects"):
             metrics.gauge(
                 "arroyo.producer.librdkafka.broker_connects",
                 broker_stats["connects"],
-                tags=broker_tags,
-            )
-
-        if broker_stats.get("disconnects"):
-            metrics.gauge(
-                "arroyo.producer.librdkafka.broker_disconnects",
-                broker_stats["disconnects"],
                 tags=broker_tags,
             )
 

--- a/arroyo/backends/kafka/configuration.py
+++ b/arroyo/backends/kafka/configuration.py
@@ -44,10 +44,8 @@ def build_kafka_configuration(
 
 
 def stats_callback(stats_json: str) -> None:
-    stats = json.loads(stats_json)
-    get_metrics().gauge(
-        "arroyo.consumer.librdkafka.total_queue_size", stats.get("replyq", 0)
-    )
+    # We can keep this for the future
+    pass
 
 
 def producer_stats_callback(stats_json: str, producer_name: Optional[str]) -> None:

--- a/arroyo/backends/kafka/configuration.py
+++ b/arroyo/backends/kafka/configuration.py
@@ -44,8 +44,10 @@ def build_kafka_configuration(
 
 
 def stats_callback(stats_json: str) -> None:
-    # We can keep this for the future
-    pass
+    stats = json.loads(stats_json)
+    get_metrics().gauge(
+        "arroyo.consumer.librdkafka.total_queue_size", stats.get("replyq", 0)
+    )
 
 
 def producer_stats_callback(stats_json: str, producer_name: Optional[str]) -> None:

--- a/arroyo/utils/metric_defs.py
+++ b/arroyo/utils/metric_defs.py
@@ -137,33 +137,15 @@ MetricName = Literal[
     # Gauge: Maximum producer message count from librdkafka statistics
     # Tagged by producer_name
     "arroyo.producer.librdkafka.message_count_max",
-    # Gauge: Producer message size from librdkafka statistics
-    # Tagged by producer_name
-    "arroyo.producer.librdkafka.message_size",
-    # Gauge: Maximum producer message size from librdkafka statistics
-    # Tagged by producer_name
-    "arroyo.producer.librdkafka.message_size_max",
-    # Gauge: Total number of messages transmitted from librdkafka statistics
-    # Tagged by producer_name
-    "arroyo.producer.librdkafka.txmsgs",
     # Gauge: Total number of transmission requests from librdkafka statistics
     # Tagged by broker_id, producer_name
     "arroyo.producer.librdkafka.broker_tx",
     # Gauge: Total number of bytes transmitted from librdkafka statistics
     # Tagged by broker_id, producer_name
     "arroyo.producer.librdkafka.broker_txbytes",
-    # Gauge: Number of requests awaiting transmission to broker from librdkafka statistics
-    # Tagged by broker_id, producer_name
-    "arroyo.producer.librdkafka.broker_outbuf_requests",
-    # Gauge: Number of messages awaiting transmission to broker from librdkafka statistics
-    # Tagged by broker_id, producer_name
-    "arroyo.producer.librdkafka.broker_outbuf_messages",
     # Gauge: Number of connection attempts to broker from librdkafka statistics
     # Tagged by broker_id, producer_name
     "arroyo.producer.librdkafka.broker_connects",
-    # Gauge: Number of disconnections from broker from librdkafka statistics
-    # Tagged by broker_id, producer_name
-    "arroyo.producer.librdkafka.broker_disconnects",
     # Gauge: Total number of transmission errors from librdkafka statistics
     # Tagged by broker_id, producer_name
     "arroyo.producer.librdkafka.broker_txerrs",

--- a/rust-arroyo/src/backends/kafka/mod.rs
+++ b/rust-arroyo/src/backends/kafka/mod.rs
@@ -168,8 +168,21 @@ impl<C: AssignmentCallbacks + Send + Sync> ClientContext for CustomContext<C> {
         })
     }
 
-    fn stats(&self, _stats: Statistics) {
-        // Keep to avoid logging all statistics
+    fn stats(&self, stats: Statistics) {
+        gauge!(
+            "arroyo.consumer.librdkafka.total_queue_size",
+            stats.replyq as u64,
+        );
+        for (topic_name, topic) in stats.topics.iter() {
+            for (partition_num, partition) in topic.partitions.iter() {
+                gauge!(
+                    "arroyo.consumer.librdkafka.fetch_queue_count",
+                    partition.fetchq_cnt as u64,
+                    "topic" => topic_name,
+                    "partition" => partition_num.to_string()
+                );
+            }
+        }
     }
 }
 

--- a/rust-arroyo/src/backends/kafka/mod.rs
+++ b/rust-arroyo/src/backends/kafka/mod.rs
@@ -168,27 +168,8 @@ impl<C: AssignmentCallbacks + Send + Sync> ClientContext for CustomContext<C> {
         })
     }
 
-    fn stats(&self, stats: Statistics) {
-        gauge!(
-            "arroyo.consumer.librdkafka.total_queue_size",
-            stats.replyq as u64,
-        );
-        for (topic_name, topic) in stats.topics.iter() {
-            for (partition_num, partition) in topic.partitions.iter() {
-                gauge!(
-                    "arroyo.consumer.librdkafka.fetch_queue_count",
-                    partition.fetchq_cnt as u64,
-                    "topic" => topic_name,
-                    "partition" => partition_num.to_string()
-                );
-                gauge!(
-                    "arroyo.consumer.librdkafka.fetch_queue_size",
-                    partition.fetchq_size as u64,
-                    "topic" => topic_name,
-                    "partition" => partition_num.to_string()
-                );
-            }
-        }
+    fn stats(&self, _stats: Statistics) {
+        // Keep to avoid logging all statistics
     }
 }
 

--- a/rust-arroyo/src/backends/kafka/producer.rs
+++ b/rust-arroyo/src/backends/kafka/producer.rs
@@ -109,7 +109,7 @@ impl ClientContext for ProducerContext {
                 "producer_name" => producer_name
             );
 
-            // Record broker connection metrics (if available)
+            // Record broker connection metrics if available
             if let Some(connects) = broker_stats.connects {
                 gauge!(
                     "arroyo.producer.librdkafka.broker_connects",

--- a/rust-arroyo/src/backends/kafka/producer.rs
+++ b/rust-arroyo/src/backends/kafka/producer.rs
@@ -147,24 +147,6 @@ impl ClientContext for ProducerContext {
             stats.msg_max as i64,
             "producer_name" => producer_name
         );
-
-        gauge!(
-            "arroyo.producer.librdkafka.message_size",
-            stats.msg_size as i64,
-            "producer_name" => producer_name
-        );
-
-        gauge!(
-            "arroyo.producer.librdkafka.message_size_max",
-            stats.msg_size_max as i64,
-            "producer_name" => producer_name
-        );
-
-        gauge!(
-            "arroyo.producer.librdkafka.txmsgs",
-            stats.txmsgs as i64,
-            "producer_name" => producer_name
-        );
     }
 }
 

--- a/rust-arroyo/src/backends/kafka/producer.rs
+++ b/rust-arroyo/src/backends/kafka/producer.rs
@@ -109,7 +109,7 @@ impl ClientContext for ProducerContext {
                 "producer_name" => producer_name
             );
 
-            // Record broker connection metrics if available
+            // Record broker connection metrics (if available)
             if let Some(connects) = broker_stats.connects {
                 gauge!(
                     "arroyo.producer.librdkafka.broker_connects",

--- a/rust-arroyo/src/backends/kafka/producer.rs
+++ b/rust-arroyo/src/backends/kafka/producer.rs
@@ -109,35 +109,11 @@ impl ClientContext for ProducerContext {
                 "producer_name" => producer_name
             );
 
-            // Record broker buffer metrics
-            gauge!(
-                "arroyo.producer.librdkafka.broker_outbuf_requests",
-                broker_stats.outbuf_cnt as i64,
-                "broker_id" => broker_id_str.clone(),
-                "producer_name" => producer_name
-            );
-
-            gauge!(
-                "arroyo.producer.librdkafka.broker_outbuf_messages",
-                broker_stats.outbuf_msg_cnt as i64,
-                "broker_id" => broker_id_str.clone(),
-                "producer_name" => producer_name
-            );
-
             // Record broker connection metrics (if available)
             if let Some(connects) = broker_stats.connects {
                 gauge!(
                     "arroyo.producer.librdkafka.broker_connects",
                     connects as i64,
-                    "broker_id" => broker_id_str.clone(),
-                    "producer_name" => producer_name
-                );
-            }
-
-            if let Some(disconnects) = broker_stats.disconnects {
-                gauge!(
-                    "arroyo.producer.librdkafka.broker_disconnects",
-                    disconnects as i64,
                     "broker_id" => broker_id_str.clone(),
                     "producer_name" => producer_name
                 );


### PR DESCRIPTION
Completes [STREAM-840](https://linear.app/getsentry/issue/STREAM-840/remove-unused-arroyo-producer-message-metrics) by removing...
* `producer.librdkafka.message_size`
* `producer.librdkafka.message_size_max`
* `producer.librdkafka.txmsgs`

Completes [STREAM-841](https://linear.app/getsentry/issue/STREAM-841/remove-unused-arroyo-producer-broker-metrics) by removing...
* `producer.librdkafka.broker_disconnects`
* `producer.librdkafka.broker_outbuf_requests`
* `producer.librdkafka.broker_outbuf_messages`

Completes [STREAM-842](https://linear.app/getsentry/issue/STREAM-842/remove-arroyo-consumerlibrdkafka-metrics) by removing...
* `arroyo.consumer.librdkafka.fetch_queue_size`

I did not remove...
* `arroyo.consumer.librdkafka.total_queue_size`
* `arroyo.consumer.librdkafka.fetch_queue_count`