### PR TITLE
fix(consumer): Don't Crash Rust Consumer on Transport Error

### DIFF
--- a/rust-arroyo/src/backends/kafka/mod.rs
+++ b/rust-arroyo/src/backends/kafka/mod.rs
@@ -81,6 +81,15 @@ impl KafkaConsumerState {
     }
 }
 
+/// Treat `RD_KAFKA_RESP_ERR__TRANSPORT` errors from `librdkafka` like an empty poll the same way Python treats `KafkaError._TRANSPORT`.
+fn kafka_poll_error_is_recoverable_transport(err: &KafkaError) -> bool {
+    matches!(
+        err,
+        KafkaError::MessageConsumption(RDKafkaErrorCode::BrokerTransportFailure)
+            | KafkaError::Global(RDKafkaErrorCode::BrokerTransportFailure)
+    )
+}
+
 fn create_kafka_message(topics: &[Topic], msg: BorrowedMessage) -> BrokerMessage<KafkaPayload> {
     let topic = msg.topic();
     // NOTE: We avoid calling `Topic::new` here, as that uses a lock to intern the `topic` name.
@@ -387,8 +396,17 @@ impl<C: AssignmentCallbacks> ArroyoConsumer<KafkaPayload, C> for KafkaConsumer<C
 
         match res {
             None => Ok(None),
-            Some(res) => {
-                let msg = create_kafka_message(&self.topics, res?);
+
+            Some(Err(err)) if kafka_poll_error_is_recoverable_transport(&err) => {
+                let error: &dyn std::error::Error = &err;
+                tracing::warn!(error, "kafka poll transport error, retrying");
+                Ok(None)
+            }
+
+            Some(Err(err)) => Err(err.into()),
+
+            Some(Ok(msg)) => {
+                let msg = create_kafka_message(&self.topics, msg);
                 self.offset_state
                     .lock()
                     .offsets

--- a/rust-arroyo/src/backends/kafka/mod.rs
+++ b/rust-arroyo/src/backends/kafka/mod.rs
@@ -81,8 +81,8 @@ impl KafkaConsumerState {
     }
 }
 
-/// Treat `RD_KAFKA_RESP_ERR__TRANSPORT` errors from `librdkafka` like an empty poll the same way Python treats `KafkaError._TRANSPORT`.
-fn kafka_poll_error_is_recoverable_transport(err: &KafkaError) -> bool {
+/// Treat recoverable `librdkafka` errors as an empty poll the same way Python treats `KafkaError._TRANSPORT`.
+fn kafka_error_is_recoverable(err: &KafkaError) -> bool {
     matches!(
         err,
         KafkaError::MessageConsumption(RDKafkaErrorCode::BrokerTransportFailure)
@@ -397,9 +397,9 @@ impl<C: AssignmentCallbacks> ArroyoConsumer<KafkaPayload, C> for KafkaConsumer<C
         match res {
             None => Ok(None),
 
-            Some(Err(err)) if kafka_poll_error_is_recoverable_transport(&err) => {
+            Some(Err(err)) if kafka_error_is_recoverable(&err) => {
                 let error: &dyn std::error::Error = &err;
-                tracing::warn!(error, "kafka poll transport error, retrying");
+                tracing::warn!(error, "Kafka poll transport error, retrying...");
                 Ok(None)
             }
 


### PR DESCRIPTION
## Linear
Completes [STREAM-856](https://linear.app/getsentry/issue/STREAM-856/rust-arroyo-consumers-crash-on-transient-errors-during-poll)

## Description
Python and Rust Arroyo consumers handle errors differently during poll.

In Python, consumers raise TransportError if they hit `KafkaError._TRANSPORT` during poll.

https://github.com/getsentry/arroyo/blob/e33f4d6e2612a929c7057b074c9eac6a90f8241e/arroyo/backends/kafka/consumer.py#L501-L502

TransportError is a RecoverableError, so StreamProcessor just swallows the error and goes to the next loop.

https://github.com/getsentry/arroyo/blob/e33f4d6e2612a929c7057b074c9eac6a90f8241e/arroyo/processing/processor.py#L458-L459

Rust doesn't seem to have a concept of recoverable errors, so it just crashes when we hit any error during poll.

https://github.com/getsentry/arroyo/blob/e33f4d6e2612a929c7057b074c9eac6a90f8241e/rust-arroyo/src/processing/mod.rs#L442

We need to update Rust Arroyo to retry / ignore `KafkaError._TRANSPORT`. This PR accomplishes that by checking whether the error is one we consider to be "recoverable", and if it is, we return `Ok(None)`. If it isn't one we consider "recoverable," we return an error as before.