### PR TITLE
feat: Add reason to InvalidMessage

### DIFF
--- a/rust-arroyo/src/processing/dlq.rs
+++ b/rust-arroyo/src/processing/dlq.rs
@@ -13,6 +13,7 @@ use crate::backends::kafka::types::KafkaPayload;
 use crate::backends::Producer;
 use crate::counter;
 use crate::gauge;
+use crate::processing::strategies::InvalidMessageReason;
 use crate::types::{BrokerMessage, Partition, Topic, TopicOrPartition};
 
 // This is a per-partition max
@@ -323,7 +324,7 @@ impl<TPayload: Send + Sync + 'static> DlqPolicyWrapper<TPayload> {
 
     // Removes all completed futures, then appends a future with message to be produced
     // to the queue. Blocks if there are too many pending futures until some are done.
-    pub fn produce(&mut self, message: BrokerMessage<TPayload>) {
+    pub fn produce(&mut self, message: BrokerMessage<TPayload>, reason: InvalidMessageReason) {
         let Some(inner) = self.inner.as_mut() else {
             tracing::info!("dlq policy missing, dropping message");
             return;
@@ -345,7 +346,14 @@ impl<TPayload: Send + Sync + 'static> DlqPolicyWrapper<TPayload> {
         }
 
         if inner.dlq_limit_state.record_invalid_message(&message) {
-            tracing::info!("producing message to dlq");
+            match reason {
+                InvalidMessageReason::Ignored => {
+                    tracing::debug!("producing ignored message to dlq");
+                }
+                InvalidMessageReason::Invalid => {
+                    tracing::info!("producing invalid message to dlq");
+                }
+            }
             let (partition, offset) = (message.partition, message.offset);
 
             let task = inner.dlq_policy.producer.produce(message);
@@ -630,12 +638,15 @@ mod tests {
         wrapper.reset_dlq_limits(&HashMap::from([(partition, 0)]));
 
         for i in 0..10 {
-            wrapper.produce(BrokerMessage {
-                partition,
-                offset: i,
-                payload: i,
-                timestamp: Utc::now(),
-            });
+            wrapper.produce(
+                BrokerMessage {
+                    partition,
+                    offset: i,
+                    payload: i,
+                    timestamp: Utc::now(),
+                },
+                InvalidMessageReason::Invalid,
+            );
         }
 
         wrapper.flush(&HashMap::from([(partition, 11)]));
@@ -667,12 +678,15 @@ mod tests {
         wrapper.reset_dlq_limits(&HashMap::from([(partition, 0)]));
 
         for i in 0..10 {
-            wrapper.produce(BrokerMessage {
-                partition,
-                offset: i,
-                payload: i,
-                timestamp: Utc::now(),
-            });
+            wrapper.produce(
+                BrokerMessage {
+                    partition,
+                    offset: i,
+                    payload: i,
+                    timestamp: Utc::now(),
+                },
+                InvalidMessageReason::Invalid,
+            );
         }
 
         wrapper.flush(&HashMap::from([(partition, 11)]));

--- a/rust-arroyo/src/processing/mod.rs
+++ b/rust-arroyo/src/processing/mod.rs
@@ -12,7 +12,9 @@ use crate::backends::kafka::types::KafkaPayload;
 use crate::backends::kafka::KafkaConsumer;
 use crate::backends::{AssignmentCallbacks, CommitOffsets, Consumer, ConsumerError};
 use crate::processing::dlq::{DlqPolicy, DlqPolicyWrapper};
-use crate::processing::strategies::{MessageRejected, StrategyError, SubmitError};
+use crate::processing::strategies::{
+    InvalidMessageReason, MessageRejected, StrategyError, SubmitError,
+};
 use crate::types::{InnerMessage, Message, Partition, Topic};
 use crate::utils::timing::Deadline;
 use crate::{counter, timer};
@@ -323,15 +325,22 @@ impl<TPayload: Clone + Send + Sync + 'static> StreamProcessor<TPayload> {
 
                     match message {
                         Some(msg) => {
-                            tracing::error!(?e, "Invalid message");
-                            consumer_state.dlq_policy.produce(msg);
+                            match e.reason {
+                                InvalidMessageReason::Invalid => {
+                                    tracing::error!(?e, "Invalid message");
+                                }
+                                InvalidMessageReason::Ignored => {
+                                    tracing::debug!(?e, "Ignored message");
+                                }
+                            };
+                            consumer_state.dlq_policy.produce(msg, e.reason);
                         }
                         None => {
-                            tracing::error!("Could not find invalid message in buffer");
+                            tracing::error!(?e, "Could not find message in DLQ buffer");
                         }
                     }
                 } else {
-                    tracing::error!(?e, "Invalid message, but no DLQ policy configured");
+                    tracing::error!(?e, "No DLQ policy configured");
                 }
             }
 
@@ -414,15 +423,22 @@ impl<TPayload: Clone + Send + Sync + 'static> StreamProcessor<TPayload> {
 
                     match message {
                         Some(msg) => {
-                            tracing::error!(?e, "Invalid message");
-                            consumer_state.dlq_policy.produce(msg);
+                            match e.reason {
+                                InvalidMessageReason::Invalid => {
+                                    tracing::error!(?e, "Invalid message");
+                                }
+                                InvalidMessageReason::Ignored => {
+                                    tracing::debug!(?e, "Ignored message");
+                                }
+                            };
+                            consumer_state.dlq_policy.produce(msg, e.reason);
                         }
                         None => {
-                            tracing::error!("Could not find invalid message in buffer");
+                            tracing::error!(?e, "Could not find message in DLQ buffer");
                         }
                     }
                 } else {
-                    tracing::error!(?e, "Invalid message, but no DLQ policy configured");
+                    tracing::error!(?e, "No DLQ policy configured");
                 }
             }
         }

--- a/rust-arroyo/src/processing/strategies/mod.rs
+++ b/rust-arroyo/src/processing/strategies/mod.rs
@@ -31,6 +31,13 @@ pub struct MessageRejected<T> {
 pub struct InvalidMessage {
     pub partition: Partition,
     pub offset: u64,
+    pub reason: InvalidMessageReason,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum InvalidMessageReason {
+    Invalid,
+    Ignored,
 }
 
 impl<TPayload> From<&BrokerMessage<TPayload>> for InvalidMessage {
@@ -38,6 +45,7 @@ impl<TPayload> From<&BrokerMessage<TPayload>> for InvalidMessage {
         Self {
             partition: value.partition,
             offset: value.offset,
+            reason: InvalidMessageReason::Invalid,
         }
     }
 }


### PR DESCRIPTION
As of https://github.com/getsentry/snuba/pull/7945, in some cases Snuba can return `RunTaskError::InvalidMessage` to avoid processing some messages and intentionally have them end up in DLQ.
From the POV of arroyo these are proper failures, which causes a ton of unnecessary logs to be emitted.
This introduces an `IgnoredMessage.reason` field that can hold `Invalid` for legit errors and `Ignored` for intentional drops.