### PR TITLE
feat(metrics): DLQ produce failures no increment a counter and log instead of panic.

### DIFF
--- a/rust-arroyo/src/processing/dlq.rs
+++ b/rust-arroyo/src/processing/dlq.rs
@@ -84,7 +84,7 @@ impl DlqProducer<KafkaPayload> for KafkaDlqProducer {
 
         headers = headers.insert(
             "original_partition",
-            Some(message.offset.to_string().into_bytes()),
+            Some(message.partition.index.to_string().into_bytes()),
         );
         headers = headers.insert(
             "original_offset",
@@ -98,9 +98,10 @@ impl DlqProducer<KafkaPayload> for KafkaDlqProducer {
         );
 
         Box::pin(async move {
-            producer
-                .produce(&topic, payload)
-                .expect("Message was produced");
+            if let Err(err) = producer.produce(&topic, payload) {
+                counter!("arroyo.consumer.dlq.produce_error", 1);
+                tracing::error!("Failed to produce to DLQ: {:?}", err);
+            }
 
             message
         })


### PR DESCRIPTION
## What
Fix DLQ producer panic + add observability for produce failures.

## How
- Replace `.expect()` in `KafkaDlqProducer::produce()` with `tracing::error!` + `arroyo.consumer.dlq.produce_error` counter

## Other
- Fix `original_partition` header — was writing offset instead of partition index

## Why
- DLQ produce failures (e.g. `MessageSizeTooLarge`) panic, get caught by the JoinHandle, and silently drop the message. 1,467 occurrences on eap-items since May 29.
- `tracing::error!` surfaces as a Sentry issue via the sentry-tracing layer. Counter gives DD visibility.

## Links
- [EAP-737](https://linear.app/getsentry/issue/EAP-737/dlq-producer-silently-drops-oversized-messages-snuba-b3q)
- [SNUBA-B3Q](https://sentry.sentry.io/issues/7514566310/?project=300688)