### PR TITLE
fix(producer): use the ConfluentProducer wrapper

### DIFF
--- a/arroyo/backends/kafka/consumer.py
+++ b/arroyo/backends/kafka/consumer.py
@@ -761,7 +761,7 @@ class KafkaProducer(Producer[KafkaPayload]):
         self, configuration: Mapping[str, Any], use_simple_futures: bool = False
     ) -> None:
         self.__configuration = configuration
-        self.__producer = ConfluentKafkaProducer(dict(configuration))
+        self.__producer = ConfluentProducer(dict(configuration))
         self.__shutdown_requested = Event()
 
         # The worker must execute in a separate thread to ensure that callbacks

--- a/arroyo/backends/kafka/consumer.py
+++ b/arroyo/backends/kafka/consumer.py
@@ -764,11 +764,6 @@ class KafkaProducer(Producer[KafkaPayload]):
         self.__producer = ConfluentProducer(dict(configuration))
         self.__shutdown_requested = Event()
 
-        self.producer_name = configuration.get("client.id") or None
-        self.__metrics = get_metrics()
-        self.__produce_counters: MutableMapping[str, int] = defaultdict(int)
-        self.__reset_metrics()
-
         # The worker must execute in a separate thread to ensure that callbacks
         # are fired -- otherwise trying to produce "synchronously" via
         # ``produce(...).result()`` could result in a deadlock.
@@ -787,7 +782,6 @@ class KafkaProducer(Producer[KafkaPayload]):
         while not self.__shutdown_requested.is_set():
             self.__producer.poll(0.1)
         self.__producer.flush()
-        self.__flush_metrics()
 
     def __delivery_callback(
         self,
@@ -796,9 +790,6 @@ class KafkaProducer(Producer[KafkaPayload]):
         error: KafkaError,
         message: ConfluentMessage,
     ) -> None:
-        self.__produce_counters["error" if error is not None else "success"] += 1
-        self.__throttled_record()
-
         if error is not None:
             future.set_exception(TransportError(error))
         else:
@@ -855,26 +846,6 @@ class KafkaProducer(Producer[KafkaPayload]):
     def close(self) -> Future[None]:
         self.__shutdown_requested.set()
         return self.__result
-
-    def __flush_metrics(self) -> None:
-        for status, count in self.__produce_counters.items():
-            tags = {"status": status}
-            if self.producer_name:
-                tags["producer_name"] = self.producer_name
-            self.__metrics.increment(
-                name="arroyo.producer.produce_status",
-                value=count,
-                tags=tags,
-            )
-        self.__reset_metrics()
-
-    def __reset_metrics(self) -> None:
-        self.__produce_counters.clear()
-        self.__last_record_time = time.time()
-
-    def __throttled_record(self) -> None:
-        if time.time() - self.__last_record_time > METRICS_FREQUENCY_SEC:
-            self.__flush_metrics()
 
 
 # Type alias for the delivery callback function

--- a/tests/backends/test_kafka.py
+++ b/tests/backends/test_kafka.py
@@ -270,7 +270,7 @@ class TestKafkaStreams(StreamsTestMixin[KafkaPayload]):
                     except EndOfPartition:
                         pass
 
-                    if processor._StreamProcessor__is_paused:  # type:ignore
+                    if processor._StreamProcessor__is_paused:  # type: ignore
                         return
                 raise RuntimeError("processor was not paused")
 
@@ -284,7 +284,7 @@ class TestKafkaStreams(StreamsTestMixin[KafkaPayload]):
             # consumer A has all partitions paused (both from consumer and from
             # StreamProcessor POV)
             assert consumer_a.paused()
-            assert processor_a._StreamProcessor__is_paused is True  # type:ignore
+            assert processor_a._StreamProcessor__is_paused is True  # type: ignore
 
             # subscribe with another consumer, now we should have rebalancing in the next few polls
             processor_b = StreamProcessor(consumer_b, topic, factory, IMMEDIATE)

--- a/tests/backends/test_kafka_producer.py
+++ b/tests/backends/test_kafka_producer.py
@@ -1,14 +1,7 @@
 import json
-from concurrent.futures import Future
 from unittest import mock
 
-from confluent_kafka import TIMESTAMP_CREATE_TIME, KafkaError
-from confluent_kafka import Message as ConfluentMessage
-
 from arroyo.backends.kafka.configuration import producer_stats_callback
-from arroyo.backends.kafka.consumer import KafkaPayload, KafkaProducer
-from arroyo.types import BrokerValue
-from tests.metrics import Increment, TestingMetricsBackend
 
 
 @mock.patch("arroyo.backends.kafka.configuration.get_metrics")
@@ -105,57 +98,3 @@ def test_producer_stats_callback_with_all_metrics(mock_get_metrics: mock.Mock) -
         1.5,
         tags={"broker_id": "1", "producer_name": "unknown"},
     )
-
-
-class TestKafkaProducerMetrics:
-    """
-    Tests for the produce status metrics recorded by KafkaProducer's delivery
-    callback.
-    """
-
-    def test_delivery_callback_records_success(self) -> None:
-        """The delivery callback records a success metric and resolves the future"""
-        producer = KafkaProducer(
-            {"bootstrap.servers": "fake:9092", "client.id": "test-producer-name"}
-        )
-        payload = KafkaPayload(None, b"value", [])
-        future: Future[BrokerValue[KafkaPayload]] = Future()
-
-        mock_message = mock.Mock(spec=ConfluentMessage)
-        mock_message.timestamp.return_value = (TIMESTAMP_CREATE_TIME, 1234567890000)
-        mock_message.topic.return_value = "test-topic"
-        mock_message.partition.return_value = 0
-        mock_message.offset.return_value = 0
-
-        producer._KafkaProducer__delivery_callback(future, payload, None, mock_message)  # type: ignore[attr-defined]
-        producer._KafkaProducer__flush_metrics()  # type: ignore[attr-defined]
-
-        assert future.result().payload == payload
-        assert (
-            Increment(
-                "arroyo.producer.produce_status",
-                1,
-                {"status": "success", "producer_name": "test-producer-name"},
-            )
-            in TestingMetricsBackend.calls
-        )
-
-    def test_delivery_callback_records_error(self) -> None:
-        """The delivery callback records an error metric and sets the exception"""
-        producer = KafkaProducer({"bootstrap.servers": "fake:9092"})
-        payload = KafkaPayload(None, b"value", [])
-        future: Future[BrokerValue[KafkaPayload]] = Future()
-
-        mock_error = mock.Mock(spec=KafkaError)
-        mock_message = mock.Mock(spec=ConfluentMessage)
-
-        producer._KafkaProducer__delivery_callback(  # type: ignore[attr-defined]
-            future, payload, mock_error, mock_message
-        )
-        producer._KafkaProducer__flush_metrics()  # type: ignore[attr-defined]
-
-        assert future.exception() is not None
-        assert (
-            Increment("arroyo.producer.produce_status", 1, {"status": "error"})
-            in TestingMetricsBackend.calls
-        )


### PR DESCRIPTION
When poking around at why we aren't getting very many producer metrics, I noticed that `KafkaProducer` (which is the backend used by pretty much everything at this point) isn't using the `ConfluentProducer` wrapper that provides produce metrics, and was using the stock `ConfluentKafkaProducer` backend. This means that only services which imported & used the `ConfluentProducer` backend directly from Arroyo were getting produce status metrics.

This PR switches the inner producer for `KafkaProducer` to be our wrapper that provides delivery metrics. Also some unrelated formatting fixes.