### PR TITLE
feat(reduce): track batch trigger reason on batch_time metric.

### DIFF
--- a/arroyo/processing/strategies/buffer.py
+++ b/arroyo/processing/strategies/buffer.py
@@ -42,6 +42,14 @@ class BufferProtocol(Protocol[TPayload, TResult]):
         """
         ...
 
+    @property
+    def readiness_reason(self) -> str:
+        """Returns why is_ready returned True.
+
+        Only meaningful when is_ready is True. Used for observability.
+        """
+        ...
+
     def append(self, message: BaseValue[TPayload]) -> None:
         """Accept a TPayload mutating the internal state of the batch builder."""
         ...
@@ -115,9 +123,12 @@ class Buffer(
             )
         )
         self.__next_step.submit(buffer_msg)
+
+        flush_reason = self.__buffer.readiness_reason if self.__buffer.is_ready else "force"
         self.__metrics.timing(
             "arroyo.strategies.reduce.batch_time",
             time.time() - self.__init_time,
+            tags={"flush_reason": flush_reason},
         )
 
         # Reset to the empty state.

--- a/arroyo/processing/strategies/reduce.py
+++ b/arroyo/processing/strategies/reduce.py
@@ -48,6 +48,12 @@ class ReduceBuffer(Generic[TPayload, TResult]):
             or time.time() >= self._buffer_until
         )
 
+    @property
+    def readiness_reason(self) -> str:
+        if self._buffer_size >= self.max_batch_size:
+            return "size"
+        return "time"
+
     def append(self, message: BaseValue[TPayload]) -> None:
         self._buffer = self.accumulator(self._buffer, message)
         if self.compute_batch_size:

--- a/rust-arroyo/src/processing/strategies/reduce.rs
+++ b/rust-arroyo/src/processing/strategies/reduce.rs
@@ -191,14 +191,19 @@ impl<T, TResult> Reduce<T, TResult> {
         }
 
         let batch_time = self.batch_state.batch_start_time.elapsed();
-        let batch_complete = self.batch_state.message_count >= self.max_batch_size
-            || batch_time >= self.max_batch_time;
+        let size_trigger_complete = self.batch_state.message_count >= self.max_batch_size;
+        let time_trigger_complete = batch_time >= self.max_batch_time;
+        let batch_complete = size_trigger_complete || time_trigger_complete;
 
         if !batch_complete && !force {
             return Ok(());
         }
 
-        timer!("arroyo.strategies.reduce.batch_time.ms", batch_time);
+        timer!(
+            "arroyo.strategies.reduce.batch_time.ms",
+            batch_time,
+            "trigger_reason" => if size_trigger_complete { "size" } else { "time" }
+        );
 
         let batch_state = mem::replace(
             &mut self.batch_state,

--- a/rust-arroyo/src/processing/strategies/reduce.rs
+++ b/rust-arroyo/src/processing/strategies/reduce.rs
@@ -193,16 +193,23 @@ impl<T, TResult> Reduce<T, TResult> {
         let batch_time = self.batch_state.batch_start_time.elapsed();
         let size_trigger_complete = self.batch_state.message_count >= self.max_batch_size;
         let time_trigger_complete = batch_time >= self.max_batch_time;
-        let batch_complete = size_trigger_complete || time_trigger_complete;
 
-        if !batch_complete && !force {
+        if !size_trigger_complete && !time_trigger_complete && !force {
             return Ok(());
         }
+
+        let trigger_reason = if size_trigger_complete {
+            "size"
+        } else if  time_trigger_complete {
+            "time"
+        } else {
+            "force"
+        };
 
         timer!(
             "arroyo.strategies.reduce.batch_time.ms",
             batch_time,
-            "trigger_reason" => if size_trigger_complete { "size" } else { "time" }
+            "trigger_reason" => trigger_reason
         );
 
         let batch_state = mem::replace(

--- a/rust-arroyo/src/processing/strategies/reduce.rs
+++ b/rust-arroyo/src/processing/strategies/reduce.rs
@@ -200,7 +200,7 @@ impl<T, TResult> Reduce<T, TResult> {
 
         let flush_reason = if size_trigger_complete {
             "size"
-        } else if  time_trigger_complete {
+        } else if time_trigger_complete {
             "time"
         } else {
             "force"

--- a/rust-arroyo/src/processing/strategies/reduce.rs
+++ b/rust-arroyo/src/processing/strategies/reduce.rs
@@ -198,7 +198,7 @@ impl<T, TResult> Reduce<T, TResult> {
             return Ok(());
         }
 
-        let trigger_reason = if size_trigger_complete {
+        let flush_reason = if size_trigger_complete {
             "size"
         } else if  time_trigger_complete {
             "time"
@@ -209,7 +209,7 @@ impl<T, TResult> Reduce<T, TResult> {
         timer!(
             "arroyo.strategies.reduce.batch_time.ms",
             batch_time,
-            "trigger_reason" => trigger_reason
+            "flush_reason" => flush_reason
         );
 
         let batch_state = mem::replace(

--- a/tests/processing/strategies/test_buffer.py
+++ b/tests/processing/strategies/test_buffer.py
@@ -22,6 +22,10 @@ class BufferTest:
     def is_ready(self) -> bool:
         return len(self._buffer) >= 3
 
+    @property
+    def readiness_reason(self) -> str:
+        return "size"
+
     def append(self, message: BaseValue[int]) -> None:
         self._buffer.append(message.payload)
 


### PR DESCRIPTION
## What
Tag `arroyo.strategies.reduce.batch_time.ms` with which trigger (`size` or `time`) caused the flush.

## How
- Compute `size_trigger_complete`/`time_trigger_complete` explicitly in `Reduce::flush()`
- Add a `trigger_reason` tag to the existing `batch_time.ms` timer instead of a new metric

## Why
- We're doing some batch size in Snuba tuning and would like to know which trigger is actually firing
- Reusing the existing timer gets flush count *and* duration split by reason for free, no new metric to track

## Notes
- Known gap: forced flushes (shutdown/rebalance via `join()`) that hit neither trigger still get tagged `"time"` — fine for now, but a `"forced"` value would make the metric fully trustworthy

## Links
- [EAP-694](https://linear.app/getsentry/issue/EAP-694/revisit-byte-based-max-batch-size-calculation)