### PR TITLE
feat(producer): add FutureTrackingProducer

### DIFF
--- a/arroyo/backends/kafka/producer.py
+++ b/arroyo/backends/kafka/producer.py
@@ -1,0 +1,126 @@
+import atexit
+import os
+from collections import defaultdict, deque
+from collections.abc import Callable
+from concurrent.futures import Future
+from typing import Any, Protocol, Sequence
+
+from arroyo.backends.abstract import ProducerFuture, SimpleProducerFuture
+from arroyo.backends.kafka import KafkaPayload
+from arroyo.types import BrokerValue, Partition, Topic
+
+TASK_PRODUCER_MAX_PENDING_FUTURES = 10_000
+
+_pending_futures: defaultdict[
+    str, deque[ProducerFuture[BrokerValue[KafkaPayload]]]
+] = defaultdict(lambda: deque(maxlen=TASK_PRODUCER_MAX_PENDING_FUTURES))
+"""
+_pending_futures is global as a process may have several `FutureTrackingProducer` instances,
+and we want to collect futures from all running instances with a single call.
+Keys are the names of each `FutureTrackingProducer` instance in the current process, values are
+deques with a maxlen to prevent unbounded queue size in case we're set to track futures,
+but `collect_futures()` is never called.
+"""
+
+
+class CloseableProducerProtocol(Protocol):
+    """Interface used by FutureTrackingProducer. Represents a producer that has a shutdown method."""
+
+    def produce(
+        self, dest: Topic | Partition, payload: KafkaPayload
+    ) -> ProducerFuture[BrokerValue[KafkaPayload]]:
+        ...
+
+    def close(self) -> Future[None]:
+        ...
+
+
+class FutureTrackingProducer:
+    """
+    FutureTrackingProducer is a producer abstraction that optionally registers futures
+    within the `_pending_futures` dict (depending on if the `ARROYO_TRACK_PRODUCER_FUTURES`
+    env var is set). Applications can then call the `collect_futures()` static method to
+    get all registered futures, await them, etc.
+
+    Args:
+        name: Unique identifying name of this FutureTrackingProducer. Used to key `_pending_futures`.
+        producer_factory: Callable that returns a producer object.
+    """
+
+    def _should_track_futures(self) -> bool:
+        return os.environ.get("ARROYO_TRACK_PRODUCER_FUTURES", "").lower() == "true"
+
+    def __init__(
+        self,
+        name: str,
+        producer_factory: Callable[[], CloseableProducerProtocol],
+    ) -> None:
+        self.name = name
+        self._producer_factory = producer_factory
+        self._inner_producer: CloseableProducerProtocol | None = None
+        self._track_futures = self._should_track_futures()
+
+    def _get(self) -> CloseableProducerProtocol:
+        if self._inner_producer is None:
+            self._inner_producer = self._producer_factory()
+            atexit.register(self._shutdown)
+        return self._inner_producer
+
+    def track_future(self, future: ProducerFuture[BrokerValue[KafkaPayload]]) -> None:
+        _pending_futures[self.name].append(future)
+
+    @staticmethod
+    def collect_futures() -> dict[str, set[ProducerFuture[BrokerValue[KafkaPayload]]]]:
+        """
+        Clears the `_pending_futures` dict, and returns a copy with all values converted to sets.
+        This generally should not be called by users, and should only be called if you want to
+        do something based on the outcome of a _group_ of futures, and not just the outcomes of individual futures.
+        For the latter, use delivery callbacks.
+
+        This operation should also always be called in the same thread as the one calling `produce()`, since there's
+        no locking around `_pending_futures`.
+        """
+
+        pending_copy = _pending_futures.copy()
+        _pending_futures.clear()
+        return {name: set(val) for name, val in pending_copy.items()}
+
+    def produce(
+        self,
+        dest: Topic | Partition,
+        payload: KafkaPayload,
+        callbacks: Sequence[Callable[[Future[BrokerValue[KafkaPayload]]], Any]] = [],
+    ) -> None:
+        """
+        Produces the given payload to the given topic.
+        Since FutureTrackingProducer tracks futures internally, it does not return the
+        producer future to the user, but the user can still add callbacks
+        to the future via the `callbacks` arg.
+
+        Args:
+            dest: Topic (or specific partition) to produce to.
+            payload: KafkaPayload to produce.
+            callbacks: List of Callables to add to the future as done callbacks. The future itself
+                       is the only arg passed to the callback.
+        """
+
+        future = self._get().produce(dest, payload)
+        if self._track_futures:
+            self.track_future(future)
+        if callbacks:
+            # Arroyo producers can return a SimpleProducerFuture,
+            # which does not accept callbacks.
+            if not isinstance(future, SimpleProducerFuture):
+                for c in callbacks:
+                    future.add_done_callback(c)
+            else:
+                raise RuntimeError(
+                    (
+                        "Cannot add callbacks to SimpleProducerFuture, either remove the callbacks "
+                        "or instantiate your producer with `use_simple_futures=False`."
+                    )
+                )
+
+    def _shutdown(self) -> None:
+        if self._inner_producer is not None:
+            self._inner_producer.close().result()

--- a/arroyo/backends/kafka/producer.py
+++ b/arroyo/backends/kafka/producer.py
@@ -1,5 +1,6 @@
 import atexit
 import os
+import threading
 from collections import defaultdict, deque
 from collections.abc import Callable
 from concurrent.futures import Future
@@ -9,11 +10,11 @@ from arroyo.backends.abstract import ProducerFuture, SimpleProducerFuture
 from arroyo.backends.kafka import KafkaPayload
 from arroyo.types import BrokerValue, Partition, Topic
 
-TASK_PRODUCER_MAX_PENDING_FUTURES = 10_000
+MAX_PENDING_FUTURES = 10_000
 
 _pending_futures: defaultdict[
     str, deque[ProducerFuture[BrokerValue[KafkaPayload]]]
-] = defaultdict(lambda: deque(maxlen=TASK_PRODUCER_MAX_PENDING_FUTURES))
+] = defaultdict(lambda: deque(maxlen=MAX_PENDING_FUTURES))
 """
 _pending_futures is global as a process may have several `FutureTrackingProducer` instances,
 and we want to collect futures from all running instances with a single call.
@@ -59,11 +60,16 @@ class FutureTrackingProducer:
         self._producer_factory = producer_factory
         self._inner_producer: CloseableProducerProtocol | None = None
         self._track_futures = self._should_track_futures()
+        # Used to ensure we don't instantiate duplicate producers when calling produce() from different threads.
+        self._producer_lock = threading.Lock()
 
     def _get(self) -> CloseableProducerProtocol:
+        # None check first so we don't have any lock contention on produces
         if self._inner_producer is None:
-            self._inner_producer = self._producer_factory()
-            atexit.register(self._shutdown)
+            with self._producer_lock:
+                if self._inner_producer is None:
+                    self._inner_producer = self._producer_factory()
+                    atexit.register(self._shutdown)
         return self._inner_producer
 
     def track_future(self, future: ProducerFuture[BrokerValue[KafkaPayload]]) -> None:
@@ -77,8 +83,8 @@ class FutureTrackingProducer:
         do something based on the outcome of a _group_ of futures, and not just the outcomes of individual futures.
         For the latter, use delivery callbacks.
 
-        This operation should also always be called in the same thread as the one calling `produce()`, since there's
-        no locking around `_pending_futures`.
+        TODO: Add locking around `_pending_futures`. For now, his operation should also always be called
+        in the same thread as the one calling `produce()`.
         """
 
         pending_copy = _pending_futures.copy()

--- a/tests/backends/test_future_tracking_producer.py
+++ b/tests/backends/test_future_tracking_producer.py
@@ -1,0 +1,127 @@
+from collections.abc import Iterator
+from concurrent.futures import Future
+from datetime import datetime
+from functools import partial
+from unittest.mock import patch
+
+import pytest
+
+from arroyo.backends.abstract import ProducerFuture, SimpleProducerFuture
+from arroyo.backends.kafka import KafkaPayload
+from arroyo.backends.kafka.producer import FutureTrackingProducer, _pending_futures
+from arroyo.types import BrokerValue, Partition, Topic
+
+
+def make_kafka_payload() -> KafkaPayload:
+    """Generates dummy KafkaPayload."""
+    return KafkaPayload(None, b"", [])
+
+
+def make_broker_value() -> BrokerValue[KafkaPayload]:
+    """Generates dummy BrokerValue[KafkaPayload]."""
+    return BrokerValue(
+        make_kafka_payload(), Partition(Topic("test"), 0), 0, datetime(1999, 2, 19)
+    )
+
+
+class DummyProducer:
+    def __init__(self, use_simple_futures: bool):
+        self.use_simple_futures = use_simple_futures
+
+    def produce(
+        self, destination: Topic | Partition, payload: KafkaPayload
+    ) -> ProducerFuture[BrokerValue[KafkaPayload]]:
+        future: ProducerFuture[BrokerValue[KafkaPayload]]
+        if self.use_simple_futures:
+            future = SimpleProducerFuture()
+        else:
+            future = Future()
+        future.set_result(make_broker_value())
+        return future
+
+    def close(self) -> Future[None]:
+        f: Future[None] = Future()
+        f.set_result(None)
+        return f
+
+
+def get_dummy_producer(use_simple_futures: bool) -> DummyProducer:
+    return DummyProducer(use_simple_futures=use_simple_futures)
+
+
+@pytest.fixture(autouse=True)
+def clear_pending_futures() -> Iterator[None]:
+    _pending_futures.clear()
+    yield
+    _pending_futures.clear()
+
+
+@pytest.fixture
+def track_futures() -> Iterator[None]:
+    with patch.object(
+        FutureTrackingProducer, "_should_track_futures", return_value=True
+    ):
+        yield
+
+
+def test_producer_tracks_futures(track_futures: None) -> None:
+    producer = FutureTrackingProducer(
+        "test.producer", partial(get_dummy_producer, use_simple_futures=True)
+    )
+    producer.produce(Topic("test"), make_kafka_payload())
+    assert len(_pending_futures) == 1
+    collected = FutureTrackingProducer.collect_futures()
+    future = next(iter(collected["test.producer"]))
+    assert future.result() == make_broker_value()
+    assert len(_pending_futures) == 0
+
+
+def test_producer_executes_callbacks(track_futures: None) -> None:
+    producer = FutureTrackingProducer(
+        "test.producer", partial(get_dummy_producer, use_simple_futures=False)
+    )
+    received: list[Future[BrokerValue[KafkaPayload]]] = []
+
+    def callback(future: Future[BrokerValue[KafkaPayload]]) -> None:
+        received.append(future)
+
+    producer.produce(Topic("test"), make_kafka_payload(), callbacks=[callback])
+    collected = FutureTrackingProducer.collect_futures()
+    tracked_future = next(iter(collected["test.producer"]))
+
+    assert len(received) == 1
+    assert received[0] is tracked_future
+    assert received[0].done()
+
+
+def test_producer_rejects_callbacks_for_simple_futures(track_futures: None) -> None:
+    producer = FutureTrackingProducer(
+        "test.producer", partial(get_dummy_producer, use_simple_futures=True)
+    )
+
+    def callback(future: Future[BrokerValue[KafkaPayload]]) -> None:
+        pass
+
+    with pytest.raises(RuntimeError, match="SimpleProducerFuture"):
+        producer.produce(Topic("test"), make_kafka_payload(), callbacks=[callback])
+
+
+def test_pending_futures_max_len(track_futures: None) -> None:
+    producer = FutureTrackingProducer(
+        "test.producer", partial(get_dummy_producer, use_simple_futures=True)
+    )
+    for _ in range(10001):
+        producer.produce(Topic("test"), make_kafka_payload())
+    assert len(_pending_futures["test.producer"]) == 10000
+
+
+def test_producer_does_not_track_futures_when_disabled() -> None:
+    with patch.object(
+        FutureTrackingProducer, "_should_track_futures", return_value=False
+    ):
+        producer = FutureTrackingProducer(
+            "test.producer", partial(get_dummy_producer, use_simple_futures=True)
+        )
+        producer.produce(Topic("test"), make_kafka_payload())
+    assert len(_pending_futures) == 0
+    assert FutureTrackingProducer.collect_futures() == {}


### PR DESCRIPTION
This PR adds `FutureTrackingProducer`, which is wrapper for a producer object that can track futures internally, then pass them into user code for processing when `FutureTrackingProducer.collect_futures()` is called.

Functionally, this is a copy & paste of [TaskProducer](https://github.com/getsentry/taskbroker/blob/main/clients/python/src/taskbroker_client/worker/producer.py#L24) in the taskbroker repo (with the addition of tracking futures optionally based off of an environment variable). I plan to fully replace `TaskProducer` with this producer in order to have a single producer we can use for tasks/consumers/etc in Sentry (and elsewhere).