### PR TITLE
feat(producer): add ability to get configuration

### DIFF
--- a/arroyo/backends/kafka/consumer.py
+++ b/arroyo/backends/kafka/consumer.py
@@ -847,6 +847,12 @@ class KafkaProducer(Producer[KafkaPayload]):
         self.__shutdown_requested.set()
         return self.__result
 
+    def get_config(self) -> dict[str, Any]:
+        """
+        Returns the configuration the producer was instantiated with.
+        """
+        return dict(self.__configuration)
+
 
 # Type alias for the delivery callback function
 DeliveryCallback = Callable[[Optional[KafkaError], ConfluentMessage], None]

--- a/tests/backends/test_kafka.py
+++ b/tests/backends/test_kafka.py
@@ -176,6 +176,10 @@ class TestKafkaStreams(StreamsTestMixin[KafkaPayload]):
                 assert future.result(5.0)
                 assert future.done()
 
+    def test_producer_get_configuration(self) -> None:
+        producer = self.get_producer()
+        assert producer.get_config() == self.configuration
+
     def test_lenient_offset_reset_latest(self) -> None:
         payload = KafkaPayload(b"a", b"0", [])
         with self.get_topic() as topic:


### PR DESCRIPTION
Adds a `get_configuration()` method so that higher-level producers which wrap `KafkaProducer` can see the configuration the producer was instantiated with.