### PR TITLE
feat(producer): add metrics for callback execution latency

### DIFF
--- a/arroyo/backends/kafka/consumer.py
+++ b/arroyo/backends/kafka/consumer.py
@@ -767,6 +767,7 @@ class KafkaProducer(Producer[KafkaPayload]):
         self.producer_name = configuration.get("client.id") or None
         self.__metrics = get_metrics()
         self.__produce_counters: MutableMapping[str, int] = defaultdict(int)
+        self.__callback_latency: list[float] = []
         self.__reset_metrics()
 
         # The worker must execute in a separate thread to ensure that callbacks
@@ -795,8 +796,10 @@ class KafkaProducer(Producer[KafkaPayload]):
         payload: KafkaPayload,
         error: KafkaError,
         message: ConfluentMessage,
+        time_of_produce: float,
     ) -> None:
         self.__produce_counters["error" if error is not None else "success"] += 1
+        self.__callback_latency.append(time.time() - time_of_produce)
         self.__throttled_record()
 
         if error is not None:
@@ -844,11 +847,17 @@ class KafkaProducer(Producer[KafkaPayload]):
             future = Future()
             future.set_running_or_notify_cancel()
 
+        time_of_produce = time.time()
         produce(
             value=payload.value,
             key=payload.key,
             headers=list(payload.headers),
-            on_delivery=partial(self.__delivery_callback, future, payload),
+            on_delivery=partial(
+                self.__delivery_callback,
+                future,
+                payload,
+                time_of_produce=time_of_produce,
+            ),
         )
         return future
 
@@ -866,10 +875,19 @@ class KafkaProducer(Producer[KafkaPayload]):
                 value=count,
                 tags=tags,
             )
+        for latency in self.__callback_latency:
+            self.__metrics.timing(
+                name="arroyo.producer.callback_latency",
+                value=latency,
+                tags={
+                    "producer_name": self.producer_name if self.producer_name else "N/A"
+                },
+            )
         self.__reset_metrics()
 
     def __reset_metrics(self) -> None:
         self.__produce_counters.clear()
+        self.__callback_latency.clear()
         self.__last_record_time = time.time()
 
     def __throttled_record(self) -> None:
@@ -894,37 +912,46 @@ class ConfluentProducer(ConfluentKafkaProducer):  # type: ignore[misc, unused-ig
         self.producer_name = configuration.get("client.id") or None
         self.__metrics = get_metrics()
         self.__produce_counters: MutableMapping[str, int] = defaultdict(int)
+        self.__callback_latency: list[float] = []
         self.__reset_metrics()
 
     def __metrics_delivery_callback(
         self,
         error: Optional[KafkaError],
         _message: ConfluentMessage,
+        time_of_produce: float,
     ) -> None:
         if error is not None:
             status = "error"
         else:
             status = "success"
         self.__produce_counters[status] += 1
+        self.__callback_latency.append(time.time() - time_of_produce)
         self.__throttled_record()
 
     def __delivery_callback(
         self,
         user_callback: Optional[DeliveryCallback],
+        time_of_produce: float,
     ) -> DeliveryCallback:
-        def wrapped(error: Optional[KafkaError], message: ConfluentMessage) -> None:
-            self.__metrics_delivery_callback(error, message)
+        def wrapped(
+            error: Optional[KafkaError],
+            message: ConfluentMessage,
+            time_of_produce: float,
+        ) -> None:
+            self.__metrics_delivery_callback(error, message, time_of_produce)
             if user_callback is not None:
                 user_callback(error, message)
 
-        return wrapped
+        return partial(wrapped, time_of_produce=time_of_produce)
 
     def produce(self, *args: Any, **kwargs: Any) -> None:
         # callback and on_delivery are aliases, callback takes precedence over on_delivery
         callback = kwargs.pop("callback", None)
         on_delivery = kwargs.pop("on_delivery", None)
         user_callback = callback or on_delivery
-        wrapped_callback = self.__delivery_callback(user_callback)
+        time_of_produce = time.time()
+        wrapped_callback = self.__delivery_callback(user_callback, time_of_produce)
         super().produce(*args, **kwargs, on_delivery=wrapped_callback)  # type: ignore[misc]
 
     def __flush_metrics(self) -> None:
@@ -937,6 +964,14 @@ class ConfluentProducer(ConfluentKafkaProducer):  # type: ignore[misc, unused-ig
                 value=count,
                 tags=tags,
             )
+        for latency in self.__callback_latency:
+            self.__metrics.timing(
+                name="arroyo.producer.callback_latency",
+                value=latency,
+                tags={
+                    "producer_name": self.producer_name if self.producer_name else "N/A"
+                },
+            )
         self.__reset_metrics()
 
     def flush(self, timeout: float | None = -1) -> int:
@@ -946,6 +981,7 @@ class ConfluentProducer(ConfluentKafkaProducer):  # type: ignore[misc, unused-ig
 
     def __reset_metrics(self) -> None:
         self.__produce_counters.clear()
+        self.__callback_latency.clear()
         self.__last_record_time = time.time()
 
     def __throttled_record(self) -> None:

--- a/arroyo/backends/kafka/consumer.py
+++ b/arroyo/backends/kafka/consumer.py
@@ -767,7 +767,6 @@ class KafkaProducer(Producer[KafkaPayload]):
         self.producer_name = configuration.get("client.id") or None
         self.__metrics = get_metrics()
         self.__produce_counters: MutableMapping[str, int] = defaultdict(int)
-        self.__callback_latency: list[float] = []
         self.__reset_metrics()
 
         # The worker must execute in a separate thread to ensure that callbacks
@@ -796,10 +795,8 @@ class KafkaProducer(Producer[KafkaPayload]):
         payload: KafkaPayload,
         error: KafkaError,
         message: ConfluentMessage,
-        time_of_produce: float,
     ) -> None:
         self.__produce_counters["error" if error is not None else "success"] += 1
-        self.__callback_latency.append(time.time() - time_of_produce)
         self.__throttled_record()
 
         if error is not None:
@@ -847,17 +844,11 @@ class KafkaProducer(Producer[KafkaPayload]):
             future = Future()
             future.set_running_or_notify_cancel()
 
-        time_of_produce = time.time()
         produce(
             value=payload.value,
             key=payload.key,
             headers=list(payload.headers),
-            on_delivery=partial(
-                self.__delivery_callback,
-                future,
-                payload,
-                time_of_produce=time_of_produce,
-            ),
+            on_delivery=partial(self.__delivery_callback, future, payload),
         )
         return future
 
@@ -875,19 +866,10 @@ class KafkaProducer(Producer[KafkaPayload]):
                 value=count,
                 tags=tags,
             )
-        for latency in self.__callback_latency:
-            self.__metrics.timing(
-                name="arroyo.producer.callback_latency",
-                value=latency,
-                tags={
-                    "producer_name": self.producer_name if self.producer_name else "N/A"
-                },
-            )
         self.__reset_metrics()
 
     def __reset_metrics(self) -> None:
         self.__produce_counters.clear()
-        self.__callback_latency.clear()
         self.__last_record_time = time.time()
 
     def __throttled_record(self) -> None:

--- a/arroyo/utils/metric_defs.py
+++ b/arroyo/utils/metric_defs.py
@@ -125,6 +125,9 @@ MetricName = Literal[
     # Gauge: Producer message count metric from librdkafka statistics
     # Tagged by producer_name
     "arroyo.producer.librdkafka.message_count",
+    # Time: Latency between when a message is produced, and when its delivery callback is called
+    # Tagged by producer_name
+    "arroyo.producer.callback_latency",
     # Gauge: Maximum producer message count from librdkafka statistics
     # Tagged by producer_name
     "arroyo.producer.librdkafka.message_count_max",

--- a/tests/backends/test_confluent_producer.py
+++ b/tests/backends/test_confluent_producer.py
@@ -6,7 +6,7 @@ from confluent_kafka import Message as ConfluentMessage
 from confluent_kafka import Producer as ConfluentKafkaProducer
 
 from arroyo.backends.kafka.consumer import ConfluentProducer
-from tests.metrics import Increment, TestingMetricsBackend
+from tests.metrics import Increment, TestingMetricsBackend, Timing
 
 
 class TestConfluentProducer:
@@ -48,6 +48,31 @@ class TestConfluentProducer:
         producer.flush()  # Flush buffered metrics
         assert (
             Increment("arroyo.producer.produce_status", 1, {"status": "error"})
+            in TestingMetricsBackend.calls
+        )
+
+    @mock.patch("arroyo.backends.kafka.consumer.time.time")
+    def test_metrics_callback_records_callback_latency(
+        self, mock_time: mock.Mock
+    ) -> None:
+        """Test that the metrics callback records a callback_latency timing metric"""
+        mock_time.return_value = 1000.5
+
+        producer = ConfluentProducer(
+            {"bootstrap.servers": "fake:9092", "client.id": "test-producer-name"}
+        )
+        mock_message = mock.Mock(spec=ConfluentMessage)
+        producer._ConfluentProducer__metrics_delivery_callback(  # type: ignore[attr-defined]
+            None, mock_message, time_of_produce=1000.0
+        )
+        producer.flush()
+
+        assert (
+            Timing(
+                "arroyo.producer.callback_latency",
+                0.5,
+                {"producer_name": "test-producer-name"},
+            )
             in TestingMetricsBackend.calls
         )
 

--- a/tests/backends/test_confluent_producer.py
+++ b/tests/backends/test_confluent_producer.py
@@ -6,7 +6,7 @@ from confluent_kafka import Message as ConfluentMessage
 from confluent_kafka import Producer as ConfluentKafkaProducer
 
 from arroyo.backends.kafka.consumer import ConfluentProducer
-from tests.metrics import Increment, TestingMetricsBackend
+from tests.metrics import Increment, TestingMetricsBackend, Timing
 
 
 class TestConfluentProducer:
@@ -28,7 +28,7 @@ class TestConfluentProducer:
             {"bootstrap.servers": "fake:9092", "client.id": "test-producer-name"}
         )
         mock_message = mock.Mock(spec=ConfluentMessage)
-        producer._ConfluentProducer__metrics_delivery_callback(None, mock_message)  # type: ignore[attr-defined]
+        producer._ConfluentProducer__metrics_delivery_callback(None, mock_message, 1000.0)  # type: ignore[attr-defined]
         producer.flush()  # Flush buffered metrics
         assert (
             Increment(
@@ -44,10 +44,35 @@ class TestConfluentProducer:
         producer = ConfluentProducer({"bootstrap.servers": "fake:9092"})
         mock_error = mock.Mock(spec=KafkaError)
         mock_message = mock.Mock(spec=ConfluentMessage)
-        producer._ConfluentProducer__metrics_delivery_callback(mock_error, mock_message)  # type: ignore[attr-defined]
+        producer._ConfluentProducer__metrics_delivery_callback(mock_error, mock_message, 1000.0)  # type: ignore[attr-defined]
         producer.flush()  # Flush buffered metrics
         assert (
             Increment("arroyo.producer.produce_status", 1, {"status": "error"})
+            in TestingMetricsBackend.calls
+        )
+
+    @mock.patch("arroyo.backends.kafka.consumer.time.time")
+    def test_metrics_callback_records_callback_latency(
+        self, mock_time: mock.Mock
+    ) -> None:
+        """Test that the metrics callback records a callback_latency timing metric"""
+        mock_time.return_value = 1000.5
+
+        producer = ConfluentProducer(
+            {"bootstrap.servers": "fake:9092", "client.id": "test-producer-name"}
+        )
+        mock_message = mock.Mock(spec=ConfluentMessage)
+        producer._ConfluentProducer__metrics_delivery_callback(  # type: ignore[attr-defined]
+            None, mock_message, time_of_produce=1000.0
+        )
+        producer.flush()
+
+        assert (
+            Timing(
+                "arroyo.producer.callback_latency",
+                0.5,
+                {"producer_name": "test-producer-name"},
+            )
             in TestingMetricsBackend.calls
         )
 
@@ -63,7 +88,7 @@ class TestConfluentProducer:
         ) -> None:
             user_callback_invoked.append((error, message))
 
-        wrapped = producer._ConfluentProducer__delivery_callback(user_callback)  # type: ignore[attr-defined]
+        wrapped = producer._ConfluentProducer__delivery_callback(user_callback, 1000.0)  # type: ignore[attr-defined]
         mock_message = mock.Mock(spec=ConfluentMessage)
         wrapped(None, mock_message)
         producer.flush()  # Flush buffered metrics

--- a/tests/backends/test_confluent_producer.py
+++ b/tests/backends/test_confluent_producer.py
@@ -6,7 +6,7 @@ from confluent_kafka import Message as ConfluentMessage
 from confluent_kafka import Producer as ConfluentKafkaProducer
 
 from arroyo.backends.kafka.consumer import ConfluentProducer
-from tests.metrics import Increment, TestingMetricsBackend, Timing
+from tests.metrics import Increment, TestingMetricsBackend
 
 
 class TestConfluentProducer:
@@ -48,31 +48,6 @@ class TestConfluentProducer:
         producer.flush()  # Flush buffered metrics
         assert (
             Increment("arroyo.producer.produce_status", 1, {"status": "error"})
-            in TestingMetricsBackend.calls
-        )
-
-    @mock.patch("arroyo.backends.kafka.consumer.time.time")
-    def test_metrics_callback_records_callback_latency(
-        self, mock_time: mock.Mock
-    ) -> None:
-        """Test that the metrics callback records a callback_latency timing metric"""
-        mock_time.return_value = 1000.5
-
-        producer = ConfluentProducer(
-            {"bootstrap.servers": "fake:9092", "client.id": "test-producer-name"}
-        )
-        mock_message = mock.Mock(spec=ConfluentMessage)
-        producer._ConfluentProducer__metrics_delivery_callback(  # type: ignore[attr-defined]
-            None, mock_message, time_of_produce=1000.0
-        )
-        producer.flush()
-
-        assert (
-            Timing(
-                "arroyo.producer.callback_latency",
-                0.5,
-                {"producer_name": "test-producer-name"},
-            )
             in TestingMetricsBackend.calls
         )
 

--- a/tests/backends/test_kafka_producer.py
+++ b/tests/backends/test_kafka_producer.py
@@ -8,7 +8,7 @@ from confluent_kafka import Message as ConfluentMessage
 from arroyo.backends.kafka.configuration import producer_stats_callback
 from arroyo.backends.kafka.consumer import KafkaPayload, KafkaProducer
 from arroyo.types import BrokerValue
-from tests.metrics import Increment, TestingMetricsBackend
+from tests.metrics import Increment, TestingMetricsBackend, Timing
 
 
 @mock.patch("arroyo.backends.kafka.configuration.get_metrics")
@@ -157,5 +157,38 @@ class TestKafkaProducerMetrics:
         assert future.exception() is not None
         assert (
             Increment("arroyo.producer.produce_status", 1, {"status": "error"})
+            in TestingMetricsBackend.calls
+        )
+
+    @mock.patch("arroyo.backends.kafka.consumer.time.time")
+    def test_delivery_callback_records_callback_latency(
+        self, mock_time: mock.Mock
+    ) -> None:
+        """The delivery callback records a callback_latency timing metric"""
+        mock_time.return_value = 1000.5
+
+        producer = KafkaProducer(
+            {"bootstrap.servers": "fake:9092", "client.id": "test-producer-name"}
+        )
+        payload = KafkaPayload(None, b"value", [])
+        future: Future[BrokerValue[KafkaPayload]] = Future()
+
+        mock_message = mock.Mock(spec=ConfluentMessage)
+        mock_message.timestamp.return_value = (TIMESTAMP_CREATE_TIME, 1234567890000)
+        mock_message.topic.return_value = "test-topic"
+        mock_message.partition.return_value = 0
+        mock_message.offset.return_value = 0
+
+        producer._KafkaProducer__delivery_callback(  # type: ignore[attr-defined]
+            future, payload, None, mock_message, time_of_produce=1000.0
+        )
+        producer._KafkaProducer__flush_metrics()  # type: ignore[attr-defined]
+
+        assert (
+            Timing(
+                "arroyo.producer.callback_latency",
+                0.5,
+                {"producer_name": "test-producer-name"},
+            )
             in TestingMetricsBackend.calls
         )


### PR DESCRIPTION
This PR adds a metric for the latency between producing a message and executing that message's callback.