### PR TITLE
ref(producer): Track futures based on arg, not env var

### DIFF
--- a/arroyo/backends/kafka/producer.py
+++ b/arroyo/backends/kafka/producer.py
@@ -1,5 +1,4 @@
 import atexit
-import os
 import threading
 from collections import defaultdict, deque
 from collections.abc import Callable
@@ -39,27 +38,27 @@ class CloseableProducerProtocol(Protocol):
 class FutureTrackingProducer:
     """
     FutureTrackingProducer is a producer abstraction that optionally registers futures
-    within the `_pending_futures` dict (depending on if the `ARROYO_TRACK_PRODUCER_FUTURES`
-    env var is set). Applications can then call the `collect_futures()` static method to
+    within the `_pending_futures` dict. Applications can then call the `collect_futures()` static method to
     get all registered futures, await them, etc.
 
     Args:
         name: Unique identifying name of this FutureTrackingProducer. Used to key `_pending_futures`.
         producer_factory: Callable that returns a producer object.
+        should_track_futures: Whether futures should be tracked in `_pending_futures`. Should only be True
+                              if you plan on calling `FutureTrackingProducer.collect_futures()` in your application,
+                              meaning you care about the results of batches of producer futures. Default False.
     """
-
-    def _should_track_futures(self) -> bool:
-        return os.environ.get("ARROYO_TRACK_PRODUCER_FUTURES", "").lower() == "true"
 
     def __init__(
         self,
         name: str,
         producer_factory: Callable[[], CloseableProducerProtocol],
+        should_track_futures: bool = False,
     ) -> None:
         self.name = name
         self._producer_factory = producer_factory
         self._inner_producer: CloseableProducerProtocol | None = None
-        self._track_futures = self._should_track_futures()
+        self._track_futures = should_track_futures
         # Used to ensure we don't instantiate duplicate producers when calling produce() from different threads.
         self._producer_lock = threading.Lock()
 

--- a/tests/backends/test_future_tracking_producer.py
+++ b/tests/backends/test_future_tracking_producer.py
@@ -2,7 +2,6 @@ from collections.abc import Iterator
 from concurrent.futures import Future
 from datetime import datetime
 from functools import partial
-from unittest.mock import patch
 
 import pytest
 
@@ -56,17 +55,11 @@ def clear_pending_futures() -> Iterator[None]:
     _pending_futures.clear()
 
 
-@pytest.fixture
-def track_futures() -> Iterator[None]:
-    with patch.object(
-        FutureTrackingProducer, "_should_track_futures", return_value=True
-    ):
-        yield
-
-
-def test_producer_tracks_futures(track_futures: None) -> None:
+def test_producer_tracks_futures() -> None:
     producer = FutureTrackingProducer(
-        "test.producer", partial(get_dummy_producer, use_simple_futures=True)
+        "test.producer",
+        partial(get_dummy_producer, use_simple_futures=True),
+        should_track_futures=True,
     )
     producer.produce(Topic("test"), make_kafka_payload())
     assert len(_pending_futures) == 1
@@ -76,9 +69,11 @@ def test_producer_tracks_futures(track_futures: None) -> None:
     assert len(_pending_futures) == 0
 
 
-def test_producer_executes_callbacks(track_futures: None) -> None:
+def test_producer_executes_callbacks() -> None:
     producer = FutureTrackingProducer(
-        "test.producer", partial(get_dummy_producer, use_simple_futures=False)
+        "test.producer",
+        partial(get_dummy_producer, use_simple_futures=False),
+        should_track_futures=True,
     )
     received: list[Future[BrokerValue[KafkaPayload]]] = []
 
@@ -94,9 +89,11 @@ def test_producer_executes_callbacks(track_futures: None) -> None:
     assert received[0].done()
 
 
-def test_producer_rejects_callbacks_for_simple_futures(track_futures: None) -> None:
+def test_producer_rejects_callbacks_for_simple_futures() -> None:
     producer = FutureTrackingProducer(
-        "test.producer", partial(get_dummy_producer, use_simple_futures=True)
+        "test.producer",
+        partial(get_dummy_producer, use_simple_futures=True),
+        should_track_futures=True,
     )
 
     def callback(future: Future[BrokerValue[KafkaPayload]]) -> None:
@@ -106,9 +103,11 @@ def test_producer_rejects_callbacks_for_simple_futures(track_futures: None) -> N
         producer.produce(Topic("test"), make_kafka_payload(), callbacks=[callback])
 
 
-def test_pending_futures_max_len(track_futures: None) -> None:
+def test_pending_futures_max_len() -> None:
     producer = FutureTrackingProducer(
-        "test.producer", partial(get_dummy_producer, use_simple_futures=True)
+        "test.producer",
+        partial(get_dummy_producer, use_simple_futures=True),
+        should_track_futures=True,
     )
     for _ in range(10001):
         producer.produce(Topic("test"), make_kafka_payload())
@@ -116,12 +115,11 @@ def test_pending_futures_max_len(track_futures: None) -> None:
 
 
 def test_producer_does_not_track_futures_when_disabled() -> None:
-    with patch.object(
-        FutureTrackingProducer, "_should_track_futures", return_value=False
-    ):
-        producer = FutureTrackingProducer(
-            "test.producer", partial(get_dummy_producer, use_simple_futures=True)
-        )
-        producer.produce(Topic("test"), make_kafka_payload())
+    producer = FutureTrackingProducer(
+        "test.producer",
+        partial(get_dummy_producer, use_simple_futures=True),
+        should_track_futures=False,
+    )
+    producer.produce(Topic("test"), make_kafka_payload())
     assert len(_pending_futures) == 0
     assert FutureTrackingProducer.collect_futures() == {}


### PR DESCRIPTION
This PR reworks `FutureTrackingProducer` to track futures based on args passed to the producer, not an environment variable. After release I'll add a helper function to Sentry that will generate an instance of FTP with this arg set depending on if we're in a taskworker or not.