### PR TITLE
feat(producer): Add produce status metrics to KafkaProducer

### DIFF
--- a/arroyo/backends/kafka/consumer.py
+++ b/arroyo/backends/kafka/consumer.py
@@ -764,6 +764,11 @@ class KafkaProducer(Producer[KafkaPayload]):
         self.__producer = ConfluentKafkaProducer(dict(configuration))
         self.__shutdown_requested = Event()
 
+        self.producer_name = configuration.get("client.id") or None
+        self.__metrics = get_metrics()
+        self.__produce_counters: MutableMapping[str, int] = defaultdict(int)
+        self.__reset_metrics()
+
         # The worker must execute in a separate thread to ensure that callbacks
         # are fired -- otherwise trying to produce "synchronously" via
         # ``produce(...).result()`` could result in a deadlock.
@@ -782,6 +787,7 @@ class KafkaProducer(Producer[KafkaPayload]):
         while not self.__shutdown_requested.is_set():
             self.__producer.poll(0.1)
         self.__producer.flush()
+        self.__flush_metrics()
 
     def __delivery_callback(
         self,
@@ -790,6 +796,9 @@ class KafkaProducer(Producer[KafkaPayload]):
         error: KafkaError,
         message: ConfluentMessage,
     ) -> None:
+        self.__produce_counters["error" if error is not None else "success"] += 1
+        self.__throttled_record()
+
         if error is not None:
             future.set_exception(TransportError(error))
         else:
@@ -846,6 +855,26 @@ class KafkaProducer(Producer[KafkaPayload]):
     def close(self) -> Future[None]:
         self.__shutdown_requested.set()
         return self.__result
+
+    def __flush_metrics(self) -> None:
+        for status, count in self.__produce_counters.items():
+            tags = {"status": status}
+            if self.producer_name:
+                tags["producer_name"] = self.producer_name
+            self.__metrics.increment(
+                name="arroyo.producer.produce_status",
+                value=count,
+                tags=tags,
+            )
+        self.__reset_metrics()
+
+    def __reset_metrics(self) -> None:
+        self.__produce_counters.clear()
+        self.__last_record_time = time.time()
+
+    def __throttled_record(self) -> None:
+        if time.time() - self.__last_record_time > METRICS_FREQUENCY_SEC:
+            self.__flush_metrics()
 
 
 # Type alias for the delivery callback function

--- a/tests/backends/test_kafka_producer.py
+++ b/tests/backends/test_kafka_producer.py
@@ -1,7 +1,14 @@
 import json
+from concurrent.futures import Future
 from unittest import mock
 
+from confluent_kafka import TIMESTAMP_CREATE_TIME, KafkaError
+from confluent_kafka import Message as ConfluentMessage
+
 from arroyo.backends.kafka.configuration import producer_stats_callback
+from arroyo.backends.kafka.consumer import KafkaPayload, KafkaProducer
+from arroyo.types import BrokerValue
+from tests.metrics import Increment, TestingMetricsBackend
 
 
 @mock.patch("arroyo.backends.kafka.configuration.get_metrics")
@@ -98,3 +105,57 @@ def test_producer_stats_callback_with_all_metrics(mock_get_metrics: mock.Mock) -
         1.5,
         tags={"broker_id": "1", "producer_name": "unknown"},
     )
+
+
+class TestKafkaProducerMetrics:
+    """
+    Tests for the produce status metrics recorded by KafkaProducer's delivery
+    callback.
+    """
+
+    def test_delivery_callback_records_success(self) -> None:
+        """The delivery callback records a success metric and resolves the future"""
+        producer = KafkaProducer(
+            {"bootstrap.servers": "fake:9092", "client.id": "test-producer-name"}
+        )
+        payload = KafkaPayload(None, b"value", [])
+        future: Future[BrokerValue[KafkaPayload]] = Future()
+
+        mock_message = mock.Mock(spec=ConfluentMessage)
+        mock_message.timestamp.return_value = (TIMESTAMP_CREATE_TIME, 1234567890000)
+        mock_message.topic.return_value = "test-topic"
+        mock_message.partition.return_value = 0
+        mock_message.offset.return_value = 0
+
+        producer._KafkaProducer__delivery_callback(future, payload, None, mock_message)  # type: ignore[attr-defined]
+        producer._KafkaProducer__flush_metrics()  # type: ignore[attr-defined]
+
+        assert future.result().payload == payload
+        assert (
+            Increment(
+                "arroyo.producer.produce_status",
+                1,
+                {"status": "success", "producer_name": "test-producer-name"},
+            )
+            in TestingMetricsBackend.calls
+        )
+
+    def test_delivery_callback_records_error(self) -> None:
+        """The delivery callback records an error metric and sets the exception"""
+        producer = KafkaProducer({"bootstrap.servers": "fake:9092"})
+        payload = KafkaPayload(None, b"value", [])
+        future: Future[BrokerValue[KafkaPayload]] = Future()
+
+        mock_error = mock.Mock(spec=KafkaError)
+        mock_message = mock.Mock(spec=ConfluentMessage)
+
+        producer._KafkaProducer__delivery_callback(  # type: ignore[attr-defined]
+            future, payload, mock_error, mock_message
+        )
+        producer._KafkaProducer__flush_metrics()  # type: ignore[attr-defined]
+
+        assert future.exception() is not None
+        assert (
+            Increment("arroyo.producer.produce_status", 1, {"status": "error"})
+            in TestingMetricsBackend.calls
+        )


### PR DESCRIPTION
## Summary

`KafkaProducer` did not report the produce success/error metrics that `ConfluentProducer` already emits. This mirrors that behavior so both producers in `arroyo/backends/kafka/consumer.py` report the `arroyo.producer.produce_status` metric.

## Changes

- `__init__`: derive `producer_name` from `client.id`, grab `get_metrics()`, initialize the `__produce_counters` defaultdict, and reset metrics state.
- `__delivery_callback`: increment the `success`/`error` counter and throttle-record before resolving the future.
- Added `__flush_metrics`, `__reset_metrics`, and `__throttled_record` helpers, emitting `arroyo.producer.produce_status` tagged with `status` (and `producer_name` when set), throttled to `METRICS_FREQUENCY_SEC`.
- `__worker`: flush metrics after the final `flush()` on shutdown.

Unlike `ConfluentProducer`, `KafkaProducer` has no public `flush()` — its worker thread owns flushing, so the metrics flush is hooked into the worker's shutdown path. Per-callback throttled recording is identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)