### PR TITLE
feat(producer): add metrics for librdkafka reply queue size

### DIFF
--- a/arroyo/backends/kafka/configuration.py
+++ b/arroyo/backends/kafka/configuration.py
@@ -120,6 +120,13 @@ def producer_stats_callback(stats_json: str, producer_name: Optional[str]) -> No
             tags={"producer_name": producer_name_tag},
         )
 
+    if stats.get("replyq") is not None:
+        metrics.gauge(
+            "arroyo.producer.librdkafka.reply_queue_size",
+            stats["replyq"],
+            tags={"producer_name": producer_name_tag},
+        )
+
 
 def build_kafka_producer_configuration(
     default_config: Mapping[str, Any],

--- a/arroyo/utils/metric_defs.py
+++ b/arroyo/utils/metric_defs.py
@@ -128,6 +128,9 @@ MetricName = Literal[
     # Gauge: Maximum producer message count from librdkafka statistics
     # Tagged by producer_name
     "arroyo.producer.librdkafka.message_count_max",
+    # Gauge: Number of ops (callbacks, events, etc) waiting in librdkafka reply queue
+    # Tagged by producer_name
+    "arroyo.producer.librdkafka.reply_queue_size",
     # Gauge: Total number of transmission errors from librdkafka statistics
     # Tagged by broker_id, producer_name
     "arroyo.producer.librdkafka.broker_txerrs",


### PR DESCRIPTION
This PR adds metrics for the librdkafka reply queue size.
When rolling out TaskProducer, I noticed a bug where some producer futures were never being marked as done. One possibility is that the delivery callback is stuck in librdkafka's reply queue for some reason.
This gives more observability into this queue.