### PR TITLE
feat(producer): add rdkafka produce queue size metrics

### DIFF
--- a/arroyo/backends/kafka/configuration.py
+++ b/arroyo/backends/kafka/configuration.py
@@ -106,7 +106,7 @@ def producer_stats_callback(stats_json: str, producer_name: Optional[str]) -> No
             )
 
     # Record global producer metrics (librdkafka namespace)
-    if stats.get("msg_cnt"):
+    if stats.get("msg_cnt") is not None:
         metrics.gauge(
             "arroyo.producer.librdkafka.message_count",
             stats["msg_cnt"],
@@ -117,6 +117,20 @@ def producer_stats_callback(stats_json: str, producer_name: Optional[str]) -> No
         metrics.gauge(
             "arroyo.producer.librdkafka.message_count_max",
             stats["msg_max"],
+            tags={"producer_name": producer_name_tag},
+        )
+
+    if stats.get("msg_size") is not None:
+        metrics.gauge(
+            "arroyo.producer.librdkafka.message_size",
+            stats["msg_size"],
+            tags={"producer_name": producer_name_tag},
+        )
+
+    if stats.get("msg_size_max"):
+        metrics.gauge(
+            "arroyo.producer.librdkafka.message_size_max",
+            stats["msg_size_max"],
             tags={"producer_name": producer_name_tag},
         )
 

--- a/arroyo/utils/metric_defs.py
+++ b/arroyo/utils/metric_defs.py
@@ -125,12 +125,18 @@ MetricName = Literal[
     # Gauge: Producer message count metric from librdkafka statistics
     # Tagged by producer_name
     "arroyo.producer.librdkafka.message_count",
+    # Gauge: Total size of all messages in the librdkafka producer queue
+    # Tagged by producer_name
+    "arroyo.producer.librdkafka.message_size",
     # Time: Latency between when a message is produced, and when its delivery callback is called
     # Tagged by producer_name
     "arroyo.producer.callback_latency",
     # Gauge: Maximum producer message count from librdkafka statistics
     # Tagged by producer_name
     "arroyo.producer.librdkafka.message_count_max",
+    # Gauge: maximum size of all messages in the librdkafka producer queue
+    # Tagged by producer_name
+    "arroyo.producer.librdkafka.message_size_max",
     # Gauge: Number of ops (callbacks, events, etc) waiting in librdkafka reply queue
     # Tagged by producer_name
     "arroyo.producer.librdkafka.reply_queue_size",

--- a/rust-arroyo/src/backends/kafka/producer.rs
+++ b/rust-arroyo/src/backends/kafka/producer.rs
@@ -96,6 +96,24 @@ impl ClientContext for ProducerContext {
             stats.msg_max as i64,
             "producer_name" => producer_name
         );
+
+        gauge!(
+            "arroyo.producer.librdkafka.message_size",
+            stats.msg_size as i64,
+            "producer_name" => producer_name
+        );
+
+        gauge!(
+            "arroyo.producer.librdkafka.message_size_max",
+            stats.msg_size_max as i64,
+            "producer_name" => producer_name
+        );
+
+        gauge!(
+            "arroyo.producer.librdkafka.reply_queue_size",
+            stats.replyq as i64,
+            "producer_name" => producer_name
+        );
     }
 }
 


### PR DESCRIPTION
rdkafka's produce queue can fill up based on size as well as length. This adds size metrics (and reply queue size metrics for rust because I missed that in #541)