### PR TITLE
feat(producer): add backpressure to FutureTrackingProducer

### DIFF
--- a/arroyo/backends/kafka/producer.py
+++ b/arroyo/backends/kafka/producer.py
@@ -1,5 +1,4 @@
 import atexit
-import os
 import threading
 from collections import defaultdict, deque
 from collections.abc import Callable
@@ -39,27 +38,27 @@ class CloseableProducerProtocol(Protocol):
 class FutureTrackingProducer:
     """
     FutureTrackingProducer is a producer abstraction that optionally registers futures
-    within the `_pending_futures` dict (depending on if the `ARROYO_TRACK_PRODUCER_FUTURES`
-    env var is set). Applications can then call the `collect_futures()` static method to
+    within the `_pending_futures` dict. Applications can then call the `collect_futures()` static method to
     get all registered futures, await them, etc.
 
     Args:
         name: Unique identifying name of this FutureTrackingProducer. Used to key `_pending_futures`.
         producer_factory: Callable that returns a producer object.
+        should_track_futures: Whether futures should be tracked in `_pending_futures`. Should only be True
+                              if you plan on calling `FutureTrackingProducer.collect_futures()` in your application,
+                              meaning you care about the results of batches of producer futures. Default False.
     """
-
-    def _should_track_futures(self) -> bool:
-        return os.environ.get("ARROYO_TRACK_PRODUCER_FUTURES", "").lower() == "true"
 
     def __init__(
         self,
         name: str,
         producer_factory: Callable[[], CloseableProducerProtocol],
+        should_track_futures: bool = False,
     ) -> None:
         self.name = name
         self._producer_factory = producer_factory
         self._inner_producer: CloseableProducerProtocol | None = None
-        self._track_futures = self._should_track_futures()
+        self._track_futures = should_track_futures
         # Used to ensure we don't instantiate duplicate producers when calling produce() from different threads.
         self._producer_lock = threading.Lock()
 

--- a/arroyo/backends/kafka/producer.py
+++ b/arroyo/backends/kafka/producer.py
@@ -57,7 +57,7 @@ class FutureTrackingProducer:
                              Default True.
         backpressure_queue_size_scale: How large the maxlen of this producer's future queues should be relative to
                                        the internal producer's producer queue max length. Must be a float in the
-                                       range (0, 1.0]. Default 0.8.
+                                       range (0, 1.0). Default 0.8.
     """
 
     def __init__(
@@ -71,6 +71,9 @@ class FutureTrackingProducer:
         assert (
             name not in _pending_futures
         ), "All FutureTrackingProducer instances in a single process must have a unique name."
+        assert (
+            queue_size_scale > 0 and queue_size_scale < 1
+        ), "queue_size_scale must be in the range (0, 1.0)."
         self.name = name
         self._producer_factory = producer_factory
         self._inner_producer: CloseableProducerProtocol | None = None
@@ -82,6 +85,7 @@ class FutureTrackingProducer:
         self._backpressure_queue: deque[
             ProducerFuture[BrokerValue[KafkaPayload]]
         ] = deque(maxlen=0)
+        _pending_futures[name] = deque(maxlen=0)
 
     def _get_queue_max_len(self) -> int:
         """
@@ -90,13 +94,15 @@ class FutureTrackingProducer:
         """
         if self._inner_producer:
             # queue.buffering.max.messages has a default value of 100k
-            internal_producer_queue_max_size = self._inner_producer.get_config().get(
-                "queue.buffering.max.messages", 100_000
+            internal_producer_queue_max_size = int(
+                self._inner_producer.get_config().get(
+                    "queue.buffering.max.messages", 100_000
+                )
             )
             return int(internal_producer_queue_max_size * self._queue_size_scale)
         return 0
 
-    def _initialize_producer(self) -> None:
+    def _initialize_producer_and_queues(self) -> None:
         self._inner_producer = self._producer_factory()
         atexit.register(self._shutdown)
         queues_max_len = self._get_queue_max_len()
@@ -110,7 +116,7 @@ class FutureTrackingProducer:
         if self._inner_producer is None:
             with self._producer_lock:
                 if self._inner_producer is None:
-                    self._initialize_producer()
+                    self._initialize_producer_and_queues()
         return cast(CloseableProducerProtocol, self._inner_producer)
 
     def track_future(self, future: ProducerFuture[BrokerValue[KafkaPayload]]) -> None:
@@ -137,9 +143,10 @@ class FutureTrackingProducer:
         in the same thread as the one calling `produce()`.
         """
 
-        pending_copy = _pending_futures.copy()
-        _pending_futures.clear()
-        return {name: set(val) for name, val in pending_copy.items()}
+        collected = {name: set(val) for name, val in _pending_futures.items()}
+        for producer in _pending_futures:
+            _pending_futures[producer].clear()
+        return collected
 
     def produce(
         self,
@@ -177,5 +184,6 @@ class FutureTrackingProducer:
                 )
 
     def _shutdown(self) -> None:
+        _pending_futures.pop(self.name, None)
         if self._inner_producer is not None:
             self._inner_producer.close().result()

--- a/arroyo/backends/kafka/producer.py
+++ b/arroyo/backends/kafka/producer.py
@@ -1,25 +1,20 @@
 import atexit
 import threading
-from collections import defaultdict, deque
+from collections import deque
 from collections.abc import Callable
 from concurrent.futures import Future
-from typing import Any, Protocol, Sequence
+from typing import Any, Protocol, Sequence, cast
 
 from arroyo.backends.abstract import ProducerFuture, SimpleProducerFuture
 from arroyo.backends.kafka import KafkaPayload
 from arroyo.types import BrokerValue, Partition, Topic
 
-MAX_PENDING_FUTURES = 10_000
-
-_pending_futures: defaultdict[
-    str, deque[ProducerFuture[BrokerValue[KafkaPayload]]]
-] = defaultdict(lambda: deque(maxlen=MAX_PENDING_FUTURES))
+_pending_futures: dict[str, deque[ProducerFuture[BrokerValue[KafkaPayload]]]] = {}
 """
 _pending_futures is global as a process may have several `FutureTrackingProducer` instances,
 and we want to collect futures from all running instances with a single call.
 Keys are the names of each `FutureTrackingProducer` instance in the current process, values are
-deques with a maxlen to prevent unbounded queue size in case we're set to track futures,
-but `collect_futures()` is never called.
+deques with a maxlen set by the corresponding `FutureTrackingProducer` instance.
 """
 
 
@@ -34,19 +29,35 @@ class CloseableProducerProtocol(Protocol):
     def close(self) -> Future[None]:
         ...
 
+    def get_config(self) -> dict[str, Any]:
+        ...
+
 
 class FutureTrackingProducer:
     """
-    FutureTrackingProducer is a producer abstraction that optionally registers futures
-    within the `_pending_futures` dict. Applications can then call the `collect_futures()` static method to
-    get all registered futures, await them, etc.
+    FutureTrackingProducer is a producer abstraction that optionally:
+    - Registers produce futures within the global `_pending_futures` dict, which applications can then
+      call the `collect_futures()` static method to get all futures in the dict
+    - Registers produce futures within a local backpressure queue, which, once full, will apply backpressure
+      by awaiting the result of the oldest future in the backpressure queue
+      - The purpose of this is to prevent the internal producer's produce queue from filling up, which raises an error
 
     Args:
         name: Unique identifying name of this FutureTrackingProducer. Used to key `_pending_futures`.
         producer_factory: Callable that returns a producer object.
-        should_track_futures: Whether futures should be tracked in `_pending_futures`. Should only be True
+        should_track_futures: Whether futures should be tracked in the global `_pending_futures`. Should only be True
                               if you plan on calling `FutureTrackingProducer.collect_futures()` in your application,
-                              meaning you care about the results of batches of producer futures. Default False.
+                              meaning you care about the results of batches of producer futures.
+                              Max size of the queue = ((internal producer queue max size) * `queue_size_scale`).
+                              Default False.
+        should_backpressure: Whether futures should be tracked in this producer's local `_backpressure_queue`.
+                             This will cause the producer to await the result of the oldest future in `_backpressure_queue`
+                             after producing when the queue is full.
+                             Max size of the queue = ((internal producer queue max size) * `queue_size_scale`).
+                             Default True.
+        backpressure_queue_size_scale: How large the maxlen of this producer's future queues should be relative to
+                                       the internal producer's producer queue max length. Must be a float in the
+                                       range (0, 1.0]. Default 0.8.
     """
 
     def __init__(
@@ -54,25 +65,65 @@ class FutureTrackingProducer:
         name: str,
         producer_factory: Callable[[], CloseableProducerProtocol],
         should_track_futures: bool = False,
+        should_backpressure: bool = True,
+        queue_size_scale: float = 0.8,
     ) -> None:
+        assert (
+            name not in _pending_futures
+        ), "All FutureTrackingProducer instances in a single process must have a unique name."
         self.name = name
         self._producer_factory = producer_factory
         self._inner_producer: CloseableProducerProtocol | None = None
         self._track_futures = should_track_futures
+        self._backpressure = should_backpressure
+        self._queue_size_scale = queue_size_scale
         # Used to ensure we don't instantiate duplicate producers when calling produce() from different threads.
         self._producer_lock = threading.Lock()
+        self._backpressure_queue: deque[
+            ProducerFuture[BrokerValue[KafkaPayload]]
+        ] = deque(maxlen=0)
+
+    def _get_queue_max_len(self) -> int:
+        """
+        Returns ((internal producer queue max size) * `queue_size_scale`).
+        Used to calculate the max length of future queues.
+        """
+        if self._inner_producer:
+            # queue.buffering.max.messages has a default value of 100k
+            internal_producer_queue_max_size = self._inner_producer.get_config().get(
+                "queue.buffering.max.messages", 100_000
+            )
+            return int(internal_producer_queue_max_size * self._queue_size_scale)
+        return 0
+
+    def _initialize_producer(self) -> None:
+        self._inner_producer = self._producer_factory()
+        atexit.register(self._shutdown)
+        queues_max_len = self._get_queue_max_len()
+        if self._backpressure:
+            self._backpressure_queue = deque(maxlen=queues_max_len)
+        if self._track_futures:
+            _pending_futures[self.name] = deque(maxlen=queues_max_len)
 
     def _get(self) -> CloseableProducerProtocol:
         # None check first so we don't have any lock contention on produces
         if self._inner_producer is None:
             with self._producer_lock:
                 if self._inner_producer is None:
-                    self._inner_producer = self._producer_factory()
-                    atexit.register(self._shutdown)
-        return self._inner_producer
+                    self._initialize_producer()
+        return cast(CloseableProducerProtocol, self._inner_producer)
 
     def track_future(self, future: ProducerFuture[BrokerValue[KafkaPayload]]) -> None:
-        _pending_futures[self.name].append(future)
+        if self._track_futures:
+            _pending_futures[self.name].append(future)
+        if self._backpressure:
+            if len(self._backpressure_queue) == self._backpressure_queue.maxlen:
+                try:
+                    # Backpressure on the result of the oldest future in the backpressure queue
+                    self._backpressure_queue[0].result()
+                except Exception:
+                    pass
+            self._backpressure_queue.append(future)
 
     @staticmethod
     def collect_futures() -> dict[str, set[ProducerFuture[BrokerValue[KafkaPayload]]]]:
@@ -110,8 +161,7 @@ class FutureTrackingProducer:
         """
 
         future = self._get().produce(dest, payload)
-        if self._track_futures:
-            self.track_future(future)
+        self.track_future(future)
         if callbacks:
             # Arroyo producers can return a SimpleProducerFuture,
             # which does not accept callbacks.

--- a/tests/backends/test_future_tracking_producer.py
+++ b/tests/backends/test_future_tracking_producer.py
@@ -2,7 +2,6 @@ from collections.abc import Iterator
 from concurrent.futures import Future
 from datetime import datetime
 from functools import partial
-from unittest.mock import patch
 
 import pytest
 
@@ -56,17 +55,11 @@ def clear_pending_futures() -> Iterator[None]:
     _pending_futures.clear()
 
 
-@pytest.fixture
-def track_futures() -> Iterator[None]:
-    with patch.object(
-        FutureTrackingProducer, "_should_track_futures", return_value=True
-    ):
-        yield
-
-
-def test_producer_tracks_futures(track_futures: None) -> None:
+def test_producer_tracks_futures() -> None:
     producer = FutureTrackingProducer(
-        "test.producer", partial(get_dummy_producer, use_simple_futures=True)
+        "test.producer",
+        partial(get_dummy_producer, use_simple_futures=True),
+        should_track_futures=True,
     )
     producer.produce(Topic("test"), make_kafka_payload())
     assert len(_pending_futures) == 1
@@ -76,9 +69,11 @@ def test_producer_tracks_futures(track_futures: None) -> None:
     assert len(_pending_futures) == 0
 
 
-def test_producer_executes_callbacks(track_futures: None) -> None:
+def test_producer_executes_callbacks() -> None:
     producer = FutureTrackingProducer(
-        "test.producer", partial(get_dummy_producer, use_simple_futures=False)
+        "test.producer",
+        partial(get_dummy_producer, use_simple_futures=False),
+        should_track_futures=True,
     )
     received: list[Future[BrokerValue[KafkaPayload]]] = []
 
@@ -94,9 +89,11 @@ def test_producer_executes_callbacks(track_futures: None) -> None:
     assert received[0].done()
 
 
-def test_producer_rejects_callbacks_for_simple_futures(track_futures: None) -> None:
+def test_producer_rejects_callbacks_for_simple_futures() -> None:
     producer = FutureTrackingProducer(
-        "test.producer", partial(get_dummy_producer, use_simple_futures=True)
+        "test.producer",
+        partial(get_dummy_producer, use_simple_futures=True),
+        should_track_futures=True,
     )
 
     def callback(future: Future[BrokerValue[KafkaPayload]]) -> None:
@@ -106,9 +103,11 @@ def test_producer_rejects_callbacks_for_simple_futures(track_futures: None) -> N
         producer.produce(Topic("test"), make_kafka_payload(), callbacks=[callback])
 
 
-def test_pending_futures_max_len(track_futures: None) -> None:
+def test_pending_futures_max_len() -> None:
     producer = FutureTrackingProducer(
-        "test.producer", partial(get_dummy_producer, use_simple_futures=True)
+        "test.producer",
+        partial(get_dummy_producer, use_simple_futures=True),
+        should_track_futures=True,
     )
     for _ in range(10001):
         producer.produce(Topic("test"), make_kafka_payload())
@@ -116,12 +115,11 @@ def test_pending_futures_max_len(track_futures: None) -> None:
 
 
 def test_producer_does_not_track_futures_when_disabled() -> None:
-    with patch.object(
-        FutureTrackingProducer, "_should_track_futures", return_value=False
-    ):
-        producer = FutureTrackingProducer(
-            "test.producer", partial(get_dummy_producer, use_simple_futures=True)
-        )
-        producer.produce(Topic("test"), make_kafka_payload())
+    producer = FutureTrackingProducer(
+        "test.producer",
+        partial(get_dummy_producer, use_simple_futures=True),
+        should_track_futures=False,
+    )
+    producer.produce(Topic("test"), make_kafka_payload())
     assert len(_pending_futures) == 0
     assert FutureTrackingProducer.collect_futures() == {}

--- a/tests/backends/test_future_tracking_producer.py
+++ b/tests/backends/test_future_tracking_producer.py
@@ -2,6 +2,7 @@ from collections.abc import Iterator
 from concurrent.futures import Future
 from datetime import datetime
 from functools import partial
+from typing import Any, cast
 
 import pytest
 
@@ -23,9 +24,30 @@ def make_broker_value() -> BrokerValue[KafkaPayload]:
     )
 
 
+class ResultTrackingFuture(Future):  # type: ignore
+    """A Future that records how many times its result() has been awaited."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.result_call_count = 0
+
+    def result(self, timeout: float | None = None) -> Any:
+        self.result_call_count += 1
+        return super().result(timeout)
+
+
 class DummyProducer:
-    def __init__(self, use_simple_futures: bool):
+    def __init__(
+        self,
+        use_simple_futures: bool,
+        queue_max_messages: int = 12500,
+        produced_futures: list[ProducerFuture[BrokerValue[KafkaPayload]]] | None = None,
+        track_results: bool = False,
+    ):
         self.use_simple_futures = use_simple_futures
+        self.queue_max_messages = queue_max_messages
+        self.produced_futures = produced_futures
+        self.track_results = track_results
 
     def produce(
         self, destination: Topic | Partition, payload: KafkaPayload
@@ -33,9 +55,13 @@ class DummyProducer:
         future: ProducerFuture[BrokerValue[KafkaPayload]]
         if self.use_simple_futures:
             future = SimpleProducerFuture()
+        elif self.track_results:
+            future = ResultTrackingFuture()
         else:
             future = Future()
         future.set_result(make_broker_value())
+        if self.produced_futures is not None:
+            self.produced_futures.append(future)
         return future
 
     def close(self) -> Future[None]:
@@ -43,9 +69,22 @@ class DummyProducer:
         f.set_result(None)
         return f
 
+    def get_config(self) -> dict[str, Any]:
+        return {"queue.buffering.max.messages": self.queue_max_messages}
 
-def get_dummy_producer(use_simple_futures: bool) -> DummyProducer:
-    return DummyProducer(use_simple_futures=use_simple_futures)
+
+def get_dummy_producer(
+    use_simple_futures: bool,
+    queue_max_messages: int = 12500,
+    produced_futures: list[ProducerFuture[BrokerValue[KafkaPayload]]] | None = None,
+    track_results: bool = False,
+) -> DummyProducer:
+    return DummyProducer(
+        use_simple_futures=use_simple_futures,
+        queue_max_messages=queue_max_messages,
+        produced_futures=produced_futures,
+        track_results=track_results,
+    )
 
 
 @pytest.fixture(autouse=True)
@@ -123,3 +162,45 @@ def test_producer_does_not_track_futures_when_disabled() -> None:
     producer.produce(Topic("test"), make_kafka_payload())
     assert len(_pending_futures) == 0
     assert FutureTrackingProducer.collect_futures() == {}
+
+
+def test_backpressure_queue_awaits_oldest_future_when_full() -> None:
+    produced: list[ProducerFuture[BrokerValue[KafkaPayload]]] = []
+    producer = FutureTrackingProducer(
+        "test.producer",
+        partial(
+            get_dummy_producer,
+            use_simple_futures=False,
+            queue_max_messages=3,
+            produced_futures=produced,
+            track_results=True,
+        ),
+        should_backpressure=True,
+        queue_size_scale=1.0,
+    )
+
+    # Fill the queue exactly to its maxlen of 3. No backpressure applied yet.
+    for _ in range(3):
+        producer.produce(Topic("test"), make_kafka_payload())
+    assert all(cast(ResultTrackingFuture, f).result_call_count == 0 for f in produced)
+
+    # The 4th produce finds the queue full and awaits the oldest (first) future.
+    producer.produce(Topic("test"), make_kafka_payload())
+    assert cast(ResultTrackingFuture, produced[0]).result_call_count == 1
+    # The evicted future should no longer be in the queue.
+    assert produced[0] not in producer._backpressure_queue
+    assert len(producer._backpressure_queue) == 3
+    assert list(producer._backpressure_queue) == produced[1:]
+
+
+def test_backpressure_queue_disabled() -> None:
+    producer = FutureTrackingProducer(
+        "test.producer",
+        partial(get_dummy_producer, use_simple_futures=True, queue_max_messages=3),
+        should_backpressure=False,
+        queue_size_scale=1.0,
+    )
+    for _ in range(10):
+        producer.produce(Topic("test"), make_kafka_payload())
+    assert producer._backpressure_queue.maxlen == 0
+    assert len(producer._backpressure_queue) == 0

--- a/tests/backends/test_future_tracking_producer.py
+++ b/tests/backends/test_future_tracking_producer.py
@@ -105,7 +105,7 @@ def test_producer_tracks_futures() -> None:
     collected = FutureTrackingProducer.collect_futures()
     future = next(iter(collected["test.producer"]))
     assert future.result() == make_broker_value()
-    assert len(_pending_futures) == 0
+    assert len(_pending_futures["test.producer"]) == 0
 
 
 def test_producer_executes_callbacks() -> None:
@@ -160,8 +160,8 @@ def test_producer_does_not_track_futures_when_disabled() -> None:
         should_track_futures=False,
     )
     producer.produce(Topic("test"), make_kafka_payload())
-    assert len(_pending_futures) == 0
-    assert FutureTrackingProducer.collect_futures() == {}
+    assert len(_pending_futures["test.producer"]) == 0
+    assert FutureTrackingProducer.collect_futures() == {"test.producer": set()}
 
 
 def test_backpressure_queue_awaits_oldest_future_when_full() -> None:
@@ -171,23 +171,20 @@ def test_backpressure_queue_awaits_oldest_future_when_full() -> None:
         partial(
             get_dummy_producer,
             use_simple_futures=False,
-            queue_max_messages=3,
+            queue_max_messages=6,
             produced_futures=produced,
             track_results=True,
         ),
         should_backpressure=True,
-        queue_size_scale=1.0,
+        queue_size_scale=0.5,
     )
 
-    # Fill the queue exactly to its maxlen of 3. No backpressure applied yet.
     for _ in range(3):
         producer.produce(Topic("test"), make_kafka_payload())
     assert all(cast(ResultTrackingFuture, f).result_call_count == 0 for f in produced)
 
-    # The 4th produce finds the queue full and awaits the oldest (first) future.
     producer.produce(Topic("test"), make_kafka_payload())
     assert cast(ResultTrackingFuture, produced[0]).result_call_count == 1
-    # The evicted future should no longer be in the queue.
     assert produced[0] not in producer._backpressure_queue
     assert len(producer._backpressure_queue) == 3
     assert list(producer._backpressure_queue) == produced[1:]
@@ -196,9 +193,9 @@ def test_backpressure_queue_awaits_oldest_future_when_full() -> None:
 def test_backpressure_queue_disabled() -> None:
     producer = FutureTrackingProducer(
         "test.producer",
-        partial(get_dummy_producer, use_simple_futures=True, queue_max_messages=3),
+        partial(get_dummy_producer, use_simple_futures=True, queue_max_messages=6),
         should_backpressure=False,
-        queue_size_scale=1.0,
+        queue_size_scale=0.5,
     )
     for _ in range(10):
         producer.produce(Topic("test"), make_kafka_payload())


### PR DESCRIPTION
This PR:
- Adds a new queue called `_backpressure_queue` to `FutureTrackingProducer`, which also stores produce futures
  - Once the queue is full, the producer will await the result of the oldest future in the queue. This acts as backpressure to keep the internal producer's produce queue from filling up, which raises an error
  - The max length of the backpressure queue is based on the max size of the internal producer's produce queue
  - Backpressure can be disabled via a parameter passed to `FutureTrackingProducer`
- Makes the max size of the producer's queue in `_pending_futures` to be based off of the internal producer's produce queue max size, rather than a static value of 10k
- Adds an assertion that each instance of `FutureTrackingProducer` in a Python process has a unique name
- Adds tests for the backpressure queue