### PR TITLE
feat(metrics): add distribution metric support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog and versioning
 
+## Unreleased
+
+### New Features ✨
+
+- Add `distribution` method to the metrics backend interface for recording distribution metrics
+
 ## 2.40.3
 
 ### New Features ✨

--- a/arroyo/utils/metrics.py
+++ b/arroyo/utils/metrics.py
@@ -44,6 +44,15 @@ class Metrics(Protocol):
         """
         raise NotImplementedError
 
+    @abstractmethod
+    def distribution(
+        self, name: MetricName, value: Union[int, float], tags: Optional[Tags] = None
+    ) -> None:
+        """
+        Records a distribution metric.
+        """
+        raise NotImplementedError
+
 
 class DummyMetricsBackend(Metrics):
     """
@@ -64,6 +73,11 @@ class DummyMetricsBackend(Metrics):
         pass
 
     def timing(
+        self, name: MetricName, value: Union[int, float], tags: Optional[Tags] = None
+    ) -> None:
+        pass
+
+    def distribution(
         self, name: MetricName, value: Union[int, float], tags: Optional[Tags] = None
     ) -> None:
         pass

--- a/docs/source/metrics.rst
+++ b/docs/source/metrics.rst
@@ -35,6 +35,12 @@ This can be done like so:
             # Emit a timing metric with the given value.
             record_timing(name, value, tags)
 
+        def distribution(
+            self, name: MetricName, value: Union[int, float], tags: Optional[Tags] = None
+        ) -> None:
+            # Emit a distribution metric with the given value.
+            record_distribution(name, value, tags)
+
     metrics_backend = MyMetrics()
 
     configure_metrics(metrics_backend)

--- a/tests/metrics.py
+++ b/tests/metrics.py
@@ -21,7 +21,13 @@ class Timing(NamedTuple):
     tags: Optional[Tags]
 
 
-MetricCall = Union[Increment, Gauge, Timing]
+class Distribution(NamedTuple):
+    name: MetricName
+    value: Union[int, float]
+    tags: Optional[Tags]
+
+
+MetricCall = Union[Increment, Gauge, Timing, Distribution]
 
 
 class _TestingMetricsBackend(Metrics):
@@ -32,7 +38,7 @@ class _TestingMetricsBackend(Metrics):
     """
 
     def __init__(self) -> None:
-        self.calls: MutableSequence[Union[Increment, Gauge, Timing]] = []
+        self.calls: MutableSequence[Union[Increment, Gauge, Timing, Distribution]] = []
 
     def increment(
         self,
@@ -51,6 +57,11 @@ class _TestingMetricsBackend(Metrics):
         self, name: MetricName, value: Union[int, float], tags: Optional[Tags] = None
     ) -> None:
         self.calls.append(Timing(name, value, tags))
+
+    def distribution(
+        self, name: MetricName, value: Union[int, float], tags: Optional[Tags] = None
+    ) -> None:
+        self.calls.append(Distribution(name, value, tags))
 
 
 TestingMetricsBackend = _TestingMetricsBackend()

--- a/tests/utils/test_metrics.py
+++ b/tests/utils/test_metrics.py
@@ -1,6 +1,7 @@
 import pytest
 
 from arroyo.utils.metrics import Gauge, MetricName, configure_metrics, get_metrics
+from tests.metrics import Distribution as DistributionCall
 from tests.metrics import Gauge as GaugeCall
 from tests.metrics import TestingMetricsBackend, _TestingMetricsBackend
 
@@ -19,6 +20,21 @@ def test_gauge_simple() -> None:
         GaugeCall(name, 0.0, tags),
         GaugeCall(name, 1.0, tags),
         GaugeCall(name, 0.0, tags),
+    ]
+
+
+def test_distribution_simple() -> None:
+    backend = _TestingMetricsBackend()
+
+    name: MetricName = "name"  # type: ignore
+    tags = {"tag": "value"}
+
+    backend.distribution(name, 1.0, tags)
+    backend.distribution(name, 2.0, tags)
+
+    assert backend.calls == [
+        DistributionCall(name, 1.0, tags),
+        DistributionCall(name, 2.0, tags),
     ]
 
 


### PR DESCRIPTION
## Summary

Adds support for **distribution** metrics to Arroyo's metrics backend interface, alongside the existing `increment`, `gauge`, and `timing` methods.

Distribution metrics let backends record the full distribution of a set of values (e.g. percentiles), which is useful for measuring things like batch sizes or latencies where aggregate statistics matter.

## Changes

- **`arroyo/utils/metrics.py`**: Add the abstract `distribution` method to the `Metrics` protocol and a no-op implementation in `DummyMetricsBackend`.
- **`tests/metrics.py`**: Add a `Distribution` call type and implement `distribution` in the testing backend so recorded distribution calls can be asserted in tests.
- **`tests/utils/test_metrics.py`**: Add a test covering the testing backend's `distribution` method.
- **`docs/source/metrics.rst`**: Document `distribution` in the example backend implementation.
- **`CHANGELOG.md`**: Add an Unreleased entry.

## Notes

This is purely additive to the metrics interface. Backends implementing the `Metrics` protocol will now need to provide a `distribution` method.

## Testing

- `pytest tests/utils/test_metrics.py` passes.
- Verified `DummyMetricsBackend` and the testing backend still satisfy the `runtime_checkable` `Metrics` protocol.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019ASHzHqVirSvv3vBRYaQPS

---
_Generated by [Claude Code](https://claude.ai/code/session_019ASHzHqVirSvv3vBRYaQPS)_