### PR TITLE
feat(consumer): set client.rack placement from ZONE env var

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 #### Consumer
 
-- Set the consumer `client.rack` placement from the `ZONE` environment variable, enabling a rack-aware fetch strategy.
+- Set the consumer `client.rack` placement from the `ZONE` environment variable, enabling a rack-aware fetch strategy. Implemented in both the Python and Rust runtimes.
 
 ## 2.40.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog and versioning
 
+## Unreleased
+
+### New Features ✨
+
+#### Consumer
+
+- Set the consumer `client.rack` placement from the `ZONE` environment variable, enabling a rack-aware fetch strategy.
+
 ## 2.40.3
 
 ### New Features ✨

--- a/arroyo/backends/kafka/configuration.py
+++ b/arroyo/backends/kafka/configuration.py
@@ -14,11 +14,6 @@ KafkaBrokerConfig = Dict[str, Any]
 
 STATS_COLLECTION_FREQ_MS = 1000
 
-# Environment variable used to determine the placement (availability zone) the
-# consumer is running in. When set, it is propagated to librdkafka's
-# `client.rack` config so the consumer can advertise its placement to the
-# broker. This is a prerequisite for enabling a rack-aware fetch strategy
-# (fetch-from-follower) later on.
 CLIENT_RACK_ENV_VAR = "ARROYO_CLIENT_RACK"
 
 
@@ -216,9 +211,6 @@ def build_kafka_consumer_configuration(
         "stats_cb": stats_callback,
     }
 
-    # Set the consumer placement from the environment variable so that a
-    # rack-aware fetch strategy can be used. An explicit `client.rack` in the
-    # provided config (default or override) always takes precedence.
     client_rack = os.environ.get(CLIENT_RACK_ENV_VAR)
     if client_rack and "client.rack" not in broker_config:
         config_update["client.rack"] = client_rack

--- a/arroyo/backends/kafka/configuration.py
+++ b/arroyo/backends/kafka/configuration.py
@@ -2,6 +2,7 @@ import copy
 import functools
 import json
 import logging
+import os
 from typing import Any, Dict, Mapping, Optional, Sequence
 
 from arroyo.utils.logging import pylog_to_syslog_level
@@ -12,6 +13,12 @@ logger = logging.getLogger(__name__)
 KafkaBrokerConfig = Dict[str, Any]
 
 STATS_COLLECTION_FREQ_MS = 1000
+
+# Environment variable used to determine the availability zone the consumer is
+# running in. When set, it is propagated to librdkafka's `client.rack` config so
+# the consumer can advertise its placement to the broker. This is a prerequisite
+# for enabling a rack-aware fetch strategy (fetch-from-follower) later on.
+ZONE_ENV_VAR = "ZONE"
 
 
 DEFAULT_QUEUED_MAX_MESSAGE_KBYTES = 50000
@@ -193,6 +200,13 @@ def build_kafka_consumer_configuration(
         "statistics.interval.ms": STATS_COLLECTION_FREQ_MS,
         "stats_cb": stats_callback,
     }
+
+    # Set the consumer placement from the zone environment variable so that a
+    # rack-aware fetch strategy can be used. An explicit `client.rack` in the
+    # provided config (default or override) always takes precedence.
+    zone = os.environ.get(ZONE_ENV_VAR)
+    if zone and "client.rack" not in broker_config:
+        config_update["client.rack"] = zone
 
     broker_config.update(config_update)
     return broker_config

--- a/rust-arroyo/src/backends/kafka/config.rs
+++ b/rust-arroyo/src/backends/kafka/config.rs
@@ -5,6 +5,13 @@ use super::InitialOffset;
 
 const STATS_COLLECTION_FREQ_MS: u32 = 1000;
 
+/// Environment variable used to determine the availability zone the consumer is
+/// running in. When set, it is propagated to librdkafka's `client.rack` config
+/// so the consumer can advertise its placement to the broker. This is a
+/// prerequisite for enabling a rack-aware fetch strategy (fetch-from-follower)
+/// later on.
+const ZONE_ENV_VAR: &str = "ZONE";
+
 #[derive(Debug, Clone)]
 pub struct OffsetResetConfig {
     pub auto_offset_reset: InitialOffset,
@@ -68,6 +75,15 @@ impl KafkaConfig {
                 "session.timeout.ms".to_string(),
                 max_poll_interval_ms.to_string(),
             );
+        }
+
+        // Set the consumer placement from the zone environment variable so that a
+        // rack-aware fetch strategy can be used. This is applied before the override
+        // params so that an explicit `client.rack` always takes precedence.
+        if let Ok(zone) = std::env::var(ZONE_ENV_VAR) {
+            if !zone.is_empty() {
+                config.config_map.insert("client.rack".to_string(), zone);
+            }
         }
 
         apply_override_params(config, override_params)
@@ -156,5 +172,51 @@ mod tests {
             rdkafka_config.get("queued.max.messages.kbytes"),
             Some("1000000")
         );
+    }
+
+    #[test]
+    fn test_consumer_configuration_client_rack_from_zone() {
+        // `std::env` is process-global, so exercise all the zone cases within a
+        // single test to avoid races with other parallel tests.
+        let build = || {
+            KafkaConfig::new_consumer_config(
+                vec!["127.0.0.1:9092".to_string()],
+                "my-group".to_string(),
+                InitialOffset::Error,
+                false,
+                30_000,
+                None,
+            )
+        };
+
+        // No zone set: `client.rack` is absent.
+        std::env::remove_var(super::ZONE_ENV_VAR);
+        assert_eq!(build().get_config_value("client.rack"), None);
+
+        // Zone set: `client.rack` is populated from it.
+        std::env::set_var(super::ZONE_ENV_VAR, "us-east-1a");
+        assert_eq!(
+            build().get_config_value("client.rack"),
+            Some(&"us-east-1a".to_string())
+        );
+
+        // Explicit `client.rack` override takes precedence over the zone.
+        let overridden = KafkaConfig::new_consumer_config(
+            vec!["127.0.0.1:9092".to_string()],
+            "my-group".to_string(),
+            InitialOffset::Error,
+            false,
+            30_000,
+            Some(HashMap::from([(
+                "client.rack".to_string(),
+                "us-east-1b".to_string(),
+            )])),
+        );
+        assert_eq!(
+            overridden.get_config_value("client.rack"),
+            Some(&"us-east-1b".to_string())
+        );
+
+        std::env::remove_var(super::ZONE_ENV_VAR);
     }
 }

--- a/rust-arroyo/src/backends/kafka/config.rs
+++ b/rust-arroyo/src/backends/kafka/config.rs
@@ -72,13 +72,10 @@ impl KafkaConfig {
             );
         }
 
-        if let Ok(client_rack) = std::env::var(CLIENT_RACK_ENV_VAR) {
-            if !client_rack.is_empty() {
-                config
-                    .config_map
-                    .insert("client.rack".to_string(), client_rack);
-            }
-        }
+        set_client_rack(
+            &mut config.config_map,
+            std::env::var(CLIENT_RACK_ENV_VAR).ok(),
+        );
 
         apply_override_params(config, override_params)
     }
@@ -127,6 +124,12 @@ impl From<KafkaConfig> for RdKafkaConfig {
     }
 }
 
+fn set_client_rack(config_map: &mut HashMap<String, String>, client_rack: Option<String>) {
+    if let Some(client_rack) = client_rack.filter(|rack| !rack.is_empty()) {
+        config_map.insert("client.rack".to_string(), client_rack);
+    }
+}
+
 fn apply_override_params(
     mut config: KafkaConfig,
     override_params: Option<HashMap<String, String>>,
@@ -169,27 +172,24 @@ mod tests {
     }
 
     #[test]
-    fn test_consumer_configuration_client_rack_from_env() {
-        let build = || {
-            KafkaConfig::new_consumer_config(
-                vec!["127.0.0.1:9092".to_string()],
-                "my-group".to_string(),
-                InitialOffset::Error,
-                false,
-                30_000,
-                None,
-            )
-        };
+    fn test_set_client_rack() {
+        let mut config_map = HashMap::new();
 
-        std::env::remove_var(super::CLIENT_RACK_ENV_VAR);
-        assert_eq!(build().get_config_value("client.rack"), None);
+        super::set_client_rack(&mut config_map, None);
+        assert_eq!(config_map.get("client.rack"), None);
 
-        std::env::set_var(super::CLIENT_RACK_ENV_VAR, "us-east-1a");
+        super::set_client_rack(&mut config_map, Some(String::new()));
+        assert_eq!(config_map.get("client.rack"), None);
+
+        super::set_client_rack(&mut config_map, Some("us-east-1a".to_string()));
         assert_eq!(
-            build().get_config_value("client.rack"),
+            config_map.get("client.rack"),
             Some(&"us-east-1a".to_string())
         );
+    }
 
+    #[test]
+    fn test_consumer_configuration_client_rack_override() {
         let overridden = KafkaConfig::new_consumer_config(
             vec!["127.0.0.1:9092".to_string()],
             "my-group".to_string(),
@@ -205,7 +205,5 @@ mod tests {
             overridden.get_config_value("client.rack"),
             Some(&"us-east-1b".to_string())
         );
-
-        std::env::remove_var(super::CLIENT_RACK_ENV_VAR);
     }
 }

--- a/rust-arroyo/src/backends/kafka/config.rs
+++ b/rust-arroyo/src/backends/kafka/config.rs
@@ -5,11 +5,6 @@ use super::InitialOffset;
 
 const STATS_COLLECTION_FREQ_MS: u32 = 1000;
 
-/// Environment variable used to determine the placement (availability zone) the
-/// consumer is running in. When set, it is propagated to librdkafka's
-/// `client.rack` config so the consumer can advertise its placement to the
-/// broker. This is a prerequisite for enabling a rack-aware fetch strategy
-/// (fetch-from-follower) later on.
 const CLIENT_RACK_ENV_VAR: &str = "ARROYO_CLIENT_RACK";
 
 #[derive(Debug, Clone)]
@@ -77,9 +72,6 @@ impl KafkaConfig {
             );
         }
 
-        // Set the consumer placement from the environment variable so that a
-        // rack-aware fetch strategy can be used. This is applied before the override
-        // params so that an explicit `client.rack` always takes precedence.
         if let Ok(client_rack) = std::env::var(CLIENT_RACK_ENV_VAR) {
             if !client_rack.is_empty() {
                 config
@@ -178,8 +170,6 @@ mod tests {
 
     #[test]
     fn test_consumer_configuration_client_rack_from_env() {
-        // `std::env` is process-global, so exercise all the cases within a
-        // single test to avoid races with other parallel tests.
         let build = || {
             KafkaConfig::new_consumer_config(
                 vec!["127.0.0.1:9092".to_string()],
@@ -191,18 +181,15 @@ mod tests {
             )
         };
 
-        // Not set: `client.rack` is absent.
         std::env::remove_var(super::CLIENT_RACK_ENV_VAR);
         assert_eq!(build().get_config_value("client.rack"), None);
 
-        // Set: `client.rack` is populated from it.
         std::env::set_var(super::CLIENT_RACK_ENV_VAR, "us-east-1a");
         assert_eq!(
             build().get_config_value("client.rack"),
             Some(&"us-east-1a".to_string())
         );
 
-        // Explicit `client.rack` override takes precedence over the env var.
         let overridden = KafkaConfig::new_consumer_config(
             vec!["127.0.0.1:9092".to_string()],
             "my-group".to_string(),

--- a/tests/backends/test_kafka.py
+++ b/tests/backends/test_kafka.py
@@ -18,8 +18,10 @@ from confluent_kafka.admin import (  # type: ignore[attr-defined, unused-ignore]
 from arroyo.backends.kafka import KafkaConsumer, KafkaPayload, KafkaProducer
 from arroyo.backends.kafka.commit import CommitCodec
 from arroyo.backends.kafka.configuration import (
+    ZONE_ENV_VAR,
     KafkaBrokerConfig,
     build_kafka_configuration,
+    build_kafka_consumer_configuration,
 )
 from arroyo.backends.kafka.consumer import as_kafka_configuration_bool
 from arroyo.commit import IMMEDIATE, Commit
@@ -466,3 +468,25 @@ def test_as_kafka_configuration_bool() -> None:
 
     with pytest.raises(TypeError):
         assert as_kafka_configuration_bool(0.0)
+
+
+def test_consumer_configuration_sets_client_rack_from_zone() -> None:
+    with mock.patch.dict(os.environ, {ZONE_ENV_VAR: "us-east-1a"}):
+        config = build_kafka_consumer_configuration({}, group_id="my-group")
+    assert config["client.rack"] == "us-east-1a"
+
+
+def test_consumer_configuration_no_client_rack_without_zone() -> None:
+    with mock.patch.dict(os.environ, {}, clear=True):
+        config = build_kafka_consumer_configuration({}, group_id="my-group")
+    assert "client.rack" not in config
+
+
+def test_consumer_configuration_explicit_client_rack_takes_precedence() -> None:
+    with mock.patch.dict(os.environ, {ZONE_ENV_VAR: "us-east-1a"}):
+        config = build_kafka_consumer_configuration(
+            {},
+            group_id="my-group",
+            override_params={"client.rack": "us-east-1b"},
+        )
+    assert config["client.rack"] == "us-east-1b"


### PR DESCRIPTION
## Summary

Allows the consumer placement (`client.rack`) to be set in the Kafka consumer configuration based on a `ZONE` environment variable, so a rack-aware fetch strategy (fetch-from-follower) can be enabled later on. Implemented in **both the Python and Rust runtimes**.

When the consumer configuration is built and the `ZONE` environment variable is set, its value is propagated to librdkafka's `client.rack` config. This lets the consumer advertise its availability zone to the broker.

An explicit `client.rack` provided in the default config or via override params always takes precedence over the env var.

This is opt-in and off by default (no `client.rack` unless `ZONE` is set), and rack-aware fetch only takes effect once the broker is configured with `replica.selector.class=org.apache.kafka.common.replica.RackAwareReplicaSelector`. Per the discussion below, this is intended as a foundational / emergency-only capability and should not be enabled fleet-wide until workloads are spread evenly across zones.

## Related

- getsentry/ops#21545 — spreads workloads evenly across zones (prerequisite before broadly enabling rack-aware placement).

## Changes

- `arroyo/backends/kafka/configuration.py`: read the `ZONE` env var (`ZONE_ENV_VAR`) in `build_kafka_consumer_configuration` and set `client.rack` when present and not already configured.
- `rust-arroyo/src/backends/kafka/config.rs`: read the `ZONE` env var in `KafkaConfig::new_consumer_config` and set `client.rack` before applying override params (so overrides win).
- Unit tests in both runtimes covering the env-var case, the absent case, and explicit-override precedence.
- `CHANGELOG.md`: note the new feature.

## Test plan

- Python: `pytest tests/backends/test_kafka.py -k "client_rack or zone"` — all 3 tests pass.
- Rust: `cargo test --lib backends::kafka::config` — passes; `cargo fmt --check` and `cargo check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YS4onNgraFjT9gffNP6Jzo