### PR TITLE
ref(metrics): remove unused producer broker metrics

### DIFF
--- a/arroyo/backends/kafka/configuration.py
+++ b/arroyo/backends/kafka/configuration.py
@@ -90,29 +90,6 @@ def producer_stats_callback(stats_json: str, producer_name: Optional[str]) -> No
                 tags=broker_tags,
             )
 
-        # Record broker transmission metrics
-        if broker_stats.get("tx"):
-            metrics.gauge(
-                "arroyo.producer.librdkafka.broker_tx",
-                broker_stats["tx"],
-                tags=broker_tags,
-            )
-
-        if broker_stats.get("txbytes"):
-            metrics.gauge(
-                "arroyo.producer.librdkafka.broker_txbytes",
-                broker_stats["txbytes"],
-                tags=broker_tags,
-            )
-
-        # Record broker connection metrics
-        if broker_stats.get("connects"):
-            metrics.gauge(
-                "arroyo.producer.librdkafka.broker_connects",
-                broker_stats["connects"],
-                tags=broker_tags,
-            )
-
         # Record broker transmission error metrics
         if broker_stats.get("txerrs"):
             metrics.gauge(

--- a/arroyo/utils/metric_defs.py
+++ b/arroyo/utils/metric_defs.py
@@ -128,15 +128,6 @@ MetricName = Literal[
     # Gauge: Maximum producer message count from librdkafka statistics
     # Tagged by producer_name
     "arroyo.producer.librdkafka.message_count_max",
-    # Gauge: Total number of transmission requests from librdkafka statistics
-    # Tagged by broker_id, producer_name
-    "arroyo.producer.librdkafka.broker_tx",
-    # Gauge: Total number of bytes transmitted from librdkafka statistics
-    # Tagged by broker_id, producer_name
-    "arroyo.producer.librdkafka.broker_txbytes",
-    # Gauge: Number of connection attempts to broker from librdkafka statistics
-    # Tagged by broker_id, producer_name
-    "arroyo.producer.librdkafka.broker_connects",
     # Gauge: Total number of transmission errors from librdkafka statistics
     # Tagged by broker_id, producer_name
     "arroyo.producer.librdkafka.broker_txerrs",

--- a/rust-arroyo/src/backends/kafka/producer.rs
+++ b/rust-arroyo/src/backends/kafka/producer.rs
@@ -68,31 +68,6 @@ impl ClientContext for ProducerContext {
                 );
             }
 
-            // Record broker transmission metrics
-            gauge!(
-                "arroyo.producer.librdkafka.broker_tx",
-                broker_stats.tx as i64,
-                "broker_id" => broker_id_str.clone(),
-                "producer_name" => producer_name
-            );
-
-            gauge!(
-                "arroyo.producer.librdkafka.broker_txbytes",
-                broker_stats.txbytes as i64,
-                "broker_id" => broker_id_str.clone(),
-                "producer_name" => producer_name
-            );
-
-            // Record broker connection metrics (if available)
-            if let Some(connects) = broker_stats.connects {
-                gauge!(
-                    "arroyo.producer.librdkafka.broker_connects",
-                    connects as i64,
-                    "broker_id" => broker_id_str.clone(),
-                    "producer_name" => producer_name
-                );
-            }
-
             // Record broker transmission error metrics
             gauge!(
                 "arroyo.producer.librdkafka.broker_txerrs",


### PR DESCRIPTION
Ref https://linear.app/getsentry/issue/STREAM-857/remove-more-unused-producer-broker-metrics

This removes more high-volume unused metrics.
Keeping the broker error/retry metrics around in case those are useful later (and are pretty low-volume).