### PR TITLE
ref(metrics): remove too_many_handles metric

### DIFF
--- a/rust-arroyo/src/processing/strategies/run_task_in_threads.rs
+++ b/rust-arroyo/src/processing/strategies/run_task_in_threads.rs
@@ -208,7 +208,6 @@ where
         }
 
         if self.handles.len() > self.concurrency {
-            counter!("arroyo.strategies.run_task_in_threads.too_many_handles", 1, "strategy_name" => self.metric_strategy_name);
             return Err(SubmitError::MessageRejected(MessageRejected { message }));
         }
 


### PR DESCRIPTION
I had added this metric in https://github.com/getsentry/arroyo/pull/450  for investigation in INC-1119. It helped in the initial debugging but overall this metric isn't actually that useful in terms of signal, better to just look at the max `snuba.consumer.arroyo.strategies.run_task_in_threads.threads` and backpressure metrics. 