### PR TITLE
chore: Widens supported rdkafka range to >=0.37.0,<0.40

### DIFF
--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -22,14 +22,20 @@ jobs:
       - run: cargo fmt --check
 
   test:
-    name: "Tests"
+    name: "Tests (rdkafka ${{ matrix.rdkafka }})"
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    strategy:
+      fail-fast: false
+      matrix:
+        rdkafka: ["0.37.0", "0.38.0", "0.39.0"]
     steps:
       - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
         name: Checkout code
       - name: Install system dependencies
         run: sudo apt-get update && sudo apt-get install -y libcurl4-openssl-dev
+      - name: Resolve rdkafka ${{ matrix.rdkafka }}
+        run: cargo update -p rdkafka --precise "${{ matrix.rdkafka }}"
       - name: Run Kafka
         run: sh scripts/run-kafka.sh
       - name: Run tests

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ chrono = "0.4.26"
 coarsetime = "0.1.33"
 once_cell = "1.18.0"
 rand = "0.8.5"
-rdkafka = { version = ">=0.37.0,<0.39", features = ["cmake-build", "tracing"] }
+rdkafka = { version = ">=0.37.0,<0.40", features = ["cmake-build", "tracing"] }
 sentry-core = { version = ">=0.32", features = ["client"] }
 serde = { version = "1.0.137", features = ["derive"] }
 serde_json = "1.0.81"


### PR DESCRIPTION
Widens the supported rdkafka version range to <0.40. Arroyo builds successfully and all Rust and Kafka integration tests pass locally with rdkafka 0.39.0.