### PR TITLE
feat(producer): Support custom contexts for synchronous Kafka producers

### DIFF
--- a/rust-arroyo/src/backends/kafka/producer.rs
+++ b/rust-arroyo/src/backends/kafka/producer.rs
@@ -97,9 +97,7 @@ where
     /// return without a callback; producing does not wait for delivery.
     pub fn new_with_context(config: KafkaConfig, context: C) -> Result<Self, KafkaError> {
         let topic_validation = config.topic_validation;
-        let mut config_obj: ClientConfig = config.into();
-        // Ensure successful messages also receive delivery callbacks.
-        config_obj.set("delivery.report.only.error", "false");
+        let config_obj: ClientConfig = config.into();
         let threaded_producer: ThreadedProducer<_> = config_obj.create_with_context(context)?;
 
         if let Some((topic, timeout)) = topic_validation {
@@ -498,13 +496,7 @@ mod tests {
     #[test]
     fn test_delivery_callback_success() {
         let cluster = MockCluster::new(1).unwrap();
-        let config = KafkaConfig::new_producer_config(
-            vec![cluster.bootstrap_servers()],
-            Some(HashMap::from([(
-                "delivery.report.only.error".to_string(),
-                "true".to_string(),
-            )])),
-        );
+        let config = KafkaConfig::new_producer_config(vec![cluster.bootstrap_servers()], None);
         let (producer, reports) = callback_producer(config);
         let destination = TopicOrPartition::Topic(Topic::new("test"));
 

--- a/rust-arroyo/src/backends/kafka/producer.rs
+++ b/rust-arroyo/src/backends/kafka/producer.rs
@@ -13,7 +13,7 @@ use rdkafka::producer::{
     DeliveryResult, FutureProducer, Producer as _, ProducerContext as RdkafkaProducerContext,
     ThreadedProducer,
 };
-use rdkafka::Statistics;
+use rdkafka::{Message, Statistics};
 use std::time::Duration;
 
 mod statistics;
@@ -23,7 +23,7 @@ pub struct ProducerContext {
 }
 
 impl ProducerContext {
-    fn new(producer_name: String) -> Self {
+    pub fn new(producer_name: String) -> Self {
         Self { producer_name }
     }
 
@@ -43,25 +43,34 @@ impl RdkafkaProducerContext for ProducerContext {
 
     fn delivery(
         &self,
-        _delivery_result: &DeliveryResult<'_>,
+        delivery_result: &DeliveryResult<'_>,
         _delivery_opaque: Self::DeliveryOpaque,
     ) {
-        let result = match _delivery_result {
-            Ok(_) => "success".to_string(),
-            Err((err, _)) => get_error_name(err),
+        let producer_name = self.get_producer_name().to_owned();
+        let counter = match delivery_result {
+            Ok(message) => metrics::counter!(
+                "arroyo.producer.produce_status",
+                "status" => "success",
+                "topic" => message.topic().to_owned(),
+                "producer_name" => producer_name
+            ),
+            Err((err, message)) => metrics::counter!(
+                "arroyo.producer.produce_status",
+                "status" => "error",
+                "code" => get_error_name(err),
+                "topic" => message.topic().to_owned(),
+                "producer_name" => producer_name
+            ),
         };
-        let producer_name = self.get_producer_name();
-        metrics::counter!(
-            "arroyo.producer.produce_status",
-            "status" => result,
-            "producer_name" => producer_name.to_owned()
-        )
-        .increment(1);
+        counter.increment(1);
     }
 }
 
-pub struct KafkaProducer {
-    producer: ThreadedProducer<ProducerContext>,
+pub struct KafkaProducer<C = ProducerContext>
+where
+    C: RdkafkaProducerContext<DeliveryOpaque = ()> + 'static,
+{
+    producer: ThreadedProducer<C>,
 }
 
 impl KafkaProducer {
@@ -73,9 +82,24 @@ impl KafkaProducer {
             .get_config_value("client.id")
             .cloned()
             .unwrap_or_else(|| "unknown".to_string());
-        let context = ProducerContext::new(producer_name.clone());
+        let context = ProducerContext::new(producer_name);
+        Self::new_with_context(config, context)
+    }
+}
+
+impl<C> KafkaProducer<C>
+where
+    C: RdkafkaProducerContext<DeliveryOpaque = ()> + 'static,
+{
+    /// Creates a producer with a custom context, replacing Arroyo's metrics callbacks.
+    ///
+    /// Delivery callbacks run once per accepted message. Immediate enqueue errors
+    /// return without a callback; producing does not wait for delivery.
+    pub fn new_with_context(config: KafkaConfig, context: C) -> Result<Self, KafkaError> {
         let topic_validation = config.topic_validation;
-        let config_obj: ClientConfig = config.into();
+        let mut config_obj: ClientConfig = config.into();
+        // Ensure successful messages also receive delivery callbacks.
+        config_obj.set("delivery.report.only.error", "false");
         let threaded_producer: ThreadedProducer<_> = config_obj.create_with_context(context)?;
 
         if let Some((topic, timeout)) = topic_validation {
@@ -87,12 +111,19 @@ impl KafkaProducer {
         })
     }
 
+    pub fn context(&self) -> &C {
+        self.producer.context().as_ref()
+    }
+
     pub fn in_flight_count(&self) -> i32 {
         self.producer.in_flight_count()
     }
 }
 
-impl ArroyoProducer<KafkaPayload> for KafkaProducer {
+impl<C> ArroyoProducer<KafkaPayload> for KafkaProducer<C>
+where
+    C: RdkafkaProducerContext<DeliveryOpaque = ()> + 'static,
+{
     fn produce(
         &self,
         destination: &TopicOrPartition,
@@ -242,18 +273,28 @@ impl ArroyoAsyncProducer<KafkaPayload> for AsyncKafkaProducer {
 
 #[cfg(test)]
 mod tests {
-    use super::{AsyncKafkaProducer, KafkaProducer};
+    use super::{AsyncKafkaProducer, KafkaProducer, RdkafkaProducerContext};
     use crate::backends::kafka::config::KafkaConfig;
     use crate::backends::kafka::types::KafkaPayload;
     use crate::backends::{AsyncProducer, Producer, ProducerError};
     use crate::types::{Topic, TopicOrPartition};
+    use rdkafka::client::ClientContext;
     use rdkafka::error::{KafkaError, RDKafkaErrorCode};
+    use rdkafka::message::Message;
     use rdkafka::mocking::MockCluster;
+    use rdkafka::producer::{DeliveryResult, Producer as _};
+    use rdkafka::types::{RDKafkaApiKey, RDKafkaRespErr};
     use std::collections::HashMap;
+    use std::sync::mpsc::{self, Receiver, Sender};
     use std::time::Duration;
 
     fn assert_producer_creation(config: KafkaConfig, expected: Result<(), KafkaError>) {
         assert_eq!(KafkaProducer::new(config.clone()).map(|_| ()), expected);
+        let (sender, _) = mpsc::channel();
+        assert_eq!(
+            KafkaProducer::new_with_context(config.clone(), CapturingContext(sender)).map(|_| ()),
+            expected
+        );
         assert_eq!(AsyncKafkaProducer::new(config).map(|_| ()), expected);
     }
 
@@ -424,5 +465,122 @@ mod tests {
             AsyncKafkaProducer::new(configuration),
             Err(KafkaError::ClientConfig(..))
         ));
+    }
+
+    type DeliveryReport = (Option<KafkaError>, String, usize);
+
+    struct CapturingContext(Sender<DeliveryReport>);
+
+    impl ClientContext for CapturingContext {}
+
+    impl RdkafkaProducerContext for CapturingContext {
+        type DeliveryOpaque = ();
+
+        fn delivery(&self, result: &DeliveryResult<'_>, (): ()) {
+            let (error, message) = match result {
+                Ok(message) => (None, message),
+                Err((error, message)) => (Some(error.clone()), message),
+            };
+            let _ = self
+                .0
+                .send((error, message.topic().to_owned(), message.payload_len()));
+        }
+    }
+
+    fn callback_producer(
+        config: KafkaConfig,
+    ) -> (KafkaProducer<CapturingContext>, Receiver<DeliveryReport>) {
+        let (sender, reports) = mpsc::channel();
+        let producer = KafkaProducer::new_with_context(config, CapturingContext(sender)).unwrap();
+        (producer, reports)
+    }
+
+    #[test]
+    fn test_delivery_callback_success() {
+        let cluster = MockCluster::new(1).unwrap();
+        let config = KafkaConfig::new_producer_config(
+            vec![cluster.bootstrap_servers()],
+            Some(HashMap::from([(
+                "delivery.report.only.error".to_string(),
+                "true".to_string(),
+            )])),
+        );
+        let (producer, reports) = callback_producer(config);
+        let destination = TopicOrPartition::Topic(Topic::new("test"));
+
+        producer
+            .produce(
+                &destination,
+                KafkaPayload::new(None, None, Some(b"payload".to_vec())),
+            )
+            .unwrap();
+        producer.producer.flush(Duration::from_secs(10)).unwrap();
+        drop(producer);
+        assert_eq!(
+            reports.into_iter().collect::<Vec<_>>(),
+            vec![(None, "test".to_owned(), 7)]
+        );
+    }
+
+    #[test]
+    fn test_delivery_callback_broker_error() {
+        let cluster = MockCluster::new(1).unwrap();
+        cluster.request_errors(
+            RDKafkaApiKey::Produce,
+            &[RDKafkaRespErr::RD_KAFKA_RESP_ERR_MSG_SIZE_TOO_LARGE],
+        );
+        let config = KafkaConfig::new_producer_config(vec![cluster.bootstrap_servers()], None);
+        let (producer, reports) = callback_producer(config);
+        let destination = TopicOrPartition::Topic(Topic::new("test"));
+
+        producer
+            .produce(
+                &destination,
+                KafkaPayload::new(None, None, Some(b"payload".to_vec())),
+            )
+            .unwrap();
+        producer.producer.flush(Duration::from_secs(10)).unwrap();
+        drop(producer);
+        assert_eq!(
+            reports.into_iter().collect::<Vec<_>>(),
+            vec![(
+                Some(KafkaError::MessageProduction(
+                    RDKafkaErrorCode::MessageSizeTooLarge
+                )),
+                "test".to_owned(),
+                7,
+            )]
+        );
+    }
+
+    #[test]
+    fn test_delivery_callback_only_for_accepted_messages() {
+        let (producer, reports) = callback_producer(queue_full_configuration());
+        let destination = TopicOrPartition::Topic(Topic::new("test"));
+        producer
+            .produce(
+                &destination,
+                KafkaPayload::new(None, None, Some(b"accepted".to_vec())),
+            )
+            .unwrap();
+        assert!(producer
+            .produce(
+                &destination,
+                KafkaPayload::new(None, None, Some(b"no".to_vec()))
+            )
+            .is_err());
+
+        producer.producer.flush(Duration::from_secs(10)).unwrap();
+        drop(producer);
+        assert_eq!(
+            reports.into_iter().collect::<Vec<_>>(),
+            vec![(
+                Some(KafkaError::MessageProduction(
+                    RDKafkaErrorCode::MessageTimedOut
+                )),
+                "test".to_owned(),
+                8,
+            )]
+        );
     }
 }


### PR DESCRIPTION
Allows synchronous Kafka producers to accept caller-provided contexts and expose the configured context. Applications can handle delivery results and explicitly delegate metrics to Arroyo.

Also adds `topic` to delivery-status metrics and standardize `status` as `success` or `error`, with a separate `code` tag on failures.