### PR TITLE
fix(producer): Register FutureTrackingProducer shutdown eagerly

### DIFF
--- a/arroyo/backends/kafka/producer.py
+++ b/arroyo/backends/kafka/producer.py
@@ -62,6 +62,13 @@ class FutureTrackingProducer:
         self._track_futures = self._should_track_futures()
         # Used to ensure we don't instantiate duplicate producers when calling produce() from different threads.
         self._producer_lock = threading.Lock()
+        # Registered here rather than lazily on the first produce, because atexit runs
+        # handlers in reverse registration order. Callers that buffer messages and flush
+        # them into this producer from their own atexit handler register that handler at
+        # construction time, which is before our first produce. Registering lazily would
+        # put our close ahead of their flush and the flush would hit a closed producer.
+        # `_shutdown` is a no-op if the inner producer was never created.
+        atexit.register(self._shutdown)
 
     def _get(self) -> CloseableProducerProtocol:
         # None check first so we don't have any lock contention on produces
@@ -69,7 +76,6 @@ class FutureTrackingProducer:
             with self._producer_lock:
                 if self._inner_producer is None:
                     self._inner_producer = self._producer_factory()
-                    atexit.register(self._shutdown)
         return self._inner_producer
 
     def track_future(self, future: ProducerFuture[BrokerValue[KafkaPayload]]) -> None:

--- a/tests/backends/test_future_tracking_producer.py
+++ b/tests/backends/test_future_tracking_producer.py
@@ -115,6 +115,33 @@ def test_pending_futures_max_len(track_futures: None) -> None:
     assert len(_pending_futures["test.producer"]) == 10000
 
 
+def test_registers_shutdown_at_construction() -> None:
+    # The shutdown must be registered eagerly, not on the first produce, so that
+    # atexit's reverse ordering runs it after handlers registered by callers that
+    # flush buffered messages into this producer at exit.
+    with patch("arroyo.backends.kafka.producer.atexit.register") as register:
+        producer = FutureTrackingProducer(
+            "test.producer", partial(get_dummy_producer, use_simple_futures=True)
+        )
+
+    register.assert_called_once_with(producer._shutdown)
+
+    # A producer that never produced closes cleanly.
+    producer._shutdown()
+
+
+def test_shutdown_closes_inner_producer() -> None:
+    producer = FutureTrackingProducer(
+        "test.producer", partial(get_dummy_producer, use_simple_futures=True)
+    )
+    producer.produce(Topic("test"), make_kafka_payload())
+
+    with patch.object(DummyProducer, "close", wraps=producer._get().close) as close:
+        producer._shutdown()
+
+    assert close.call_count == 1
+
+
 def test_producer_does_not_track_futures_when_disabled() -> None:
     with patch.object(
         FutureTrackingProducer, "_should_track_futures", return_value=False


### PR DESCRIPTION
`FutureTrackingProducer` registered its `atexit` close lazily, on the first `produce()`. Since `atexit` runs handlers in reverse registration order, any caller that buffers messages and flushes them into the producer from its own `atexit` handler loses that flush: the caller registers at construction time, which is before our first produce, so the producer's close ends up ahead of the flush and the flush hits an already-closed producer.

```
RuntimeError: producer has been closed
```

Sentry hits this with `OutcomeAggregator`, which buffers outcomes in memory and flushes them into the outcomes producer at exit. Every taskworker child that shuts down or recycles drops whatever outcomes were still buffered. Sentry previously fixed the same bug in its own `SingletonProducer` ([getsentry/sentry#118650](https://github.com/getsentry/sentry/pull/118650)) by registering eagerly, then switched the outcomes path to `FutureTrackingProducer` ([getsentry/sentry#119126](https://github.com/getsentry/sentry/pull/119126)), which reintroduced it.

## Fix

Register the shutdown in `__init__` instead, so it runs after handlers registered later. `_shutdown` already no-ops when the inner producer was never created, so producers that never produce are unaffected.

## Tests

- `test_registers_shutdown_at_construction` — asserts the registration happens in the constructor. Verified this fails on `main` and passes with the fix.
- `test_shutdown_closes_inner_producer` — guards the other half, that moving the registration didn't break the actual close.