### PR TITLE
fix(kafka): explicitly export FutureTrackingProducer

### DIFF
--- a/arroyo/backends/kafka/__init__.py
+++ b/arroyo/backends/kafka/__init__.py
@@ -4,12 +4,14 @@ from .configuration import (
     build_kafka_producer_configuration,
 )
 from .consumer import ConfluentProducer, KafkaConsumer, KafkaPayload, KafkaProducer
+from .producer import FutureTrackingProducer
 
 __all__ = [
     "build_kafka_configuration",
     "build_kafka_consumer_configuration",
     "build_kafka_producer_configuration",
     "ConfluentProducer",
+    "FutureTrackingProducer",
     "KafkaConsumer",
     "KafkaPayload",
     "KafkaProducer",

--- a/tests/backends/test_future_tracking_producer.py
+++ b/tests/backends/test_future_tracking_producer.py
@@ -7,8 +7,8 @@ from unittest.mock import patch
 import pytest
 
 from arroyo.backends.abstract import ProducerFuture, SimpleProducerFuture
-from arroyo.backends.kafka import KafkaPayload
-from arroyo.backends.kafka.producer import FutureTrackingProducer, _pending_futures
+from arroyo.backends.kafka import FutureTrackingProducer, KafkaPayload
+from arroyo.backends.kafka.producer import _pending_futures
 from arroyo.types import BrokerValue, Partition, Topic
 
 


### PR DESCRIPTION
Forgot this in #547 