### PR TITLE
feat(producer): add metrics for poll frequency

### DIFF
--- a/arroyo/backends/kafka/consumer.py
+++ b/arroyo/backends/kafka/consumer.py
@@ -758,11 +758,17 @@ class KafkaConsumer(Consumer[KafkaPayload]):
 
 class KafkaProducer(Producer[KafkaPayload]):
     def __init__(
-        self, configuration: Mapping[str, Any], use_simple_futures: bool = False
+        self,
+        configuration: Mapping[str, Any],
+        use_simple_futures: bool = False,
+        record_poll_metrics: bool = False,
     ) -> None:
+        self.producer_name = configuration.get("client.id") or None
         self.__configuration = configuration
         self.__producer = ConfluentProducer(dict(configuration))
         self.__shutdown_requested = Event()
+        self.__metrics = get_metrics()
+        self.__record_poll_metrics = record_poll_metrics
 
         # The worker must execute in a separate thread to ensure that callbacks
         # are fired -- otherwise trying to produce "synchronously" via
@@ -779,8 +785,22 @@ class KafkaProducer(Producer[KafkaPayload]):
         after a shutdown request has been issued (via ``close``) and all
         in-flight messages have been delivered.
         """
+        POLL_METRIC_FREQUENCY = 10
+        poll_count = 0
         while not self.__shutdown_requested.is_set():
             self.__producer.poll(0.1)
+            if self.__record_poll_metrics:
+                if poll_count % POLL_METRIC_FREQUENCY == 0:
+                    self.__metrics.increment(
+                        "arroyo.producer.worker.poll",
+                        value=POLL_METRIC_FREQUENCY,
+                        tags={
+                            "producer_name": (
+                                self.producer_name if self.producer_name else "N/A"
+                            )
+                        },
+                    )
+                poll_count += 1
         self.__producer.flush()
 
     def __delivery_callback(

--- a/arroyo/backends/kafka/consumer.py
+++ b/arroyo/backends/kafka/consumer.py
@@ -762,6 +762,7 @@ class KafkaProducer(Producer[KafkaPayload]):
         configuration: Mapping[str, Any],
         use_simple_futures: bool = False,
         record_poll_metrics: bool = False,
+        poll_metric_frequency: int = 10,
     ) -> None:
         self.producer_name = configuration.get("client.id") or None
         self.__configuration = configuration
@@ -769,6 +770,8 @@ class KafkaProducer(Producer[KafkaPayload]):
         self.__shutdown_requested = Event()
         self.__metrics = get_metrics()
         self.__record_poll_metrics = record_poll_metrics
+        # Poll metrics are recorded every X poll iterations
+        self.__poll_metric_frequency = poll_metric_frequency
 
         # The worker must execute in a separate thread to ensure that callbacks
         # are fired -- otherwise trying to produce "synchronously" via
@@ -785,21 +788,21 @@ class KafkaProducer(Producer[KafkaPayload]):
         after a shutdown request has been issued (via ``close``) and all
         in-flight messages have been delivered.
         """
-        POLL_METRIC_FREQUENCY = 10
-        poll_count = 0
+        poll_count = 1
         while not self.__shutdown_requested.is_set():
             self.__producer.poll(0.1)
             if self.__record_poll_metrics:
-                if poll_count % POLL_METRIC_FREQUENCY == 0:
+                if poll_count % self.__poll_metric_frequency == 0:
                     self.__metrics.increment(
                         "arroyo.producer.worker.poll",
-                        value=POLL_METRIC_FREQUENCY,
+                        value=self.__poll_metric_frequency,
                         tags={
                             "producer_name": (
                                 self.producer_name if self.producer_name else "N/A"
                             )
                         },
                     )
+                    poll_count = 0
                 poll_count += 1
         self.__producer.flush()
 

--- a/arroyo/utils/metric_defs.py
+++ b/arroyo/utils/metric_defs.py
@@ -146,6 +146,10 @@ MetricName = Literal[
     # Gauge: Total number of request retries from librdkafka statistics
     # Tagged by broker_id, producer_name
     "arroyo.producer.librdkafka.broker_txretries",
+    # Counter: Incremented when the KafkaProducer worker thread polls the
+    # internal librdkafka producer.
+    # Tagged by producer_name
+    "arroyo.producer.worker.poll",
     # Counter: Incremented when backpressure is hit during join() in the
     # RunTask strategy (better_backpressure mode).
     "arroyo.strategies.run_task.join.backpressure",


### PR DESCRIPTION
Adds a sampled counter metric that's incremented when the arroyo `KafkaProducer` worker thread polls the internal librdkafka producer. Arroyo's metrics backend doesn't expose a `sample_rate` option so I did this manually by incrementing every X polls by X (configurable). Metric tracking is enabled when the produce is instantiated, I plan on enabling in Sentry thru an option.

This is being added in an attempt to root cause INC-2308.