### PR TITLE
feat: Add backpressure metrics to Buffer and RunTask join()

### DIFF
--- a/arroyo/processing/strategies/buffer.py
+++ b/arroyo/processing/strategies/buffer.py
@@ -1,14 +1,6 @@
 import time
 from datetime import datetime
-from typing import (
-    Generic,
-    MutableMapping,
-    Optional,
-    TypeVar,
-    Union,
-    cast,
-    Protocol,
-)
+from typing import Generic, MutableMapping, Optional, Protocol, TypeVar, Union, cast
 
 from arroyo.processing.strategies import MessageRejected, ProcessingStrategy
 from arroyo.types import BaseValue, FilteredPayload, Message, Partition, Value
@@ -187,6 +179,7 @@ class Buffer(
                 self.__flush(force=True)
                 break
             except MessageRejected:
+                self.__metrics.increment("arroyo.strategies.buffer.join.backpressure")
                 pass
 
         self.__next_step.close()

--- a/arroyo/processing/strategies/run_task.py
+++ b/arroyo/processing/strategies/run_task.py
@@ -6,6 +6,7 @@ from typing import Callable, Generic, Optional, TypeVar, Union, cast
 from arroyo.processing.strategies.abstract import MessageRejected, ProcessingStrategy
 from arroyo.processing.strategies.guard import StrategyGuard
 from arroyo.types import FilteredPayload, Message, TStrategyPayload
+from arroyo.utils.metrics import get_metrics
 
 TResult = TypeVar("TResult")
 
@@ -48,6 +49,7 @@ class RunTask(
         self.__next_step = next_step
         self.__better_backpressure = better_backpressure
         self.__message_carried_over: Optional[Message[TResult]] = None
+        self.__metrics = get_metrics()
 
     def submit(
         self, message: Message[Union[FilteredPayload, TStrategyPayload]]
@@ -92,6 +94,9 @@ class RunTask(
                         self.__message_carried_over = None
                         break
                     except MessageRejected:
+                        self.__metrics.increment(
+                            "arroyo.strategies.run_task.join.backpressure"
+                        )
                         pass
 
             remaining = max(deadline - time.time(), 0) if deadline is not None else None

--- a/arroyo/utils/metric_defs.py
+++ b/arroyo/utils/metric_defs.py
@@ -134,4 +134,10 @@ MetricName = Literal[
     # Gauge: Total number of request retries from librdkafka statistics
     # Tagged by broker_id, producer_name
     "arroyo.producer.librdkafka.broker_txretries",
+    # Counter: Incremented when backpressure is hit during join() in the
+    # RunTask strategy (better_backpressure mode).
+    "arroyo.strategies.run_task.join.backpressure",
+    # Counter: Incremented when backpressure is hit during join() in the
+    # Buffer strategy.
+    "arroyo.strategies.buffer.join.backpressure",
 ]


### PR DESCRIPTION
## Summary
- Add `arroyo.strategies.buffer.join.backpressure` counter metric to track backpressure during Buffer's `join()` flush attempts
- Add `arroyo.strategies.run_task.join.backpressure` counter metric to track backpressure during RunTask's `join()` in `better_backpressure` mode

We're seeing some backpressure during rebalancing of process-spans, and realized that we don't know where it's coming from at all.

ref STREAM-881


## Test plan
- [x] Existing tests pass
- [x] Type checking passes

🤖 Generated with [Claude Code](https://claude.ai/code)